### PR TITLE
Added return in AsyncModbusSerialClient.connect

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -121,6 +121,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
         except Exception as exc:  # pylint: disable=broad-except
             txt = f"Failed to connect: {exc}"
             _logger.warning(txt)
+        return self.connected
 
     def protocol_made_connection(self, protocol):
         """Notify successful connection."""


### PR DESCRIPTION
AsyncModbusSerialClient.connect is missing a return, which causes it to be unusable for `async with` blocks, since the `__aenter__` always assumes it failed now.
