### PR TITLE
small performance improvement on debug log

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -389,15 +389,17 @@ class ModbusClientProtocol(
         """Start the producer to send the next request to consumer.write(Frame(request))."""
         request.transaction_id = self.transaction.getNextTID()
         packet = self.framer.buildPacket(request)
-        txt = f"send: {hexlify_packets(packet)}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"send: {hexlify_packets(packet)}"
+            _logger.debug(txt)
         self.write_transport(packet)
         return self._build_response(request.transaction_id)
 
     def _data_received(self, data):
         """Get response, check for valid message, decode result."""
-        txt = f"recv: {hexlify_packets(data)}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"recv: {hexlify_packets(data)}"
+            _logger.debug(txt)
         self.framer.processIncomingPacket(data, self._handle_response, unit=0)
 
     def _handle_response(self, reply, **kwargs):  # pylint: disable=unused-argument

--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -62,8 +62,9 @@ class ModbusSlaveContext(IModbusSlaveContext):
         """
         if not self.zero_mode:
             address = address + 1
-        txt = f"validate: fc-[{fc_as_hex}] address-{address}: count-{count}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"validate: fc-[{fc_as_hex}] address-{address}: count-{count}"
+            _logger.debug(txt)
         return self.store[self.decode(fc_as_hex)].validate(address, count)
 
     def getValues(self, fc_as_hex, address, count=1):
@@ -76,8 +77,9 @@ class ModbusSlaveContext(IModbusSlaveContext):
         """
         if not self.zero_mode:
             address = address + 1
-        txt = f"getValues: fc-[{fc_as_hex}] address-{address}: count-{count}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"getValues: fc-[{fc_as_hex}] address-{address}: count-{count}"
+            _logger.debug(txt)
         return self.store[self.decode(fc_as_hex)].getValues(address, count)
 
     def setValues(self, fc_as_hex, address, values):
@@ -89,8 +91,9 @@ class ModbusSlaveContext(IModbusSlaveContext):
         """
         if not self.zero_mode:
             address = address + 1
-        txt = f"setValues[{fc_as_hex}] address-{address}: count-{len(values)}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"setValues[{fc_as_hex}] address-{address}: count-{len(values)}"
+            _logger.debug(txt)
         self.store[self.decode(fc_as_hex)].setValues(address, values)
 
     def register(self, function_code, fc_as_hex, datablock=None):

--- a/pymodbus/factory.py
+++ b/pymodbus/factory.py
@@ -202,8 +202,9 @@ class ServerDecoder(IModbusDecoder):
         """
         function_code = int(data[0])
         if not (request := self.__lookup.get(function_code, lambda: None)()):
-            txt = f"Factory Request[{function_code}]"
-            _logger.debug(txt)
+            if _logger.isEnabledFor(logging.DEBUG):
+                txt = f"Factory Request[{function_code}]"
+                _logger.debug(txt)
             request = IllegalFunctionRequest(function_code)
         else:
             fc_string = "%s: %s" % (  # pylint: disable=consider-using-f-string
@@ -212,8 +213,9 @@ class ServerDecoder(IModbusDecoder):
                 .rstrip('">"'),
                 function_code,
             )
-            txt = f"Factory Request[{fc_string}]"
-            _logger.debug(txt)
+            if _logger.isEnabledFor(logging.DEBUG):
+                txt = f"Factory Request[{fc_string}]"
+                _logger.debug(txt)
         request.decode(data[1:])
 
         if hasattr(request, "sub_function_code"):
@@ -344,8 +346,9 @@ class ClientDecoder(IModbusDecoder):
                 .rstrip('">"'),
                 function_code,
             )
-        txt = f"Factory Response[{fc_string}]"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"Factory Response[{fc_string}]"
+            _logger.debug(txt)
         response = self.__lookup.get(function_code, lambda: None)()
         if function_code > 0x80:
             code = function_code & 0x7F  # strip error portion

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -125,11 +125,12 @@ class ModbusRtuFramer(ModbusFramer):
         end of the message (python just doesn't have the resolution to
         check for millisecond delays).
         """
-        txt = (
-            f"Resetting frame - Current Frame in "
-            f"buffer - {hexlify_packets(self._buffer)}"
-        )
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = (
+                f"Resetting frame - Current Frame in "
+                f"buffer - {hexlify_packets(self._buffer)}"
+            )
+            _logger.debug(txt)
         self._buffer = b""
         self._header = {"uid": 0x00, "len": 0, "crc": b"\x00\x00"}
 
@@ -190,7 +191,8 @@ class ModbusRtuFramer(ModbusFramer):
         buffer = self._buffer[start:end]
         if end > 0:
             txt = f"Getting Frame - {hexlify_packets(buffer)}"
-            _logger.debug(txt)
+            if _logger.isEnabledFor(logging.DEBUG):
+                _logger.debug(txt)
             return buffer
         return b""
 
@@ -248,8 +250,9 @@ class ModbusRtuFramer(ModbusFramer):
                     self.resetFrame()
                     break
             else:
-                txt = f"Frame - [{data}] not ready"
-                _logger.debug(txt)
+                if _logger.isEnabledFor(logging.DEBUG):
+                    txt = f"Frame - [{data}] not ready"
+                    _logger.debug(txt)
                 break
 
     def buildPacket(self, message):
@@ -277,20 +280,22 @@ class ModbusRtuFramer(ModbusFramer):
         while self.client.state != ModbusTransactionState.IDLE:
             if self.client.state == ModbusTransactionState.TRANSACTION_COMPLETE:
                 timestamp = round(time.time(), 6)
-                txt = (
-                    f"Changing state to IDLE - Last Frame End - {self.client.last_frame_end}, "
-                    f"Current Time stamp - {timestamp}"
-                )
-                _logger.debug(txt)
+                if _logger.isEnabledFor(logging.DEBUG):
+                    txt = (
+                        f"Changing state to IDLE - Last Frame End - {self.client.last_frame_end}, "
+                        f"Current Time stamp - {timestamp}"
+                    )
+                    _logger.debug(txt)
 
                 if self.client.last_frame_end:
                     idle_time = self.client.idle_time()
                     if round(timestamp - idle_time, 6) <= self.client.silent_interval:
-                        txt = (
-                            f"Waiting for 3.5 char before next "
-                            f"send - {self.client.silent_interval * 1000} ms"
-                        )
-                        _logger.debug(txt)
+                        if _logger.isEnabledFor(logging.DEBUG):
+                            txt = (
+                                f"Waiting for 3.5 char before next "
+                                f"send - {self.client.silent_interval * 1000} ms"
+                            )
+                            _logger.debug(txt)
                         time.sleep(self.client.silent_interval)
                 else:
                     # Recovering from last error ??
@@ -337,8 +342,9 @@ class ModbusRtuFramer(ModbusFramer):
 
     def getRawFrame(self):  # pylint: disable=invalid-name
         """Return the complete buffer."""
-        txt = f"Getting Raw Frame - {hexlify_packets(self._buffer)}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"Getting Raw Frame - {hexlify_packets(self._buffer)}"
+            _logger.debug(txt)
         return self._buffer
 
     def get_expected_response_length(self, data):

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -167,8 +167,9 @@ class ModbusSocketFramer(ModbusFramer):
         if not isinstance(unit, (list, tuple)):
             unit = [unit]
         single = kwargs.get("single", False)
-        txt = f"Processing: {hexlify_packets(data)}"
-        _logger.debug(txt)
+        if _logger.isEnabledFor(logging.DEBUG):
+            txt = f"Processing: {hexlify_packets(data)}"
+            _logger.debug(txt)
         self.addToFrame(data)
         while True:
             if self.isFrameReady():


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

Greetings!

I've been using pymodbus on an Orange Pi Lite, it works great and I'm very pleased with it.

The CPU on this board is very slow, and while profiling I noticed quite a lot of time was spent formatting strings intended to be used in logger.debug()... but unless the log level is actually set to DEBUG, these strings are not used at all, so the cpu time is wasted.

This patch is really simple: I added a bunch of if's to avoid the "slow" (on this CPU) calls to hexlify and other formatting functions unless the logger actually wants the output.

This reduced the cpu usage of the entire application by about 30%, quite spectacular for such a simple patch!

Have a nice day ;)