### PR TITLE
Fix Unix sockets parsing

### DIFF
--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -210,7 +210,7 @@ class ModbusTcpClient(ModbusBaseClient):
         if self.socket:
             return True
         try:
-            if self.params.host.startswith("unit:"):
+            if self.params.host.startswith("unix:"):
                 self.socket = socket.socket(socket.AF_UNIX)
                 self.socket.settimeout(self.params.timeout)
                 self.socket.connect(self.params.host[5:])


### PR DESCRIPTION
@peufeu2 found a typo:

> tcp.py line 213:
> `            if self.params.host.startswith("unit:"):`
> 
> "unit" should be "unix", since it's about unix sockets...
> 

_Originally posted by @peufeu2 in https://github.com/pymodbus-dev/pymodbus/issues/1279#issuecomment-1400424302_
            