### PR TITLE
Fix register type check for size bigger than 3 registers (6 bytes)

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -517,22 +517,12 @@ class ModbusSimulatorContext:
     _write_func_code = (5, 6, 15, 16, 22, 23)
     _bits_func_code = (1, 2, 5, 15)
 
-    def validate(self, func_code, address, count=1):
-        """Check to see if the request is in range.
+    def loop_validate(self, address, end_address, fx_write):
+        """Validate entry in loop.
 
         :meta private:
         """
-        if func_code in self._bits_func_code:
-            # Bit count, correct to register count
-            count = int((count + WORD_SIZE - 1) / WORD_SIZE)
-            address = int(address / 16)
-        real_address = self.fc_offset[func_code] + address
-        if real_address <= 0 or real_address > self.register_count:
-            return False
-
-        fx_write = func_code in self._write_func_code
-        i = real_address
-        end_address = real_address + count
+        i = address
         while i < end_address:
             reg = self.registers[i]
             if fx_write and not reg.access or reg.type == CellType.INVALID:
@@ -548,12 +538,28 @@ class ModbusSimulatorContext:
                 if i + 1 >= end_address:
                     return False
                 i += 2
-            else:  #  CellType.STRING
+            else:
                 i += 1
-                while i  < end_address:
+                while i < end_address:
                     if self.registers[i].type == CellType.NEXT:
                         i += 1
         return True
+
+    def validate(self, func_code, address, count=1):
+        """Check to see if the request is in range.
+
+        :meta private:
+        """
+        if func_code in self._bits_func_code:
+            # Bit count, correct to register count
+            count = int((count + WORD_SIZE - 1) / WORD_SIZE)
+            address = int(address / 16)
+        real_address = self.fc_offset[func_code] + address
+        if real_address <= 0 or real_address > self.register_count:
+            return False
+
+        fx_write = func_code in self._write_func_code
+        return self.loop_validate(real_address, real_address + count, fx_write)
 
     def getValues(self, func_code, address, count=1):  # pylint: disable=invalid-name
         """Return the requested values of the datastore.
@@ -731,9 +737,7 @@ class ModbusSimulatorContext:
             check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)
             reg_step = 2
 
-        for i in range(  # pylint: disable=consider-using-any-or-all
-            real_address, real_address + count, reg_step
-        ):
+        for i in range(real_address, real_address + count, reg_step):
             if self.registers[i].type in check:
                 continue
             if self.registers[i].type is CellType.NEXT:

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -720,8 +720,11 @@ class ModbusSimulatorContext:
         for i in range(  # pylint: disable=consider-using-any-or-all
             real_address, real_address + count, reg_step
         ):
-            if self.registers[i].type not in check:
-                return False
+            if self.registers[i].type in check:
+                continue
+            if self.registers[i].type is CellType.NEXT:
+                continue
+            return False
         return True
 
     @classmethod

--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -97,9 +97,9 @@ class TestSimulator:
         ],
         "string": [
             {"addr": [43, 44], "value": "Str"},
-            {"addr": [45, 47], "value": "Strxyz"},
+            {"addr": [45, 48], "value": "Strxyz12"},
         ],
-        "repeat": [{"addr": [0, 47], "to": [48, 144]}],
+        "repeat": [{"addr": [0, 48], "to": [49, 147]}],
     }
 
     test_registers = [
@@ -151,7 +151,8 @@ class TestSimulator:
         Cell(type=CellType.STRING, value=int.from_bytes(bytes("St", "utf-8"), "big")),
         Cell(type=CellType.NEXT, value=int.from_bytes(bytes("rx", "utf-8"), "big")),
         Cell(type=CellType.NEXT, value=int.from_bytes(bytes("yz", "utf-8"), "big")),
-        # 47 MAX before repeat
+        Cell(type=CellType.NEXT, value=int.from_bytes(bytes("12", "utf-8"), "big")),
+        # 48 MAX before repeat
     ]
 
     @classmethod
@@ -188,7 +189,7 @@ class TestSimulator:
         """Test basic configuration."""
         # Manually build expected memory image and then compare.
         assert self.simulator.register_count == 250
-        for offset in (0, 48, 96):
+        for offset in (0, 49, 98):
             for i, test_cell in enumerate(self.test_registers):
                 reg = self.simulator.registers[i + offset]
                 assert reg.type == test_cell.type, f"at index {i} - {offset}"
@@ -340,6 +341,7 @@ class TestSimulator:
             (FX_READ_REG, 21, 1, False),
             (FX_READ_REG, 21, 2, True),
             (FX_READ_REG, 43, 2, True),
+            (FX_READ_REG, 45, 4, True),
         ):
             validated = exc_simulator.validate(entry[0], entry[1], entry[2])
             assert entry[3] == validated, f"at entry {entry}"

--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -335,7 +335,7 @@ class TestSimulator:
             (FX_READ_BIT, 116, 16, True),
             (FX_READ_BIT, 112, 32, True),
             (FX_READ_BIT, 128, 17, False),
-            (FX_READ_BIT, 256, 1, False),
+            (FX_READ_BIT, 256, 1, True),
             (FX_READ_REG, 16, 1, True),
             (FX_READ_REG, 43, 1, True),
             (FX_READ_REG, 21, 1, False),


### PR DESCRIPTION
This commit fixes the register type check for configuration where more than 3 registers are configured as one area (I think for the moment this happens only for string types for the moment).
I updated unit tests for this case. 