### PR TITLE
Remove unused linters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,6 @@ flake8-docstrings==1.7.0
 flake8-noqa==1.3.0
 flake8-comprehensions==3.10.1
 isort==5.11.4
-pep8==1.7.1
 pyflakes==3.0.1
 pydocstyle==6.3.0
 pycodestyle==2.10.0

--- a/setup_commands.py
+++ b/setup_commands.py
@@ -118,67 +118,6 @@ class LintCommand(Command):
             return False
 
 
-class Python3Command(Command):
-    """Helper command to scan for potential python 3 errors.
-
-    ./setup.py scan_2to3 > build/diffs_2to3 build/report_2to3
-    """
-
-    description = "perform 2to3 scan of the code"
-    user_options = []
-    directories = ['pymodbus', 'test', 'examples']
-
-    def initialize_options(self):
-        """Initialize options setup."""
-        if not os.path.exists('./build'):
-            os.mkdir('./build')
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        """Run command"""
-        self._run_python3()
-
-    def _run_python3(self):
-        try:
-            from lib2to3.main import main
-            sys.argv = ['2to3'] + self.directories
-            main("lib2to3.fixes")
-            return True
-        except Exception:
-            return False
-
-
-class Pep8Command(Command):
-    """Helper command to scan for potential pep8 violations."""
-
-    description = "perform pep8 scan of the code"
-    user_options = []
-    directories = ['pymodbus']
-
-    def initialize_options(self):
-        """Initialize options setup"""
-        if not os.path.exists('./build'):
-            os.mkdir('./build')
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        """Run command."""
-        self._run_pep8()
-
-    def _run_pep8(self):
-        try:
-            from pep8 import _main as main
-            sys.argv = """pep8 --repeat --count --statistics
-            """.split() + self.directories
-            main()
-            return True
-        except Exception:
-            return False
-
 # --------------------------------------------------------------------------- #
 # Command Configuration
 # --------------------------------------------------------------------------- #
@@ -188,8 +127,6 @@ command_classes = {
     'deep_clean': DeepCleanCommand,
     'build_apidocs': BuildApiDocsCommand,
     'lint': LintCommand,
-    'scan_2to3': Python3Command,
-    'pep8': Pep8Command,
 }
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
It appears to me that neither `pep8` nor `lib2to3` are used anymore, and can be removed.
