### PR TITLE
lint /doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,4 @@
 """Document configuration."""
-# -*- coding: utf-8 -*-
 #
 # PyModbus documentation build configuration file,
 #
@@ -11,9 +10,9 @@ import os
 import sys
 
 from recommonmark.transform import AutoStructify
-from recommonmark.parser import CommonMarkParser
 
 from pymodbus import __version__
+
 
 parent_dir = os.path.abspath(os.pardir)
 sys.path.insert(0, parent_dir)

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -6,7 +6,7 @@ The examples can be downloaded from https://github.com/pymodbus-dev/pymodbus/tre
 Examples version 3.x
 --------------------
 
-These examples are considered essential usage examples, and are guarenteed to work,
+These examples are considered essential usage examples, and are guaranteed to work,
 because they are tested automatilly with each dev branch commit using CI.
 
 

--- a/doc/source/library/client.rst
+++ b/doc/source/library/client.rst
@@ -48,8 +48,8 @@ and a asynchronous example::
 Large parts of the implementation are shared between the different classes,
 to ensure high stability and efficient maintenance.
 
-Tranport classes
-----------------
+Transport classes
+-----------------
 
 .. autoclass:: pymodbus.client.ModbusBaseClient
     :members:

--- a/doc/source/library/simulator/datastore.rst
+++ b/doc/source/library/simulator/datastore.rst
@@ -2,7 +2,7 @@ Simulator datastore
 ===================
 
 The simulator datastore is an advanced datastore.
-The simulator allows to simulate the registers of a real life modbus device by adding a simple dict (defintion see :ref:`Device entries`).
+The simulator allows to simulate the registers of a real life modbus device by adding a simple dict (definition see :ref:`Device entries`).
 
 The simulator datastore allows to add actions (functions) to a register, and thus allows a low level automation.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -478,7 +478,7 @@ check-str-concat-over-line-jumps=no
 #max-line-length-suggestions=
 
 [flake8]
-exclude         = pymodbus/client/serial_asyncio, venv,.venv,.git,doc,build,examples/v2.5.3
+exclude         = pymodbus/client/serial_asyncio, venv,.venv,.git,build,examples/v2.5.3
 doctests        = True
 max-line-length = 120
 # To work with Black
@@ -542,11 +542,11 @@ omit =
     examples/contrib/tornado_twister
 
 [codespell]
-skip=doc,venv,.venv,.git,htmlcov,CHANGELOG.rst
+skip=./doc/source/_static,venv,.venv,.git,htmlcov,CHANGELOG.rst
 ignore-words-list = asend
 
 [isort]
-skip=doc,venv,.venv,.git,pymodbus/client/serial_asyncio
+skip=venv,.venv,.git,pymodbus/client/serial_asyncio
 py_version=38
 profile=black
 line_length = 79


### PR DESCRIPTION
No need to exclude `/doc` from the easy linters.