### PR TITLE
Even more type fixes

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass
-from typing import Any, Type
+from typing import Any, Tuple, Type
 
 from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.constants import Defaults
@@ -90,7 +90,7 @@ class ModbusBaseClient(ModbusClientMixin):
         stopbits: int = None
         handle_local_echo: bool = None
 
-        source_address: str = None
+        source_address: Tuple[str, int] = None
 
         sslctx: str = None
         certfile: str = None

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Type
 
 from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.constants import Defaults
@@ -73,7 +73,7 @@ class ModbusBaseClient(ModbusClientMixin):
 
         host: str = None
         port: str | int = None
-        framer: ModbusFramer = None
+        framer: Type[ModbusFramer] = None
         timeout: float = None
         retries: int = None
         retry_on_empty: bool = None
@@ -100,7 +100,7 @@ class ModbusBaseClient(ModbusClientMixin):
 
     def __init__(
         self,
-        framer: str = None,
+        framer: Type[ModbusFramer] = None,
         timeout: str | float = Defaults.Timeout,
         retries: str | int = Defaults.Retries,
         retry_on_empty: bool = Defaults.RetryOnEmpty,

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -1,5 +1,4 @@
 """Modbus Client Common."""
-from abc import abstractmethod
 from typing import Any, List, Tuple, Union
 
 import pymodbus.bit_read_message as pdu_bit_read
@@ -10,7 +9,7 @@ import pymodbus.mei_message as pdu_mei
 import pymodbus.other_message as pdu_other_msg
 import pymodbus.register_read_message as pdu_reg_read
 import pymodbus.register_write_message as pdu_req_write
-from pymodbus.pdu import ModbusRequest
+from pymodbus.pdu import ModbusRequest, ModbusResponse
 
 
 class ModbusClientMixin:  # pylint: disable=too-many-public-methods
@@ -40,8 +39,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     def __init__(self):
         """Initialize."""
 
-    @abstractmethod
-    def execute(self, request: ModbusRequest):
+    def execute(self, request: ModbusRequest) -> ModbusResponse:
         """Execute request (code ???).
 
         :param request: Request to send
@@ -53,7 +51,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         .. tip::
             Response is not interpreted.
         """
-        return request  # (for pytest)  Concrete methods return a response
+        return request
 
     def read_coils(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -1,4 +1,5 @@
 """Modbus Client Common."""
+from abc import abstractmethod
 from typing import Any, List, Tuple, Union
 
 import pymodbus.bit_read_message as pdu_bit_read
@@ -9,7 +10,7 @@ import pymodbus.mei_message as pdu_mei
 import pymodbus.other_message as pdu_other_msg
 import pymodbus.register_read_message as pdu_reg_read
 import pymodbus.register_write_message as pdu_req_write
-from pymodbus.pdu import ModbusRequest, ModbusResponse
+from pymodbus.pdu import ModbusRequest
 
 
 class ModbusClientMixin:  # pylint: disable=too-many-public-methods
@@ -39,7 +40,8 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     def __init__(self):
         """Initialize."""
 
-    def execute(self, request: ModbusRequest) -> ModbusResponse:
+    @abstractmethod
+    def execute(self, request: ModbusRequest):
         """Execute request (code ???).
 
         :param request: Request to send
@@ -51,7 +53,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         .. tip::
             Response is not interpreted.
         """
-        return request
+        return request  # (for pytest)  Concrete methods return a response
 
     def read_coils(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -2,7 +2,7 @@
 import asyncio
 import time
 from functools import partial
-from typing import Any
+from typing import Any, Type
 
 from pymodbus.client.base import ModbusBaseClient, ModbusClientProtocol
 from pymodbus.client.serial_asyncio import create_serial_connection
@@ -52,7 +52,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
     def __init__(
         self,
         port: str,
-        framer: ModbusFramer = ModbusRtuFramer,
+        framer: Type[ModbusFramer] = ModbusRtuFramer,
         baudrate: int = Defaults.Baudrate,
         bytesize: int = Defaults.Bytesize,
         parity: str = Defaults.Parity,
@@ -209,7 +209,7 @@ class ModbusSerialClient(ModbusBaseClient):
     def __init__(
         self,
         port: str,
-        framer: ModbusFramer = ModbusRtuFramer,
+        framer: Type[ModbusFramer] = ModbusRtuFramer,
         baudrate: int = Defaults.Baudrate,
         bytesize: int = Defaults.Bytesize,
         parity: str = Defaults.Parity,

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -3,7 +3,7 @@ import asyncio
 import select
 import socket
 import time
-import typing
+from typing import Any, Tuple, Type
 
 from pymodbus.client.base import ModbusBaseClient, ModbusClientProtocol
 from pymodbus.constants import Defaults
@@ -41,9 +41,9 @@ class AsyncModbusTcpClient(ModbusBaseClient):
         self,
         host: str,
         port: int = Defaults.TcpPort,
-        framer: ModbusFramer = ModbusSocketFramer,
-        source_address: typing.Tuple[str, int] = None,
-        **kwargs: typing.Any,
+        framer: Type[ModbusFramer] = ModbusSocketFramer,
+        source_address: Tuple[str, int] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus TCP Client."""
         self.protocol = None
@@ -201,9 +201,9 @@ class ModbusTcpClient(ModbusBaseClient):
         self,
         host: str,
         port: int = Defaults.TcpPort,
-        framer: ModbusFramer = ModbusSocketFramer,
-        source_address: typing.Tuple[str, int] = None,
-        **kwargs: typing.Any,
+        framer: Type[ModbusFramer] = ModbusSocketFramer,
+        source_address: Tuple[str, int] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize Modbus TCP Client."""
         super().__init__(framer=framer, **kwargs)

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -1,7 +1,7 @@
 """Modbus client async TLS communication."""
 import socket
 import ssl
-from typing import Any
+from typing import Any, Type
 
 from pymodbus.client.tcp import AsyncModbusTcpClient, ModbusTcpClient
 from pymodbus.constants import Defaults
@@ -69,7 +69,7 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
         self,
         host: str,
         port: int = Defaults.TlsPort,
-        framer: ModbusFramer = ModbusTlsFramer,
+        framer: Type[ModbusFramer] = ModbusTlsFramer,
         sslctx: str = None,
         certfile: str = None,
         keyfile: str = None,
@@ -140,7 +140,7 @@ class ModbusTlsClient(ModbusTcpClient):
         self,
         host: str,
         port: int = Defaults.TlsPort,
-        framer: ModbusFramer = ModbusTlsFramer,
+        framer: Type[ModbusFramer] = ModbusTlsFramer,
         sslctx: str = None,
         certfile: str = None,
         keyfile: str = None,

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -2,7 +2,7 @@
 import asyncio
 import functools
 import socket
-import typing
+from typing import Any, Tuple, Type
 
 from pymodbus.client.base import ModbusBaseClient, ModbusClientProtocol
 from pymodbus.constants import Defaults
@@ -40,9 +40,9 @@ class AsyncModbusUdpClient(ModbusBaseClient):
         self,
         host: str,
         port: int = Defaults.UdpPort,
-        framer: ModbusFramer = ModbusSocketFramer,
-        source_address: typing.Tuple[str, int] = None,
-        **kwargs: typing.Any,
+        framer: Type[ModbusFramer] = ModbusSocketFramer,
+        source_address: Tuple[str, int] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus UDP Client."""
         self.protocol = None
@@ -202,9 +202,9 @@ class ModbusUdpClient(ModbusBaseClient):
         self,
         host: str,
         port: int = Defaults.UdpPort,
-        framer: ModbusFramer = ModbusSocketFramer,
-        source_address: typing.Tuple[str, int] = None,
-        **kwargs: typing.Any,
+        framer: Type[ModbusFramer] = ModbusSocketFramer,
+        source_address: Tuple[str, int] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize Modbus UDP Client."""
         super().__init__(framer=framer, **kwargs)

--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -8,8 +8,10 @@ import struct
 
 # pylint: disable=missing-type-doc
 from collections import OrderedDict
+from typing import List
 
 from pymodbus.constants import DeviceInformation
+from pymodbus.events import ModbusEvent
 from pymodbus.interfaces import Singleton
 from pymodbus.utilities import dict_property
 
@@ -457,7 +459,7 @@ class ModbusControlBlock(Singleton):
     __counters = ModbusCountersHandler()
     __identity = ModbusDeviceIdentification()
     __plus = ModbusPlusStatistics()
-    __events = []
+    __events: List[ModbusEvent] = []
 
     # -------------------------------------------------------------------------#
     #  Magic
@@ -479,7 +481,7 @@ class ModbusControlBlock(Singleton):
     # -------------------------------------------------------------------------#
     #  Events
     # -------------------------------------------------------------------------#
-    def addEvent(self, event):  # pylint: disable=invalid-name
+    def addEvent(self, event: ModbusEvent):  # pylint: disable=invalid-name
         """Add a new event to the event log.
 
         :param event: A new event to add to the log

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,4 @@ pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 pytest-timeout==2.1.0
 pytest-xdist==3.1.0
+sqlalchemy-stubs==0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -545,7 +545,7 @@ omit =
     examples/contrib/tornado_twister
 
 [codespell]
-skip=./doc/_build,./doc/source/_static,venv,.venv,.git,htmlcov,CHANGELOG.rst
+skip=./doc/_build,./doc/source/_static,venv,.venv,.git,htmlcov,CHANGELOG.rst,.mypy_cache
 ignore-words-list = asend
 
 [isort]


### PR DESCRIPTION
Down to 32 `mypy` errors.

I don't quite understand how the mixin works, but using `@abstractmethod` seemed appropriate.  Perhaps it should also be used in 
`base.py`?
https://github.com/pymodbus-dev/pymodbus/blob/39f1c8c9ba07cd5c974e5367c895fcbd39ecf858/pymodbus/client/base.py#L153-L160
