### PR TITLE
Fix NoReponse -> NoResponse

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -7,6 +7,8 @@ Version 3.2.0
 -------------
 - StartAsync<type>Server, removed defer_start argument, return is None.
   instead of using defer_start instantiate the Modbus<type>Server directly.
+- `ReturnSlaveNoReponseCountResponse` has been corrected to
+  `ReturnSlaveNoResponseCountResponse`
 
 -------------
 Version 3.1.0

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -291,7 +291,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_slave_no_response_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> pdu_diag.ReturnSlaveNoReponseCountResponse:
+    ) -> pdu_diag.ReturnSlaveNoResponseCountResponse:
         """Diagnose read Slave No Response Count (code 0x08 sub 0x0F).
 
         :param slave: (optional) Modbus slave ID

--- a/pymodbus/diag_message.py
+++ b/pymodbus/diag_message.py
@@ -577,10 +577,10 @@ class ReturnSlaveNoResponseCountRequest(DiagnosticStatusSimpleRequest):
         :returns: The initialized response message
         """
         count = _MCB.Counter.SlaveNoResponse
-        return ReturnSlaveNoReponseCountResponse(count)
+        return ReturnSlaveNoResponseCountResponse(count)
 
 
-class ReturnSlaveNoReponseCountResponse(DiagnosticStatusSimpleResponse):
+class ReturnSlaveNoResponseCountResponse(DiagnosticStatusSimpleResponse):
     """Return slave no response.
 
     The response data field returns the quantity of messages addressed to the
@@ -854,7 +854,7 @@ __all__ = [
     "ReturnSlaveMessageCountRequest",
     "ReturnSlaveMessageCountResponse",
     "ReturnSlaveNoResponseCountRequest",
-    "ReturnSlaveNoReponseCountResponse",
+    "ReturnSlaveNoResponseCountResponse",
     "ReturnSlaveNAKCountRequest",
     "ReturnSlaveNAKCountResponse",
     "ReturnSlaveBusyCountRequest",

--- a/pymodbus/factory.py
+++ b/pymodbus/factory.py
@@ -56,8 +56,8 @@ from pymodbus.diag_message import (
     ReturnSlaveMessageCountResponse,
     ReturnSlaveNAKCountRequest,
     ReturnSlaveNAKCountResponse,
-    ReturnSlaveNoReponseCountResponse,
     ReturnSlaveNoResponseCountRequest,
+    ReturnSlaveNoResponseCountResponse,
 )
 from pymodbus.exceptions import MessageRegisterException, ModbusException
 from pymodbus.file_message import (
@@ -275,7 +275,7 @@ class ClientDecoder(IModbusDecoder):
         ReturnBusCommunicationErrorCountResponse,
         ReturnBusExceptionErrorCountResponse,
         ReturnSlaveMessageCountResponse,
-        ReturnSlaveNoReponseCountResponse,
+        ReturnSlaveNoResponseCountResponse,
         ReturnSlaveNAKCountResponse,
         ReturnSlaveBusyCountResponse,
         ReturnSlaveBusCharacterOverrunCountResponse,

--- a/test/test_diag_messages.py
+++ b/test/test_diag_messages.py
@@ -39,8 +39,8 @@ from pymodbus.diag_message import (
     ReturnSlaveMessageCountResponse,
     ReturnSlaveNAKCountRequest,
     ReturnSlaveNAKCountResponse,
-    ReturnSlaveNoReponseCountResponse,
     ReturnSlaveNoResponseCountRequest,
+    ReturnSlaveNoResponseCountResponse,
 )
 from pymodbus.exceptions import NotImplementedException
 
@@ -112,7 +112,7 @@ class SimpleDataStoreTest(unittest.TestCase):
             (ReturnBusCommunicationErrorCountResponse, b"\x00\x0c\x00\x00"),
             (ReturnBusExceptionErrorCountResponse, b"\x00\x0d\x00\x00"),
             (ReturnSlaveMessageCountResponse, b"\x00\x0e\x00\x00"),
-            (ReturnSlaveNoReponseCountResponse, b"\x00\x0f\x00\x00"),
+            (ReturnSlaveNoResponseCountResponse, b"\x00\x0f\x00\x00"),
             (ReturnSlaveNAKCountResponse, b"\x00\x10\x00\x00"),
             (ReturnSlaveBusyCountResponse, b"\x00\x11\x00\x00"),
             (ReturnSlaveBusCharacterOverrunCountResponse, b"\x00\x12\x00\x00"),

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -119,7 +119,7 @@ class SimpleFactoryTest(unittest.TestCase):
             response = self.client.lookupPduClass(func)
             self.assertNotEqual(response, None)
 
-    def test_request_ookup(self):
+    def test_request_lookup(self):
         """Test a working request factory lookup"""
         for func, _ in self.request:
             request = self.client.lookupPduClass(func)


### PR DESCRIPTION
While confused by type hinting, I found this typo.  Leaving the `2.5.3` examples alone...
