### PR TITLE
repl config path

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -9,6 +9,7 @@ Version 3.2.0
   instead of using defer_start instantiate the Modbus<type>Server directly.
 - `ReturnSlaveNoReponseCountResponse` has been corrected to
   `ReturnSlaveNoResponseCountResponse`
+- Option `--modbus-config` for REPL server renamed to `--modbus-config-path`
 
 -------------
 Version 3.1.0

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -1,5 +1,4 @@
 """Modbus Client Common."""
-from abc import abstractmethod
 from typing import Any, List, Tuple, Union
 
 import pymodbus.bit_read_message as pdu_bit_read
@@ -10,7 +9,7 @@ import pymodbus.mei_message as pdu_mei
 import pymodbus.other_message as pdu_other_msg
 import pymodbus.register_read_message as pdu_reg_read
 import pymodbus.register_write_message as pdu_req_write
-from pymodbus.pdu import ModbusRequest
+from pymodbus.pdu import ModbusRequest, ModbusResponse
 
 
 class ModbusClientMixin:  # pylint: disable=too-many-public-methods
@@ -40,8 +39,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     def __init__(self):
         """Initialize."""
 
-    @abstractmethod
-    def execute(self, request: ModbusRequest):
+    def execute(self, request: ModbusRequest) -> ModbusResponse:
         """Execute request (code ???).
 
         :param request: Request to send
@@ -53,7 +51,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         .. tip::
             Response is not interpreted.
         """
-        return request  # (for pytest)  Concrete methods return a response
+        return request
 
     def read_coils(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -15,6 +15,10 @@ from pymodbus.pdu import ModbusRequest, ModbusResponse
 class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     """**ModbusClientMixin**.
 
+    This is an interface class to facilitate the sending requests/receiving responses like read_coils.
+    execute() allows to make a call with non-standard or user defined function codes (remember to add a PDU
+    in the transport class to interpret the request/response).
+
     Simple modbus message call::
 
         response = client.read_coils(1, 10)
@@ -32,8 +36,6 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     .. tip::
         All methods can be used directly (synchronous) or
         with await <method> (asynchronous) depending on the client used.
-
-    jan
     """
 
     def __init__(self):
@@ -51,6 +53,10 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         .. tip::
             Response is not interpreted.
         """
+
+        # The implementation of this method is only used in test, to secure that
+        # the methods uses the correct PDU.
+        # execute() will be overwritten in the transport class.
         return request
 
     def read_coils(

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -1,4 +1,5 @@
 """Modbus Client Common."""
+from abc import abstractmethod
 from typing import Any, List, Tuple, Union
 
 import pymodbus.bit_read_message as pdu_bit_read
@@ -9,7 +10,7 @@ import pymodbus.mei_message as pdu_mei
 import pymodbus.other_message as pdu_other_msg
 import pymodbus.register_read_message as pdu_reg_read
 import pymodbus.register_write_message as pdu_req_write
-from pymodbus.pdu import ModbusRequest, ModbusResponse
+from pymodbus.pdu import ModbusRequest
 
 
 class ModbusClientMixin:  # pylint: disable=too-many-public-methods
@@ -39,7 +40,8 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     def __init__(self):
         """Initialize."""
 
-    def execute(self, request: ModbusRequest) -> ModbusResponse:
+    @abstractmethod
+    def execute(self, request: ModbusRequest):
         """Execute request (code ???).
 
         :param request: Request to send
@@ -51,7 +53,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         .. tip::
             Response is not interpreted.
         """
-        return request
+        return request  # (for pytest)  Concrete methods return a response
 
     def read_coils(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any

--- a/pymodbus/repl/server/README.md
+++ b/pymodbus/repl/server/README.md
@@ -65,7 +65,7 @@ docker run -it pymodbus-dev/pymodbus pymodbus.server --help
 │ --framer         -f      TEXT     Modbus framer to use [default: ModbusFramerTypes.socket]                                 │
 │ --modbus-port    -p      INTEGER  Modbus port [default: 5020]                                                              │
 │ --unit-id        -u      INTEGER  Supported Modbus unit id's [default: None]                                               │
-│ --modbus-config          PATH     Path to additional modbus server config [default: None]                                  │
+│ --modbus-config-path     PATH     Path to additional modbus server config [default: None]                                  │
 │ --random         -r      INTEGER  Randomize every `r` reads. 0=never, 1=always,2=every-second-read, and so on. Applicable  │
 │                                   IR and DI.                                                                               │
 │                                   [default: 0]                                                                             │

--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -142,7 +142,7 @@ def run(
     modbus_unit_id: List[int] = typer.Option(
         None, "--unit-id", "-u", help="Supported Modbus unit id's"
     ),
-    modbus_config: Path = typer.Option(
+    modbus_config_path: Path = typer.Option(
         None, help="Path to additional modbus server config"
     ),
     randomize: int = typer.Option(
@@ -169,8 +169,8 @@ def run(
     web_app_config = ctx.obj
     loop = asyncio.get_event_loop()
     framer = DEFAULT_FRAMER.get(modbus_framer, ModbusSocketFramer)
-    if modbus_config:
-        with open(modbus_config) as my_file:  # pylint: disable=unspecified-encoding
+    if modbus_config_path:
+        with open(modbus_config_path, encoding="utf-8") as my_file:
             modbus_config = json.load(my_file)
     else:
         modbus_config = DEFAULT_CONFIG

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,7 @@ flake8-docstrings==1.7.0
 flake8-noqa==1.3.0
 flake8-comprehensions==3.10.1
 isort==5.11.4
+mypy==1.0.1
 pyflakes==3.0.1
 pydocstyle==6.3.0
 pycodestyle==2.10.0
@@ -68,4 +69,3 @@ pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 pytest-timeout==2.1.0
 pytest-xdist==3.1.0
-sqlalchemy-stubs==0.4


### PR DESCRIPTION
`mypy` is not happy with the option `modbus_config` being used for both a Path and a dictionary (possibly) loaded from that path.  This fixes another 9 errors.

Since this is technically an interface change, I've kept it separate from my other type fixes.  Another option to to use e.g. `modbus_config_dict` but that seemed verbose.
```python
if modbus_config:
    with open(modbus_config) as my_file:  # pylint: disable=unspecified-encoding
        modbus_config_dict = json.load(my_file)
```
@dhoomakethu 
