### PR TITLE
Fix type hints for http_server

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -130,7 +130,7 @@ class ModbusSimulatorServer:
         }
         if custom_actions_module:
             actions_module = importlib.import_module(custom_actions_module)
-            custom_actions_module = actions_module.custom_actions_dict
+            custom_actions_dict = actions_module.custom_actions_dict
         server = setup["server_list"][modbus_server]
         server["loop"] = asyncio.get_running_loop()
         if server["comm"] != "serial":
@@ -138,7 +138,9 @@ class ModbusSimulatorServer:
             del server["host"]
             del server["port"]
         device = setup["device_list"][modbus_device]
-        self.datastore_context = ModbusSimulatorContext(device, custom_actions_module)
+        self.datastore_context = ModbusSimulatorContext(
+            device, custom_actions_dict or None
+        )
         datastore = ModbusServerContext(slaves=self.datastore_context, single=True)
         comm = comm_class[server.pop("comm")]
         framer = framer_class[server.pop("framer")]

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -163,10 +163,10 @@ class ModbusSimulatorServer:
         self.web_app.on_startup.append(self.start_modbus_server)
         self.web_app.on_shutdown.append(self.stop_modbus_server)
         self.generator_html = {
-            "log": [None, self.build_html_log],
-            "registers": [None, self.build_html_registers],
-            "calls": [None, self.build_html_calls],
-            "server": [None, self.build_html_server],
+            "log": ["", self.build_html_log],
+            "registers": ["", self.build_html_registers],
+            "calls": ["", self.build_html_calls],
+            "server": ["", self.build_html_server],
         }
         self.generator_json = {
             "log_json": [None, self.build_json_log],

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -180,7 +180,7 @@ class ModbusSimulatorServer:
                 self.generator_html[entry][0] = handle.read()
         self.refresh_rate = 0
         self.register_filter: List[int] = []
-        self.call_list = []
+        self.call_list: List[str] = []  # not implemented yet
         self.call_monitor = CallTypeMonitor()
         self.call_response = CallTypeResponse()
 


### PR DESCRIPTION
Eliminates 3 more errors.

```
pymodbus/server/simulator/http_server.py:141: error: Argument 2 to "ModbusSimulatorContext" has incompatible type "str"; expected "Dict[str, Callable[..., Any]]"  [arg-type]
pymodbus/server/simulator/http_server.py:178: error: No overload variant of "__setitem__" of "list" matches argument types "int", "str"  [call-overload]
pymodbus/server/simulator/http_server.py:178: note: Possible overload variants:
pymodbus/server/simulator/http_server.py:178: note:     def __setitem__(self, SupportsIndex, Callable[[Any, Any], Any], /) -> None
pymodbus/server/simulator/http_server.py:178: note:     def __setitem__(self, slice, Iterable[Callable[[Any, Any], Any]], /) -> None
pymodbus/server/simulator/http_server.py:181: error: Need type annotation for "call_list" (hint: "call_list: List[<type>] = ...")  [var-annotated]
```
