### PR TITLE
Fix typing for reactive server

### DIFF
--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -51,7 +51,7 @@ from pymodbus.exceptions import NotImplementedException, ParameterException
 # ---------------------------------------------------------------------------#
 #  Datablock Storage
 # ---------------------------------------------------------------------------#
-class BaseModbusDataBlock(dict):
+class BaseModbusDataBlock:
     """Base class for a modbus datastore
 
     Derived classes must create the following fields:
@@ -72,12 +72,16 @@ class BaseModbusDataBlock(dict):
         :param value: The default value to set to the fields
         """
         self.default_value = value  # pylint: disable=attribute-defined-outside-init
-        self.values = [self.default_value] * count
+        self.values = [  # pylint: disable=attribute-defined-outside-init
+            self.default_value
+        ] * count
         self.address = 0x00  # pylint: disable=attribute-defined-outside-init
 
     def reset(self):
         """Reset the datastore to the initialized default value."""
-        self.values = [self.default_value] * len(self.values)
+        self.values = [  # pylint: disable=attribute-defined-outside-init
+            self.default_value
+        ] * len(self.values)
 
     def validate(self, address, count=1):
         """Check to see if the request is in range.

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -51,7 +51,7 @@ from pymodbus.exceptions import NotImplementedException, ParameterException
 # ---------------------------------------------------------------------------#
 #  Datablock Storage
 # ---------------------------------------------------------------------------#
-class BaseModbusDataBlock:
+class BaseModbusDataBlock(dict):
     """Base class for a modbus datastore
 
     Derived classes must create the following fields:
@@ -72,16 +72,12 @@ class BaseModbusDataBlock:
         :param value: The default value to set to the fields
         """
         self.default_value = value  # pylint: disable=attribute-defined-outside-init
-        self.values = [  # pylint: disable=attribute-defined-outside-init
-            self.default_value
-        ] * count
+        self.values = [self.default_value] * count
         self.address = 0x00  # pylint: disable=attribute-defined-outside-init
 
     def reset(self):
         """Reset the datastore to the initialized default value."""
-        self.values = [  # pylint: disable=attribute-defined-outside-init
-            self.default_value
-        ] * len(self.values)
+        self.values = [self.default_value] * len(self.values)
 
     def validate(self, address, count=1):
         """Check to see if the request is in range.

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -415,7 +415,7 @@ class ReactiveServer:
             unit = [unit]
         slaves = {}
         for i in unit:
-            block = {}
+            block = BaseModbusDataBlock()
             for modbus_entity, block_desc in data_block.items():
                 start_address = block_desc.get("block_start", 0)
                 default_count = block_desc.get("block_size", 0)

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -415,7 +415,7 @@ class ReactiveServer:
             unit = [unit]
         slaves = {}
         for i in unit:
-            block = BaseModbusDataBlock()
+            block = {}
             for modbus_entity, block_desc in data_block.items():
                 start_address = block_desc.get("block_start", 0)
                 default_count = block_desc.get("block_size", 0)

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -447,7 +447,7 @@ class ReactiveServer:
             if not single:
                 slaves[i] = slave_context
             else:
-                slaves = slave_context
+                slaves[0] = slave_context
         server_context = ModbusServerContext(slaves, single=single)
         return server_context
 


### PR DESCRIPTION
Solves the following mypy errors:
- [ ] `pymodbus/server/reactive/main.py:441: error: Argument 1 to "ReactiveModbusSlaveContext" has incompatible type "**Dict[Any, Dict[Any, Any]]"; expected "BaseModbusDataBlock"  [arg-type]`
- [x] `pymodbus/server/reactive/main.py:450: error: Incompatible types in assignment (expression has type "ReactiveModbusSlaveContext", variable has type "Dict[int, ReactiveModbusSlaveContext]")  
[assignment]`
