### PR TITLE
Fix mypy errors in reactive server

### DIFF
--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -429,11 +429,8 @@ class ReactiveServer:
                             range(start_address + 1, default_count), default_count - 1
                         )
                         address_map.insert(0, 0)
-                    block[modbus_entity] = {
-                        add: val
-                        for add in sorted(address_map)
-                        for val in default_values
-                    }
+                        address_map.sort()
+                    block[modbus_entity] = db(address_map, default_values)
                 else:
                     block[modbus_entity] = db(start_address, default_values)
 

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -447,7 +447,7 @@ class ReactiveServer:
             if not single:
                 slaves[i] = slave_context
             else:
-                slaves = slave_context
+                slaves[0] = slave_context
         server_context = ModbusServerContext(slaves, single=single)
         return server_context
 


### PR DESCRIPTION
Supercedes https://github.com/pymodbus-dev/pymodbus/pull/1371

It turns out the correct answer was, in fact, cleaner code instead of trying to abuse `mypy`. :)
