### PR TITLE
Remove unneeded attribute from version

### DIFF
--- a/pymodbus/version.py
+++ b/pymodbus/version.py
@@ -38,9 +38,6 @@ class Version:
 
 
 version = Version("pymodbus", 3, 1, "x", "")
-version.__name__ = (  # fix epydoc error # pylint: disable=attribute-defined-outside-init
-    "pymodbus"
-)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes `pymodbus/version.py:41: error: "Version" has no attribute "__name__"  [attr-defined]`

the comment refers to "epydoc", which has not been used for a long time.  I could find no other use.
