### PR TITLE
Enable mypy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           - name: pytest
             cmd: pytest --cov=pymodbus --cov=test --cov-report=term-missing --cov-report=xml -v --full-trace --timeout=20
             type: test
+          - name: mypy
+            cmd: mypy pymodbus
+            type: lint
         os:
           - name: Linux
             on: ubuntu-latest

--- a/check_ci.sh
+++ b/check_ci.sh
@@ -10,5 +10,6 @@ black --safe --quiet examples/ pymodbus/ test/
 isort .
 pylint --recursive=y examples pymodbus test
 flake8
+mypy pymodbus
 pytest --numprocesses auto
 echo "Ready to push"

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -121,7 +121,7 @@ class ModbusBaseClient(ModbusClientMixin):
         self.params.kwargs = kwargs
 
         # Common variables.
-        self.framer = self.params.framer(ClientDecoder(), self)
+        self.framer = self.params.framer(ClientDecoder(), self)  # type: ignore
         self.transaction = DictTransactionManager(self, **kwargs)
         self.delay_ms = self.params.reconnect_delay
         self.use_protocol = False
@@ -147,7 +147,7 @@ class ModbusBaseClient(ModbusClientMixin):
         Use register() to add non-standard responses (like e.g. a login prompt) and
         have them interpreted automatically.
         """
-        self.framer.decoder.register(custom_response_class)
+        self.framer.decoder.register(custom_response_class)  # type: ignore
 
     def connect(self) -> None:
         """Connect to the modbus remote host (call **sync/async**).
@@ -187,7 +187,7 @@ class ModbusBaseClient(ModbusClientMixin):
             if not self._connected:
                 raise ConnectionException(f"Not connected[{str(self)}]")
             return self.async_execute(request)
-        if not self.connect():
+        if not self.connect():  # type: ignore
             raise ConnectionException(f"Failed to connect[{str(self)}]")
         return self.transaction.execute(request)
 


### PR DESCRIPTION
Three typing errors remain in with the default `mypy` config.  They are all in `base.py` and can be ignored since it will be refactored soon.

By setting `py.typed` in the module folder, other programs built on top of `pymodbus` can use its typing.  This works locally on my system when installed with `python3 -m pip install -e .`. I'm not sure if this will happen automatically when installed from PyPI; we may need to look at the `typeshed` project.

Current config:
```
[mypy]
strict_optional = False
````


