### PR TITLE
Add request names

### DIFF
--- a/pymodbus/bit_read_message.py
+++ b/pymodbus/bit_read_message.py
@@ -136,6 +136,7 @@ class ReadCoilsRequest(ReadBitsRequestBase):
     """
 
     function_code = 1
+    function_code_name = "read_coils"
 
     def __init__(self, address=None, count=None, unit=Defaults.Slave, **kwargs):
         """Initialize a new instance.
@@ -201,6 +202,7 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
     """
 
     function_code = 2
+    function_code_name = "read_discrete_input"
 
     def __init__(self, address=None, count=None, unit=Defaults.Slave, **kwargs):
         """Initialize a new instance.

--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -37,6 +37,8 @@ class WriteSingleCoilRequest(ModbusRequest):
     """
 
     function_code = 5
+    function_code_name = "write_coil"
+
     _rtu_frame_size = 8
 
     def __init__(self, address=None, value=None, unit=None, **kwargs):
@@ -160,6 +162,7 @@ class WriteMultipleCoilsRequest(ModbusRequest):
     """
 
     function_code = 15
+    function_code_name = "write_coils"
     _rtu_byte_count_pos = 6
 
     def __init__(self, address=None, values=None, unit=None, **kwargs):

--- a/pymodbus/diag_message.py
+++ b/pymodbus/diag_message.py
@@ -26,6 +26,7 @@ class DiagnosticStatusRequest(ModbusRequest):
     """This is a base class for all of the diagnostic request functions."""
 
     function_code = 0x08
+    function_code_name = "diagnostic_status"
     _rtu_frame_size = 8
 
     def __init__(self, **kwargs):

--- a/pymodbus/factory.py
+++ b/pymodbus/factory.py
@@ -114,7 +114,7 @@ class ServerDecoder(IModbusDecoder):
     To add more implemented functions, simply add them to the list
     """
 
-    __function_table = [
+    function_table = [
         ReadHoldingRegistersRequest,
         ReadDiscreteInputsRequest,
         ReadInputRegistersRequest,
@@ -158,8 +158,8 @@ class ServerDecoder(IModbusDecoder):
 
     def __init__(self):
         """Initialize the client lookup tables."""
-        functions = {f.function_code for f in self.__function_table}
-        self.__lookup = {f.function_code: f for f in self.__function_table}
+        functions = {f.function_code for f in self.function_table}
+        self.__lookup = {f.function_code: f for f in self.function_table}
         self.__sub_lookup = {f: {} for f in functions}
         for f in self.__sub_function_table:
             self.__sub_lookup[f.function_code][f.sub_function_code] = f
@@ -243,7 +243,7 @@ class ClientDecoder(IModbusDecoder):
     To add more implemented functions, simply add them to the list
     """
 
-    __function_table = [
+    function_table = [
         ReadHoldingRegistersResponse,
         ReadDiscreteInputsResponse,
         ReadInputRegistersResponse,
@@ -287,8 +287,8 @@ class ClientDecoder(IModbusDecoder):
 
     def __init__(self):
         """Initialize the client lookup tables."""
-        functions = {f.function_code for f in self.__function_table}
-        self.__lookup = {f.function_code: f for f in self.__function_table}
+        functions = {f.function_code for f in self.function_table}
+        self.__lookup = {f.function_code: f for f in self.function_table}
         self.__sub_lookup = {f: {} for f in functions}
         for f in self.__sub_function_table:
             self.__sub_lookup[f.function_code][f.sub_function_code] = f

--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -84,6 +84,7 @@ class ReadFileRecordRequest(ModbusRequest):
     """
 
     function_code = 0x14
+    function_code_name = "read_file_record"
     _rtu_byte_count_pos = 2
 
     def __init__(self, records=None, **kwargs):
@@ -202,6 +203,7 @@ class WriteFileRecordRequest(ModbusRequest):
     """
 
     function_code = 0x15
+    function_code_name = "write_file_record"
     _rtu_byte_count_pos = 2
 
     def __init__(self, records=None, **kwargs):
@@ -331,6 +333,7 @@ class ReadFifoQueueRequest(ModbusRequest):
     """
 
     function_code = 0x18
+    function_code_name = "read_fifo_queue"
     _rtu_frame_size = 6
 
     def __init__(self, address=0x0000, **kwargs):

--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -47,6 +47,7 @@ class ReadDeviceInformationRequest(ModbusRequest):
 
     function_code = 0x2B
     sub_function_code = 0x0E
+    function_code_name = "read_device_information"
     _rtu_frame_size = 7
 
     def __init__(self, read_code=None, object_id=0x00, **kwargs):

--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -25,6 +25,7 @@ class ReadExceptionStatusRequest(ModbusRequest):
     """
 
     function_code = 0x07
+    function_code_name = "read_exception_status"
     _rtu_frame_size = 4
 
     def __init__(self, unit=None, **kwargs):
@@ -129,6 +130,7 @@ class GetCommEventCounterRequest(ModbusRequest):
     """
 
     function_code = 0x0B
+    function_code_name = "get_event_counter"
     _rtu_frame_size = 4
 
     def __init__(self, **kwargs):
@@ -239,6 +241,7 @@ class GetCommEventLogRequest(ModbusRequest):
     """
 
     function_code = 0x0C
+    function_code_name = "get_event_log"
     _rtu_frame_size = 4
 
     def __init__(self, **kwargs):
@@ -359,6 +362,7 @@ class ReportSlaveIdRequest(ModbusRequest):
     """
 
     function_code = 0x11
+    function_code_name = "report_slave_id"
     _rtu_frame_size = 4
 
     def __init__(self, unit=Defaults.Slave, **kwargs):

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -118,6 +118,7 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
     """
 
     function_code = 3
+    function_code_name = "read_holding_registers"
 
     def __init__(self, address=None, count=None, unit=Defaults.Slave, **kwargs):
         """Initialize a new instance of the request.
@@ -175,6 +176,7 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
     """
 
     function_code = 4
+    function_code_name = "read_input_registers"
 
     def __init__(self, address=None, count=None, unit=Defaults.Slave, **kwargs):
         """Initialize a new instance of the request.
@@ -238,6 +240,7 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
     """
 
     function_code = 23
+    function_code_name = "read_write_multiple_registers"
     _rtu_byte_count_pos = 10
 
     def __init__(self, **kwargs):

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -15,6 +15,7 @@ class WriteSingleRegisterRequest(ModbusRequest):
     """
 
     function_code = 6
+    function_code_name = "write_register"
     _rtu_frame_size = 8
 
     def __init__(self, address=None, value=None, unit=None, **kwargs):
@@ -143,6 +144,7 @@ class WriteMultipleRegistersRequest(ModbusRequest):
     """
 
     function_code = 16
+    function_code_name = "write_registers"
     _rtu_byte_count_pos = 6
     _pdu_length = 5  # func + adress1 + adress2 + outputQuant1 + outputQuant2
 
@@ -276,6 +278,7 @@ class MaskWriteRegisterRequest(ModbusRequest):
     """
 
     function_code = 0x16
+    function_code_name = "mask_write_register"
     _rtu_frame_size = 10
 
     def __init__(self, address=0x0000, and_mask=0xFFFF, or_mask=0x0000, **kwargs):


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Add function_code_name to all Request classes, this allows e.g. simulator to convert function codes to names.
