### PR TITLE
Add tests for writing multiple writes with a single value

### DIFF
--- a/test/test_bit_write_messages.py
+++ b/test/test_bit_write_messages.py
@@ -43,6 +43,8 @@ class ModbusBitMessageTests(unittest.TestCase):
             WriteSingleCoilResponse(1, 0xABCD): b"\x00\x01\xff\x00",
             WriteMultipleCoilsRequest(1, [True] * 5): b"\x00\x01\x00\x05\x01\x1f",
             WriteMultipleCoilsResponse(1, 5): b"\x00\x01\x00\x05",
+            WriteMultipleCoilsRequest(1, True): b"\x00\x01\x00\x01\x01\x01",
+            WriteMultipleCoilsResponse(1, 1): b"\x00\x01\x00\x01",
         }
         for request, expected in iter(messages.items()):
             self.assertEqual(request.encode(), expected)
@@ -61,6 +63,13 @@ class ModbusBitMessageTests(unittest.TestCase):
         self.assertEqual(request.byte_count, 1)
         self.assertEqual(request.address, 1)
         self.assertEqual(request.values, [True] * 5)
+        self.assertEqual(request.get_response_pdu_size(), 5)
+
+        request = WriteMultipleCoilsRequest(1, True)
+        request.decode(b"\x00\x01\x00\x01\x01\x01")
+        self.assertEqual(request.byte_count, 1)
+        self.assertEqual(request.address, 1)
+        self.assertEqual(request.values, [True])
         self.assertEqual(request.get_response_pdu_size(), 5)
 
     def test_invalid_write_multiple_coils_request(self):

--- a/test/test_register_read_messages.py
+++ b/test/test_register_read_messages.py
@@ -38,7 +38,6 @@ class ReadRegisterMessagesTest(unittest.TestCase):
             "read_address": 1,
             "read_count": 5,
             "write_address": 1,
-            "write_registers": [0x00] * 5,
         }
         self.value = 0xABCD
         self.values = [0xA, 0xB, 0xC]
@@ -47,10 +46,16 @@ class ReadRegisterMessagesTest(unittest.TestCase):
             ReadHoldingRegistersRequest(1, 5): b"\x00\x01\x00\x05",
             ReadInputRegistersRequest(1, 5): b"\x00\x01\x00\x05",
             ReadWriteMultipleRegistersRequest(
-                **arguments
+                write_registers=[0x00] * 5,
+                **arguments,
             ): b"\x00\x01\x00\x05\x00\x01\x00"
             b"\x05\x0a\x00\x00\x00\x00\x00"
             b"\x00\x00\x00\x00\x00",
+            ReadWriteMultipleRegistersRequest(
+                write_registers=0xAB,
+                **arguments,
+            ): b"\x00\x01\x00\x05\x00\x01\x00"
+            b"\x01\x02\x00\xAB",
         }
         self.response_read = {
             ReadRegistersResponseBase(self.values): TEST_MESSAGE,

--- a/test/test_register_write_messages.py
+++ b/test/test_register_write_messages.py
@@ -41,7 +41,7 @@ class WriteRegisterMessagesTest(unittest.TestCase):
             WriteSingleRegisterResponse(1, self.value): b"\x00\x01\xab\xcd",
             WriteMultipleRegistersRequest(
                 1, self.values
-            ): b"\x00\x01\x00\x03\x06\x00\n\x00\x0b\x00\x0c",
+            ): b"\x00\x01\x00\x03\x06\x00\x0a\x00\x0b\x00\x0c",
             WriteMultipleRegistersResponse(1, 5): b"\x00\x01\x00\x05",
             WriteSingleRegisterRequest(
                 1, self.payload[0], skip_encode=True

--- a/test/test_register_write_messages.py
+++ b/test/test_register_write_messages.py
@@ -42,6 +42,7 @@ class WriteRegisterMessagesTest(unittest.TestCase):
             WriteMultipleRegistersRequest(
                 1, self.values
             ): b"\x00\x01\x00\x03\x06\x00\x0a\x00\x0b\x00\x0c",
+            WriteMultipleRegistersRequest(1, 0xD): b"\x00\x01\x00\x01\x02\x00\x0D",
             WriteMultipleRegistersResponse(1, 5): b"\x00\x01\x00\x05",
             WriteSingleRegisterRequest(
                 1, self.payload[0], skip_encode=True
@@ -114,6 +115,10 @@ class WriteRegisterMessagesTest(unittest.TestCase):
 
         context.valid = True
         request = WriteMultipleRegistersRequest(0x00, [0x00] * 10)
+        result = request.execute(context)
+        self.assertEqual(result.function_code, request.function_code)
+
+        request = WriteMultipleRegistersRequest(0x00, 0x00)
         result = request.execute(context)
         self.assertEqual(result.function_code, request.function_code)
 


### PR DESCRIPTION
Closes #1363

Currently there are only tests for e.g. `write_coils([list])`. This adds them for `write_coils(bool)`.

See also #1377
