### PR TITLE
Remove unneccesary custom LOG_LEVEL check

### DIFF
--- a/pymodbus/logging.py
+++ b/pymodbus/logging.py
@@ -58,6 +58,7 @@ class Log:
     def setLevel(cls, level):
         """Apply basic logging level"""
         cls._logger.setLevel(level)
+
     @classmethod
     def build_msg(cls, txt, *args):
         """Build message."""

--- a/pymodbus/logging.py
+++ b/pymodbus/logging.py
@@ -35,7 +35,6 @@ class Log:
     :meta private:
     """
 
-    LOG_LEVEL = logging.NOTSET
     _logger = logging.getLogger(__name__)
 
     @classmethod
@@ -59,8 +58,6 @@ class Log:
     def setLevel(cls, level):
         """Apply basic logging level"""
         cls._logger.setLevel(level)
-        cls.LOG_LEVEL = level
-
     @classmethod
     def build_msg(cls, txt, *args):
         """Build message."""
@@ -90,39 +87,29 @@ class Log:
     @classmethod
     def info(cls, txt, *args):
         """Log info messagees."""
-        if cls.LOG_LEVEL == logging.NOTSET:
-            cls.LOG_LEVEL = cls._logger.getEffectiveLevel()
-        if logging.INFO >= cls.LOG_LEVEL:
+        if cls._logger.isEnabledFor(logging.INFO):
             cls._logger.info(cls.build_msg(txt, *args))
 
     @classmethod
     def debug(cls, txt, *args):
         """Log debug messagees."""
-        if cls.LOG_LEVEL == logging.NOTSET:
-            cls.LOG_LEVEL = cls._logger.getEffectiveLevel()
-        if logging.DEBUG >= cls.LOG_LEVEL:
+        if cls._logger.isEnabledFor(logging.DEBUG):
             cls._logger.debug(cls.build_msg(txt, *args))
 
     @classmethod
     def warning(cls, txt, *args):
         """Log warning messagees."""
-        if cls.LOG_LEVEL == logging.NOTSET:
-            cls.LOG_LEVEL = cls._logger.getEffectiveLevel()
-        if logging.WARNING >= cls.LOG_LEVEL:
+        if cls._logger.isEnabledFor(logging.WARNING):
             cls._logger.warning(cls.build_msg(txt, *args))
 
     @classmethod
     def error(cls, txt, *args):
         """Log error messagees."""
-        if cls.LOG_LEVEL == logging.NOTSET:
-            cls.LOG_LEVEL = cls._logger.getEffectiveLevel()
-        if logging.ERROR >= cls.LOG_LEVEL:
+        if cls._logger.isEnabledFor(logging.ERROR):
             cls._logger.error(cls.build_msg(txt, *args))
 
     @classmethod
     def critical(cls, txt, *args):
         """Log critical messagees."""
-        if cls.LOG_LEVEL == logging.NOTSET:
-            cls.LOG_LEVEL = cls._logger.getEffectiveLevel()
-        if logging.CRITICAL >= cls.LOG_LEVEL:
+        if cls._logger.isEnabledFor(logging.CRITICAL):
             cls._logger.critical(cls.build_msg(txt, *args))

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,7 +1,7 @@
 """Test datastore."""
 import logging
-
 from unittest.mock import patch
+
 import pytest
 
 from pymodbus.logging import Log

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -11,7 +11,7 @@ class TestLogging:
     """Tests of pymodbus logging."""
 
     def test_log_dont_call_build_msg(self):
-        """Verify that build_msg is not called unneccesary"""
+        """Verify that build_msg is not called unnecessary"""
         with patch("pymodbus.logging.Log.build_msg") as build_msg_mock:
             Log.setLevel(logging.INFO)
             Log.debug("test")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -4,7 +4,6 @@ import logging
 from unittest.mock import patch
 import pytest
 
-from pymodbus import pymodbus_apply_logging_config
 from pymodbus.logging import Log
 
 
@@ -12,16 +11,15 @@ class TestLogging:
     """Tests of pymodbus logging."""
 
     def test_log_dont_call_build_msg(self):
+        """Verify that build_msg is not called unneccesary"""
         with patch("pymodbus.logging.Log.build_msg") as build_msg_mock:
-
             Log.setLevel(logging.INFO)
             Log.debug("test")
-            assert build_msg_mock.call_count == 0
+            build_msg_mock.assert_not_called()
 
             Log.setLevel(logging.DEBUG)
             Log.debug("test2")
-            assert build_msg_mock.call_count == 1
-
+            build_msg_mock.assert_called_once()
 
     def test_log_simple(self):
         """Test simple string"""

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,6 +1,7 @@
 """Test datastore."""
 import logging
 
+from unittest.mock import patch
 import pytest
 
 from pymodbus import pymodbus_apply_logging_config
@@ -10,26 +11,17 @@ from pymodbus.logging import Log
 class TestLogging:
     """Tests of pymodbus logging."""
 
-    def test_log_our_default(self):
-        """Test default logging"""
-        logging.getLogger().setLevel(logging.WARNING)
-        Log.setLevel(logging.NOTSET)
-        Log.info("test")
-        assert Log.LOG_LEVEL == logging.WARNING
-        Log.setLevel(logging.NOTSET)
-        logging.getLogger().setLevel(logging.INFO)
-        Log.info("test")
-        assert Log.LOG_LEVEL == logging.INFO
-        Log.setLevel(logging.NOTSET)
-        pymodbus_apply_logging_config()
-        assert Log.LOG_LEVEL == logging.DEBUG
+    def test_log_dont_call_build_msg(self):
+        with patch("pymodbus.logging.Log.build_msg") as build_msg_mock:
 
-    def test_log_set_level(self):
-        """Test default logging"""
-        pymodbus_apply_logging_config(logging.DEBUG)
-        assert Log.LOG_LEVEL == logging.DEBUG
-        pymodbus_apply_logging_config(logging.INFO)
-        assert Log.LOG_LEVEL == logging.INFO
+            Log.setLevel(logging.INFO)
+            Log.debug("test")
+            assert build_msg_mock.call_count == 0
+
+            Log.setLevel(logging.DEBUG)
+            Log.debug("test2")
+            assert build_msg_mock.call_count == 1
+
 
     def test_log_simple(self):
         """Test simple string"""


### PR DESCRIPTION
As requested in https://github.com/pymodbus-dev/pymodbus/pull/1324#issuecomment-1462890719, this is a PR which removes the `LOG_LEVEL` class variable from the `pymodbus.logging.Log` class.

I added a test which demonstrates that `Log.build_msg` is still called as little as possible.