### PR TITLE
Fix wrong error message with pymodbus console

### DIFF
--- a/pymodbus/repl/client/main.py
+++ b/pymodbus/repl/client/main.py
@@ -277,7 +277,7 @@ def main(
         logging.basicConfig(format=use_format)
         _logger.setLevel(logging.DEBUG)
     ctx.obj = {
-        "broadcast": broadcast_support,
+        "broadcast_enable": broadcast_support,
         "retry_on_empty": retry_on_empty,
         "retry_on_invalid": retry_on_error,
         "retries": retries,

--- a/pymodbus/repl/client/mclient.py
+++ b/pymodbus/repl/client/mclient.py
@@ -439,7 +439,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         :return:
         """
         request = ChangeAsciiInputDelimiterRequest(data, **kwargs)
-        return self._execute_diagnostic_request(request, slave=request.slave_id)
+        return self._execute_diagnostic_request(request)
 
     def force_listen_only_mode(self, data=0, **kwargs):
         """Force addressed remote device to its Listen Only Mode.

--- a/pymodbus/repl/client/mclient.py
+++ b/pymodbus/repl/client/mclient.py
@@ -266,8 +266,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         :return:
         """
         resp = super().mask_write_register(  # pylint: disable=no-member
-            address=address, and_mask=and_mask,
-            or_mask=or_mask, slave=slave, **kwargs
+            address=address, and_mask=and_mask, or_mask=or_mask, slave=slave, **kwargs
         )
         if not resp.isError():
             return {
@@ -276,10 +275,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "and mask": resp.and_mask,
                 "or mask": resp.or_mask,
             }
-        return ExtendedRequestSupport._process_exception(
-            resp,
-            slave=slave
-        )
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     def read_device_information(self, read_code=None, object_id=0x00, **kwargs):
         """Read the identification and additional information of remote slave.
@@ -301,10 +297,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "more follows": resp.more_follows,
                 "space left": resp.space_left,
             }
-        return ExtendedRequestSupport._process_exception(
-            resp,
-            slave=request.slave_id
-        )
+        return ExtendedRequestSupport._process_exception(resp, slave=request.slave_id)
 
     def report_slave_id(self, slave=Defaults.Slave, **kwargs):
         """Report information about remote slave ID.
@@ -335,10 +328,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         resp = self.execute(request)  # pylint: disable=no-member
         if not resp.isError():
             return {"function_code": resp.function_code, "status": resp.status}
-        return ExtendedRequestSupport._process_exception(
-            resp,
-            slave=request.slave_id
-        )
+        return ExtendedRequestSupport._process_exception(resp, slave=request.slave_id)
 
     def get_com_event_counter(self, **kwargs):
         """Read status word and an event count.
@@ -356,10 +346,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "status": resp.status,
                 "count": resp.count,
             }
-        return ExtendedRequestSupport._process_exception(
-            resp,
-            slave=request.slave_id
-        )
+        return ExtendedRequestSupport._process_exception(resp, slave=request.slave_id)
 
     def get_com_event_log(self, **kwargs):
         """Read status word.
@@ -380,10 +367,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "event count": resp.event_count,
                 "events": resp.events,
             }
-        return ExtendedRequestSupport._process_exception(
-            resp,
-            slave=request.slave_id
-        )
+        return ExtendedRequestSupport._process_exception(resp, slave=request.slave_id)
 
     def _execute_diagnostic_request(self, request):
         """Execute diagnostic request."""
@@ -394,10 +378,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "sub function code": resp.sub_function_code,
                 "message": resp.message,
             }
-        return ExtendedRequestSupport._process_exception(
-            resp,
-            slave=request.slave_id
-        )
+        return ExtendedRequestSupport._process_exception(resp, slave=request.slave_id)
 
     def return_query_data(self, message=0, **kwargs):
         """Loop back data sent in response.

--- a/pymodbus/repl/client/mclient.py
+++ b/pymodbus/repl/client/mclient.py
@@ -104,7 +104,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         )
         if not resp.isError():
             return {"function_code": resp.function_code, "bits": resp.bits}
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     def read_discrete_inputs(self, address, count=1, slave=Defaults.Slave, **kwargs):
         """Read `count` number of discrete inputs starting at offset `address`.
@@ -120,7 +120,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         )
         if not resp.isError():
             return {"function_code": resp.function_code, "bits": resp.bits}
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     @handle_brodcast
     def write_coil(self, address, value, slave=Defaults.Slave, **kwargs):
@@ -196,7 +196,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         )
         if not resp.isError():
             return {"function_code": resp.function_code, "registers": resp.registers}
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     def read_input_registers(self, address, count=1, slave=Defaults.Slave, **kwargs):
         """Read `count` number of input registers starting at `address`.
@@ -212,7 +212,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         )
         if not resp.isError():
             return {"function_code": resp.function_code, "registers": resp.registers}
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     def readwrite_registers(
         self,
@@ -246,7 +246,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         )
         if not resp.isError():
             return {"function_code": resp.function_code, "registers": resp.registers}
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     def mask_write_register(
         self,
@@ -266,7 +266,8 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         :return:
         """
         resp = super().mask_write_register(  # pylint: disable=no-member
-            address=address, and_mask=and_mask, or_mask=or_mask, slave=slave, **kwargs
+            address=address, and_mask=and_mask,
+            or_mask=or_mask, slave=slave, **kwargs
         )
         if not resp.isError():
             return {
@@ -275,7 +276,10 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "and mask": resp.and_mask,
                 "or mask": resp.or_mask,
             }
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(
+            resp,
+            slave=slave
+        )
 
     def read_device_information(self, read_code=None, object_id=0x00, **kwargs):
         """Read the identification and additional information of remote slave.
@@ -297,7 +301,10 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "more follows": resp.more_follows,
                 "space left": resp.space_left,
             }
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(
+            resp,
+            slave=request.slave_id
+        )
 
     def report_slave_id(self, slave=Defaults.Slave, **kwargs):
         """Report information about remote slave ID.
@@ -315,7 +322,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "status": resp.status,
                 "byte count": resp.byte_count,
             }
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(resp, slave=slave)
 
     def read_exception_status(self, slave=Defaults.Slave, **kwargs):
         """Read contents of eight Exception Status output in a remote device.
@@ -328,7 +335,10 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         resp = self.execute(request)  # pylint: disable=no-member
         if not resp.isError():
             return {"function_code": resp.function_code, "status": resp.status}
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(
+            resp,
+            slave=request.slave_id
+        )
 
     def get_com_event_counter(self, **kwargs):
         """Read status word and an event count.
@@ -346,7 +356,10 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "status": resp.status,
                 "count": resp.count,
             }
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(
+            resp,
+            slave=request.slave_id
+        )
 
     def get_com_event_log(self, **kwargs):
         """Read status word.
@@ -367,7 +380,10 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "event count": resp.event_count,
                 "events": resp.events,
             }
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(
+            resp,
+            slave=request.slave_id
+        )
 
     def _execute_diagnostic_request(self, request):
         """Execute diagnostic request."""
@@ -378,7 +394,10 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
                 "sub function code": resp.sub_function_code,
                 "message": resp.message,
             }
-        return ExtendedRequestSupport._process_exception(resp)
+        return ExtendedRequestSupport._process_exception(
+            resp,
+            slave=request.slave_id
+        )
 
     def return_query_data(self, message=0, **kwargs):
         """Loop back data sent in response.
@@ -420,7 +439,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         :return:
         """
         request = ChangeAsciiInputDelimiterRequest(data, **kwargs)
-        return self._execute_diagnostic_request(request)
+        return self._execute_diagnostic_request(request, slave=request.slave_id)
 
     def force_listen_only_mode(self, data=0, **kwargs):
         """Force addressed remote device to its Listen Only Mode.


### PR DESCRIPTION
Pass  `slave` info while processing exceptions when working with pymodbus repl client

```
pymodbus on  fix-#1454 [$?] via 🐍 v3.8.13 (pymodbus) took 2s
❯ pymodbus.console tcp --host localhost --port 5020

----------------------------------------------------------------------------
__________          _____             .___  __________              .__
\______   \___.__. /     \   ____   __| _/  \______   \ ____ ______ |  |
 |     ___<   |  |/  \ /  \ /  _ \ / __ |    |       _// __ \\\____ \|  |
 |    |    \___  /    Y    (  <_> ) /_/ |    |    |   \  ___/|  |_> >  |__
 |____|    / ____\____|__  /\____/\____ | /\ |____|_  /\___  >   __/|____/
           \/            \/            \/ \/        \/     \/|__|
                                        v1.3.0 - 3.3.0
----------------------------------------------------------------------------

> client.read_input_registers address 1 count 1 slave 1
{
    "original_function_code": "4 (0x4)",
    "error": "[Input/Output] Modbus Error: [Invalid Message] No response received, expected at least 8 bytes (0 received)"
}

```
closes #1454 (Well not exactly!)
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
