### PR TITLE
pymodbus.simulator fixes

### DIFF
--- a/pymodbus/server/simulator/main.py
+++ b/pymodbus/server/simulator/main.py
@@ -41,6 +41,7 @@ options:
 """
 import argparse
 import asyncio
+import os
 
 from pymodbus import pymodbus_apply_logging_config
 from pymodbus.logging import Log
@@ -84,7 +85,7 @@ def get_commandline():
         "--json_file",
         help='name of json file, default is "setup.json"',
         type=str,
-        default="./pymodbus/server/simulator/setup.json",
+        default=os.path.join(os.path.dirname(__file__), "setup.json"),
     )
     parser.add_argument(
         "--log_file",

--- a/pymodbus/server/simulator/main.py
+++ b/pymodbus/server/simulator/main.py
@@ -66,12 +66,12 @@ def get_commandline():
         "--http_host",
         help="use <http_host> as host to bind http listen",
         type=str,
-        default=8081,
     )
     parser.add_argument(
         "--http_port",
         help="use <http_port> as port to bind http listen",
         type=str,
+        default=8081,
     )
     parser.add_argument(
         "--log",


### PR DESCRIPTION
This PR is related to issue #1455: starting pymodbus.simulator.

- correct misplaced default value: 8081 applies to the http_port and not the http_host
- makes the default path for setup.json independent of the current working directory
