### PR TITLE
Remove old aliases to OSError

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -335,7 +335,7 @@ class ModbusBaseClient(ModbusClientMixin):
         """Get the correct address family."""
         try:
             _ = socket.inet_pton(socket.AF_INET6, address)
-        except socket.error:  # not a valid ipv6 address
+        except OSError:  # not a valid ipv6 address
             return socket.AF_INET
         return socket.AF_INET6
 

--- a/pymodbus/client/sync_diag.py
+++ b/pymodbus/client/sync_diag.py
@@ -101,7 +101,7 @@ class ModbusTcpDiagClient(ModbusTcpClient):
                 timeout=self.params.timeout,
                 source_address=self.params.source_address,
             )
-        except socket.error as msg:
+        except OSError as msg:
             Log.error(LOG_MSGS["connfail_msg"], self.params.host, self.params.port, msg)
             self.close()
         return self.socket is not None

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -218,7 +218,7 @@ class ModbusTcpClient(ModbusBaseClient):
                 "Connection to Modbus server established. Socket {}",
                 self.socket.getsockname(),
             )
-        except socket.error as msg:
+        except OSError as msg:
             Log.error(
                 "Connection to ({}, {}) failed: {}",
                 self.params.host,

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -176,7 +176,7 @@ class ModbusTlsClient(ModbusTcpClient):
             )
             self.socket.settimeout(self.params.timeout)
             self.socket.connect((self.params.host, self.params.port))
-        except socket.error as msg:
+        except OSError as msg:
             Log.error(
                 "Connection to ({}, {}) failed: {}",
                 self.params.host,

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -213,7 +213,7 @@ class ModbusUdpClient(ModbusBaseClient):
             family = ModbusUdpClient._get_address_family(self.params.host)
             self.socket = socket.socket(family, socket.SOCK_DGRAM)
             self.socket.settimeout(self.params.timeout)
-        except socket.error as exc:
+        except OSError as exc:
             Log.error("Unable to create udp socket {}", exc)
             self.close()
         return self.socket is not None

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -11,7 +11,6 @@ __all__ = [
 ]
 
 # pylint: disable=missing-type-doc
-import socket
 import struct
 import time
 from functools import partial
@@ -317,11 +316,7 @@ class ModbusTransactionManager:
             result = self._recv(response_length, full)
             # result2 = self._recv(response_length, full)
             Log.debug("RECV: {}", result, ":hex")
-        except (
-            socket.error,
-            ModbusIOException,
-            InvalidMessageReceivedException,
-        ) as msg:
+        except (OSError, ModbusIOException, InvalidMessageReceivedException) as msg:
             if self.reset_socket:
                 self.client.close()
             Log.debug("Transaction failed. ({}) ", msg)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -489,7 +489,7 @@ def test_client_udp_connect():
         assert client.connect()
 
     with mock.patch.object(socket, "socket") as mock_method:
-        mock_method.side_effect = socket.error()
+        mock_method.side_effect = OSError()
         client = lib_client.ModbusUdpClient("127.0.0.1")
         assert not client.connect()
 
@@ -504,7 +504,7 @@ def test_client_tcp_connect():
         assert client.connect()
 
     with mock.patch.object(socket, "create_connection") as mock_method:
-        mock_method.side_effect = socket.error()
+        mock_method.side_effect = OSError()
         client = lib_client.ModbusTcpClient("127.0.0.1")
         assert not client.connect()
 
@@ -516,7 +516,7 @@ def test_client_tls_connect():
         assert client.connect()
 
     with mock.patch.object(socket, "create_connection") as mock_method:
-        mock_method.side_effect = socket.error()
+        mock_method.side_effect = OSError()
         client = lib_client.ModbusTlsClient("127.0.0.1")
         assert not client.connect()
 

--- a/test/test_client_sync_diag.py
+++ b/test/test_client_sync_diag.py
@@ -48,7 +48,7 @@ class TestSynchronousDiagnosticClient:
             assert client.connect()
 
         with mock.patch.object(socket, "create_connection") as mock_method:
-            mock_method.side_effect = socket.error()
+            mock_method.side_effect = OSError()
             client = ModbusTcpDiagClient()
             assert not client.connect()
 


### PR DESCRIPTION
> _exception_ socket.**error**
>
> A deprecated alias of [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError).
> 
> Changed in version 3.3: Following [PEP 3151](https://peps.python.org/pep-3151/), this class was made an alias of [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError).

https://docs.python.org/3/library/socket.html#socket.error
