### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,7 @@ jobs:
           - name: bandit
             cmd: bandit -r -c bandit.yaml .
             type: lint
-          - name: flake8
-            cmd: flake8
-            type: lint
-          - name: precommit (isort and black)
+          - name: precommit (isort, black, and ruff)
             cmd: pre-commit run --all-files
             type: lint
           - name: docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
     hooks:
     -   id: isort
         exclude: ^(doc/_build|venv|.venv|.git|pymodbus/client/serial_asyncio)
+# run ruff with --fix before black
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.261'
+    hooks:
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
 -   repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:

--- a/check_ci.sh
+++ b/check_ci.sh
@@ -8,7 +8,6 @@ trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 codespell
 pre-commit run --all-files
 pylint --recursive=y examples pymodbus test
-flake8
 mypy pymodbus
 pytest --numprocesses auto
 echo "Ready to push"

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,10 +49,6 @@ sphinx-rtd-theme==1.1.1
 bandit==1.7.4
 codespell==2.2.2
 coverage==7.1.0
-flake8==6.0.0
-flake8-docstrings==1.7.0
-flake8-noqa==1.3.0
-flake8-comprehensions==3.10.1
 mypy==1.0.1
 pre-commit==3.1.1
 pyflakes==3.0.1
@@ -64,5 +60,6 @@ pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 pytest-timeout==2.1.0
 pytest-xdist==3.1.0
+ruff==0.0.261
 types-Pygments
 types-pyserial

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,7 +5,6 @@ exclude = [
     ".venv",
     ".git",
     "build",
-    "examples/v2.5.3",
 ]
 ignore = [
     "D202", # No blank lines allowed after function docstring (to work with black)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,24 @@
+target-version="py38"
+exclude = [
+    "pymodbus/client/serial_asyncio",
+    "venv",
+    ".venv",
+    ".git",
+    "build",
+    "examples/v2.5.3",
+]
+ignore = [
+    "D202", # No blank lines allowed after function docstring (to work with black)
+    "E501", # line too long
+    "E731", # lambda expressions
+    "D400"  # docstrings ending in period
+]
+line-length = 120
+select = [
+    "D",
+    "E",
+    "F",
+    "W",
+]
+[pydocstyle]
+convention = "pep257"

--- a/setup.cfg
+++ b/setup.cfg
@@ -477,30 +477,6 @@ check-str-concat-over-line-jumps=no
 # Max line length for which to sill emit suggestions.
 #max-line-length-suggestions=
 
-[flake8]
-exclude         = pymodbus/client/serial_asyncio, venv,.venv,.git,build,examples/v2.5.3
-doctests        = True
-max-line-length = 120
-# To work with Black
-# D202 No blank lines allowed after function docstring
-# E203: Whitespace before ':'
-# E501: line too long
-# W503: Line break occurred before a binary operator
-# W504 line break after binary operator
-ignore =
-    D202,
-    E203,
-    E501,
-    W503,
-    W504,
-
-    D211,
-    D400,
-    E731,
-    W503
-noqa-require-code = True
-
-
 [mypy]
 strict_optional = False
 exclude = pymodbus/client/base.py


### PR DESCRIPTION
`ruff` is rapidly absorbing lots of linters.  I used `flake8-to-ruff` to generate a config which basically matches the current `flake8` configuration.

Integration of bandit is left for later, since it uses the rule names from [`flake8-bandit`](https://beta.ruff.rs/docs/rules/#flake8-bandit-s) which are slightly different.

Note: HomeAssistant has already switched, although [their rules](https://github.com/home-assistant/core/blob/7eccef87c2cccb834f5ff394f765e697831390e3/pyproject.toml#L240) are more strict so I did not copy them (yet).