### PR TITLE
Enable pylint and pygrep rules in ruff, and label rules.

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -14,20 +14,25 @@ ignore = [
 ]
 line-length = 120
 select = [
-    "D",
-    "E",
-    "F",
-    "W",
-    "SIM105",
-    "SIM117",
-    "SIM118",
-    "SIM201",
-    "SIM212",
-    "SIM300",
-    "SIM401",
-    "RUF",
-    "I",
-    "U",
+    "D",      # docstrings
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "SIM105", # flake8-simplify
+    "SIM117", #
+    "SIM118", #
+    "SIM201", #
+    "SIM212", #
+    "SIM300", #
+    "SIM401", #
+    "RUF",    # ruff builtins
+    "I",      # isort
+    "UP",     # pyupgrade
+    "PLC",    # pylint
+    "PGH",    # pygrep-hooks
+    # "TRY",    # tryceratops
+    # "B",      # bandit
+    # "C",      # complexity
 ]
 [pydocstyle]
 convention = "pep257"

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@
 from setuptools import setup
 
 
-dependencies = {}
+dependencies: dict = {}
 with open("requirements.txt") as reqs:
     option = None
     for line in reqs.read().split("\n"):
-        if line == "":
+        if not line:
             option = None
         elif line.startswith("# install:"):
             option = line.split(":")[1]


### PR DESCRIPTION
See https://github.com/pymodbus-dev/pymodbus/issues/1477
