### PR TITLE
Don't catch KeyboardInterrupt twice for REPL server

### DIFF
--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -198,14 +198,11 @@ def run(
         **web_app_config,
         **modbus_config,
     )
-    try:
+    if repl:
+        loop.run_until_complete(run_repl(app))
+    else:
         loop.run_until_complete(app.run_async(repl))
-        if repl:
-            loop.run_until_complete(run_repl(app))
         loop.run_forever()
-
-    except CANCELLED_ERROR:
-        print("Done!!!!!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1497

New behaviour:

```
❯ pymodbus.server run --modbus-server tcp --framer socket --slave-id 1 --slave-id 4 --random 2

__________                          .______.                    _________
\______   \___.__. _____   ____   __| _/\_ |__  __ __  ______  /   _____/ ______________  __ ___________
 |     ___<   |  |/     \ /  _ \ / __ |  | __ \|  |  \/  ___/  \_____  \_/ __ \_  __ \  \/ // __ \_  __ \\
 |    |    \___  |  Y Y  (  <_> ) /_/ |  | \_\ \  |  /\___ \   /        \  ___/|  | \/\   /\  ___/|  | \/
 |____|    / ____|__|_|  /\____/\____ |  |___  /____//____  > /_______  /\___  >__|    \_/  \___  >__|
           \/          \/            \/      \/           \/          \/     \/                 \/


SERVER > exit
Bye Bye!!!

```
