### PR TITLE
Refactor REPL server to reduce complexity

### DIFF
--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -104,6 +104,7 @@ def print_help():
             HTML(f"<skyblue>{cmd:45s}</skyblue><seagreen>{hlp:100s}</seagreen>")
         )
 
+
 def print_title():
     """Print title - large if there are sufficient columns, otherwise small."""
     col = get_terminal_width()
@@ -117,7 +118,8 @@ def print_title():
             HTML(f'<u><b><style color="green">{SMALL_TITLE}</style></b></u>')
         )
 
-async def interactive_shell(server):
+
+async def interactive_shell(server):  # pylint: disable=too-complex
     """Run CLI interactive shell."""
     print_title()
     info("")
@@ -127,7 +129,7 @@ async def interactive_shell(server):
     )
 
     # Run echo loop. Read text from stdin, and reply it back.
-    while True:  # pylint: disable=too-many-nested-blocks
+    while True:
         try:
             result = await session.prompt_async()
             if result == "exit":
@@ -147,7 +149,7 @@ async def interactive_shell(server):
                     warning(f'Usage: "{USAGE}"')
                 else:
                     val_dict = _process_args(command[1:])
-                    if val_dict:
+                    if val_dict:  # pylint: disable=consider-using-assignment-expr
                         server.update_manipulator_config(val_dict)
                         # server.manipulator_config = val_dict
                 # result = await run_command(tester, *command)
@@ -155,7 +157,9 @@ async def interactive_shell(server):
         except (EOFError, KeyboardInterrupt):
             return
 
-def _process_args(args) -> dict:
+
+def _process_args(args) -> dict:  # pylint: disable=too-complex
+    """Process arguments passed to CLI."""
     skip_next = False
     val_dict = {}
     for index, arg in enumerate(args):
@@ -190,6 +194,7 @@ def _process_args(args) -> dict:
                 continue
         val_dict[arg] = value
     return val_dict
+
 
 async def main(server):
     """Run main."""

--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -104,9 +104,8 @@ def print_help():
             HTML(f"<skyblue>{cmd:45s}</skyblue><seagreen>{hlp:100s}</seagreen>")
         )
 
-
-async def interactive_shell(server):  # pylint: disable=too-complex
-    """Run CLI interactive shell."""
+def print_title():
+    """Print title - large if there are sufficient columns, otherwise small."""
     col = get_terminal_width()
     max_len = max(  # pylint: disable=consider-using-generator
         [len(t) for t in TITLE.split("\n")]
@@ -117,6 +116,10 @@ async def interactive_shell(server):  # pylint: disable=too-complex
         print_formatted_text(
             HTML(f'<u><b><style color="green">{SMALL_TITLE}</style></b></u>')
         )
+
+async def interactive_shell(server):
+    """Run CLI interactive shell."""
+    print_title()
     info("")
     completer = NestedCompleter.from_nested_dict(COMMANDS)
     session = PromptSession(

--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -146,43 +146,7 @@ async def interactive_shell(server):  # pylint: disable=too-complex
                 if len(command) == 1:
                     warning(f'Usage: "{USAGE}"')
                 else:
-                    args = command[1:]
-                    skip_next = False
-                    val_dict = {}
-                    for index, arg in enumerate(args):
-                        if skip_next:
-                            skip_next = False
-                            continue
-                        if "=" in arg:
-                            arg, value = arg.split("=")
-                        elif arg in COMMAND_ARGS:
-                            try:
-                                value = args[index + 1]
-                                skip_next = True
-                            except IndexError:
-                                error(f"Missing value for argument - {arg}")
-                                warning('Usage: "{USAGE}"')
-                                break
-                        valid = True
-                        if arg == "response_type":
-                            if value not in RESPONSE_TYPES:
-                                warning(f"Invalid response type request - {value}")
-                                warning(f"Choose from {RESPONSE_TYPES}")
-                                valid = False
-                        elif arg in {  # pylint: disable=confusing-consecutive-elif
-                            "error_code",
-                            "delay_by",
-                            "clear_after",
-                            "data_len",
-                        }:
-                            try:
-                                value = int(value)
-                            except ValueError:
-                                warning(f"Expected integer value for {arg}")
-                                valid = False
-
-                        if valid:
-                            val_dict[arg] = value
+                    val_dict = _process_args(command[1:])
                     if val_dict:
                         server.update_manipulator_config(val_dict)
                         # server.manipulator_config = val_dict
@@ -191,6 +155,44 @@ async def interactive_shell(server):  # pylint: disable=too-complex
         except (EOFError, KeyboardInterrupt):
             return
 
+def _process_args(args) -> dict:
+    skip_next = False
+    val_dict = {}
+    for index, arg in enumerate(args):
+        if skip_next:
+            skip_next = False
+            continue
+        if "=" in arg:
+            arg, value = arg.split("=")
+        elif arg in COMMAND_ARGS:
+            try:
+                value = args[index + 1]
+                skip_next = True
+            except IndexError:
+                error(f"Missing value for argument - {arg}")
+            warning('Usage: "{USAGE}"')
+            break
+        valid = True
+        if arg == "response_type":
+            if value not in RESPONSE_TYPES:
+                warning(f"Invalid response type request - {value}")
+                warning(f"Choose from {RESPONSE_TYPES}")
+                valid = False
+        elif arg in {  # pylint: disable=confusing-consecutive-elif
+            "error_code",
+            "delay_by",
+            "clear_after",
+            "data_len",
+        }:
+            try:
+                value = int(value)
+            except ValueError:
+                warning(f"Expected integer value for {arg}")
+                valid = False
+
+    if valid:
+        val_dict[arg] = value
+    return val_dict
 
 async def main(server):
     """Run main."""

--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -126,7 +126,6 @@ async def interactive_shell(server):  # pylint: disable=too-complex
     # Run echo loop. Read text from stdin, and reply it back.
     while True:  # pylint: disable=too-many-nested-blocks
         try:
-            invalid_command = False
             result = await session.prompt_async()
             if result == "exit":
                 await server.web_app.shutdown()
@@ -139,8 +138,6 @@ async def interactive_shell(server):  # pylint: disable=too-complex
                 continue
             if command := result.split():
                 if command[0] not in COMMANDS:
-                    invalid_command = True
-                if invalid_command:
                     warning(f"Invalid command or invalid usage of command - {command}")
                     continue
                 if len(command) == 1:
@@ -172,12 +169,11 @@ def _process_args(args) -> dict:
                 error(f"Missing value for argument - {arg}")
             warning('Usage: "{USAGE}"')
             break
-        valid = True
         if arg == "response_type":
             if value not in RESPONSE_TYPES:
                 warning(f"Invalid response type request - {value}")
                 warning(f"Choose from {RESPONSE_TYPES}")
-                valid = False
+                continue
         elif arg in {  # pylint: disable=confusing-consecutive-elif
             "error_code",
             "delay_by",
@@ -188,9 +184,7 @@ def _process_args(args) -> dict:
                 value = int(value)
             except ValueError:
                 warning(f"Expected integer value for {arg}")
-                valid = False
-
-    if valid:
+                continue
         val_dict[arg] = value
     return val_dict
 


### PR DESCRIPTION
See https://github.com/pymodbus-dev/pymodbus/pull/1489

This splits up another large function (complexity 23) into smaller ones.

This was much easier/cleaner than the client.  HOWEVER, there are no tests.  I ran the examples in the readme- both servers at least _start_, but I didn't test in detail.
