### PR TITLE
Remove superfluous type check to reduce complexity

### DIFF
--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -119,7 +119,7 @@ def print_title():
         )
 
 
-async def interactive_shell(server):  # pylint: disable=too-complex
+async def interactive_shell(server):
     """Run CLI interactive shell."""
     print_title()
     info("")
@@ -158,7 +158,7 @@ async def interactive_shell(server):  # pylint: disable=too-complex
             return
 
 
-def _process_args(args) -> dict:  # pylint: disable=too-complex
+def _process_args(args) -> dict:
     """Process arguments passed to CLI."""
     skip_next = False
     val_dict = {}

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -201,8 +201,6 @@ class ModbusBaseRequestHandler(asyncio.BaseProtocol):
                 else:
                     addr = (None,)  # empty tuple
 
-                if not isinstance(slaves, (list, tuple)):
-                    slaves = [slaves]
                 # if broadcast is enabled make sure to
                 # process requests to address 0
                 if self.server.broadcast_enable:  # pragma: no cover

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -163,7 +163,7 @@ class ModbusBaseRequestHandler(asyncio.BaseProtocol):
                 traceback.format_exc(),
             )
 
-    async def handle(self):  # pylint: disable=too-complex
+    async def handle(self):
         """Return Asyncio coroutine which represents a single conversation.
 
         between the modbus slave and master

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -124,7 +124,7 @@ class ModbusTransactionManager:
             return mbap.get("length") == exp_resp_len
         return True
 
-    def execute(self, request):  # pylint: disable=too-complex
+    def execute(self, request):  # noqa: C901
         """Start the producer to send the next request to consumer.write(Frame(request))."""
         with self._transaction_lock:
             try:
@@ -332,7 +332,7 @@ class ModbusTransactionManager:
         """Send."""
         return self.client.framer.sendPacket(packet)
 
-    def _recv(self, expected_response_length, full):  # pylint: disable=too-complex
+    def _recv(self, expected_response_length, full):  # noqa: C901
         """Receive."""
         total = None
         if not full:

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,7 +32,7 @@ select = [
     "PGH",    # pygrep-hooks
     # "TRY",    # tryceratops
     # "B",      # bandit
-    # "C",      # complexity
+    "C",      # complexity
 ]
 [pydocstyle]
 convention = "pep257"

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,12 +96,12 @@ load-plugins=
     pylint.extensions.emptystring,
     pylint.extensions.eq_without_hash,
     pylint.extensions.for_any_all,
-    pylint.extensions.mccabe,
     pylint.extensions.overlapping_exceptions,
     pylint.extensions.private_import,
     pylint.extensions.set_membership,
     pylint.extensions.typing,
 # NOT WANTED:
+#     pylint.extensions.mccabe,  (replaced by ruff)
 #     pylint.extensions.broad_try_clause,
 #     pylint.extensions.consider_ternary_expression,
 #     pylint.extensions.empty_comment,


### PR DESCRIPTION
`ruff`, `pylint`, and `radon` all report a McCabe complexity of 11 for this function:
https://github.com/pymodbus-dev/pymodbus/blob/759b222869f5da4ce26d2d18be826bf258ed7a0e/pymodbus/server/async_io.py#L166

There's a conditional to cast `slaves` to a list if it's an integer:
https://github.com/pymodbus-dev/pymodbus/blob/759b222869f5da4ce26d2d18be826bf258ed7a0e/pymodbus/server/async_io.py#L204-L205

However, I think this isn't needed since `slaves` will be setup as a list.
https://github.com/pymodbus-dev/pymodbus/blob/759b222869f5da4ce26d2d18be826bf258ed7a0e/pymodbus/datastore/context.py#L196-L199

Killing this conditional reduces the McCabe complexity from 11 to 10 for both `ruff` and `radon`, although `pylint` still reports it as 11 for some reason >_>.  (I've therefore kept the `# pylint: disable=too-complex` for now.  In the future I intend to disable in favor of ruff.)
