### PR TITLE
Switch to cache included in setup-python action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: requirements.txt
 
-      - name: venv create
+      - name: create venv
         if: steps.setup-python.outputs.cache-hit != 'true'
         run: pip install -e . -r requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,18 +86,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up ${{ matrix.python.version }}
+        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python.version }}
-
-      - name: venv restore
-        id: cache-venv
-        uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: requirements.txt
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
 
       - name: venv create
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+        if: steps.setup-python.outputs.cache-hit != 'true'
         run: pip install -e . -r requirements.txt
 
       - name: test/lint

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -119,7 +119,7 @@ class ModbusBaseClient(ModbusClientMixin, BaseTransport):
         self.state = ModbusTransactionState.IDLE
         self.last_frame_end: float = 0
         self.silent_interval: float = 0
-        self._reconnect_task = None
+        self._reconnect_task: asyncio.Task = None
 
         # Initialize  mixin
         ModbusClientMixin.__init__(self)


### PR DESCRIPTION
Currently the GH actions CI uses `syphar/restore-virtualenv@v1` to restore cache/restore pip dependencies.

It should be possible to do this with `actions/setup-python@v4` directly, since it has [built-in caching](syphar/restore-virtualenv@v1).