### PR TITLE
Enable remaining HomeAssistant rules in ruff

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -14,6 +14,7 @@ ignore = [
 ]
 line-length = 120
 select = [
+    "B007",   # Loop control variable {name} not used within loop body
     "D",      # docstrings
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,6 +15,8 @@ ignore = [
 line-length = 120
 select = [
     "B007",   # Loop control variable {name} not used within loop body
+    "B014",   # Exception handler with duplicate exception
+    "C",      # complexity
     "D",      # docstrings
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
@@ -32,8 +34,8 @@ select = [
     "PLC",    # pylint
     "PGH",    # pygrep-hooks
     # "TRY",    # tryceratops
+    "TRY004", # Prefer TypeError exception for invalid type
     # "B",      # bandit
-    "C",      # complexity
 ]
 [pydocstyle]
 convention = "pep257"

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -121,7 +121,7 @@ class TestFactory:
 
     def test_response_working(self):
         """Test a working response factory decoders"""
-        for func, msg in self.response:
+        for _func, msg in self.response:
             self.client.decode(msg)
 
     def test_response_errors(self):
@@ -134,7 +134,7 @@ class TestFactory:
 
     def test_requests_working(self):
         """Test a working request factory decoders"""
-        for func, msg in self.request:
+        for _func, msg in self.request:
             self.server.decode(msg)
 
     def test_client_factory_fails(self):


### PR DESCRIPTION
Closes #1477

There are still more rules to enable, and `ignore`s to remove, but I'm happy with this for now.
