### PR TITLE
Defaulted pylint

### DIFF
--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -259,9 +259,7 @@ class ModbusTcpClient(ModbusBaseClient):
 
         return b"".join(data)
 
-    def _handle_abrupt_socket_close(
-        self, size, data, duration
-    ):  # pylint: disable=missing-type-doc
+    def _handle_abrupt_socket_close(self, size, data, duration):
         """Handle unexpected socket close by remote end.
 
         Intended to be invoked after determining that the remote end

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -191,7 +191,7 @@ class ModbusStatus:  # pylint: disable=too-few-public-methods
 
     Waiting = 0xFFFF
     Ready = 0x0000
-    On = 0xFF00  # pylint: disable=invalid-name
+    On = 0xFF00
     Off = 0x0000
     SlaveOn = 0xFF
     SlaveOff = 0x00

--- a/setup.cfg
+++ b/setup.cfg
@@ -158,14 +158,6 @@ attr-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 # Regular expression matching correct method names.
 method-rgx=[a-z_][a-zA-Z0-9_]{2,}$
 
-[pylint.typecheck]
-
-# List of class names for which member attributes should not be checked.
-ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
-
-# List of members which are set dynamically.
-generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace
-
 [pylint.design]
 
 # Maximum number of arguments for function / method

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,19 +65,13 @@ include = pymodbus*
 
 
 [pylint.master]
-# Specify a configuration file.
-#rcfile=
-
-# Python code to execute.
-#init-hook=
-
-# Files or directories to be skipped.
-#ignore=CVS
 
 # Add files or directories matching the regex patterns to the ignore-list.
 ignore-paths=
     pymodbus/client/serial_asyncio,
     doc
+
+# Files or directories matching the regular expression patterns are skipped.
 ignore-patterns=^\.#
 
 # Pickle collected data for later comparisons.
@@ -111,32 +105,10 @@ load-plugins=
 # Use multiple processes to speed up Pylint, 0 will auto-detect.
 jobs=0
 
-# pylint would attempt to guess common misconfiguration.
-suggestion-mode=yes
-
-# Allow loading of arbitrary C extensions.
-unsafe-load-any-extension=no
-
-# package or module names from where C extensions may be loaded.
-extension-pkg-allow-list=
-
 # Minimum supported python version
-py-version = 3.8.0
-
-# Amount of potential inferred values with a single object.
-limit-inference-results=100
-
-# Specify a score threshold to be exceeded before program exits with error.
-fail-under=10.0
-
-# Return non-zero exit code if any of these messages/categories are detected.
-fail-on=
-
-
+py-version = 3.8
 
 [pylint.messages_control]
-# Only show warnings with the listed confidence levels.
-# confidence=
 
 # Enable/Disable the message/report/category/checker with the given id(s).
 enable=all
@@ -148,42 +120,16 @@ disable=
     suppressed-message, # NOT wanted
 
 [pylint.reports]
+
 # Set the output format.
 output-format=text
 
-# Tells whether to display a full report or only the messages
-reports=no
-
-# Python expression which should return a note less than 10.
-evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
-
-# Template used to display messages.
-#msg-template=
-
-# Activate the evaluation score.
-score=yes
-
 [pylint.logging]
-# Logging modules to check the string format.
-logging-modules=logging
 
 # The type of string formatting that logging methods do.
 logging-format-style=new
 
-[pylint.miscellaneous]
-# List of note tags/regular expression to take in consideration.
-notes=FIXME,XXX,TODO
-#notes-rgx=
-
 [pylint.similarities]
-# Minimum lines number of a similarity.
-min-similarity-lines=4
-
-# Ignore comments when computing similarities.
-ignore-comments=yes
-
-# Ignore docstrings when computing similarities.
-ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
 ignore-imports=no
@@ -191,135 +137,28 @@ ignore-imports=no
 # Signatures are removed from the similarity computation
 ignore-signatures=no
 
-
 [pylint.variables]
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
 
 # A regular expression matching the name of dummy variables
-#dummy-variables-rgx=_$|dummy
 dummy-variables-rgx=
 
-# List of additional names supposed to be defined in builtins.
-additional-builtins=
-
-# List of strings which can identify a callback function by name.
-#callbacks=cb_,_cb
-callbacks=
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=yes
-
-# List of names allowed to shadow builtins
-allowed-redefined-builtins=
-
-# Argument names that match this expression will be ignored.
-ignored-argument-names=_.*
-
-# List of qualified module names which can have objects that can redefine
-# builtins.
-#redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
-redefining-builtins-modules=past.builtins,future.builtins,builtins,io
-
 [pylint.format]
-# Maximum number of characters on a single line.
-max-line-length=100
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Allow the body of an if to be on the same line.
-single-line-if-stmt=no
-
-# Allow the body of a class to be on the same line as the declaration
-single-line-class-stmt=no
 
 # Maximum number of lines in a module
 max-module-lines=2000
 
-# String used as indentation.
-indent-string='    '
-indent-after-paren=4
-
-# Expected format of line ending.
-#expected-line-ending-format=
-
 [pylint.basic]
+
 # Good variable names which should always be accepted.
-#good-names=i,j,k,run,_
 good-names=i,j,k,rr,fc,rq,fd,x,_
-#good-names-rgxs=
 
-# Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
-bad-names-rgxs=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Include a hint for the correct naming format with invalid-name
-include-naming-hint=no
-
-# Naming style matching correct function names.
-function-naming-style=snake_case
-function-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming style matching correct variable names.
-variable-naming-style=snake_case
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Naming style matching correct attribute names.
-attr-naming-style=snake_case
+# Regular expression matching correct attribute names.
 attr-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
-# Naming style matching correct argument names.
-argument-naming-style=snake_case
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style=any
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Naming style matching correct class constant names.
-class-const-naming-style=UPPER_CASE
-#class-const-rgx=
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming style matching correct class names.
-class-naming-style=PascalCase
-class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming style matching correct module names.
-module-naming-style=snake_case
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Naming style matching correct method names.
-method-naming-style=snake_case
+# Regular expression matching correct method names.
 method-rgx=[a-z_][a-zA-Z0-9_]{2,}$
 
-# function or class names that do not require a docstring.
-no-docstring-rgx=__.*__
-
-# Minimum line length for functions/classes that require docstrings.
-docstring-min-length=-1
-
-# List of decorators that define properties, such as abc.abstractproperty.
-property-classes=abc.abstractproperty
-
 [pylint.typecheck]
-# Regex pattern to define which classes are considered mixins
-mixin-class-rgx=.*MixIn
-
-# List of module names for which member attributes should not be checked.
-ignored-modules=
 
 # List of class names for which member attributes should not be checked.
 ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
@@ -327,44 +166,8 @@ ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
 # List of members which are set dynamically.
 generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace
 
-# List of decorators that create context managers from functions.
-contextmanager-decorators=contextlib.contextmanager
-
-# Warn about missing members when the attribute can be None.
-ignore-none=yes
-
-# This flag controls whether pylint should warn about no-member
-ignore-on-opaque-inference=yes
-
-# Show a hint with possible names when a member name was not found.
-missing-member-hint=yes
-
-# The minimum edit distance a name should have.
-missing-member-hint-distance=1
-
-# The total number of similar names that should be taken in consideration.
-missing-member-max-choices=1
-
-[pylint.spelling]
-# Spelling dictionary name.
-spelling-dict=
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# List of comma separated words that should be considered directives.
-spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,isort:skip,mypy:
-
-# A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words.
-spelling-store-unknown-words=no
-
-# Limits count of emitted suggestions for spelling mistakes.
-max-spelling-suggestions=4
-
 [pylint.design]
+
 # Maximum number of arguments for function / method
 max-args=10
 
@@ -380,101 +183,32 @@ max-branches=27
 # Maximum number of statements in function / method body
 max-statements=100
 
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# List of qualified class names to ignore when counting class parents.
-ignored-parents=
-
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
 
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=25
 
-# Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr=5
-
-# Regular expressions of class ancestor names to ignore.
-exclude-too-few-public-methods=
-
 [pylint.classes]
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp,__post_init__
-
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
 valid-metaclass-classmethod-first-arg=mcs
 
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,_fields,_replace,_source,_make
-
-# Warn about protected attribute access inside special methods
-check-protected-access-in-special-methods=no
-
 [pylint.imports]
-# List of modules that can be imported at any level.
-#allow-any-import-level=
-allow-any-import-level=no
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
-
-# Analyse import fallback blocks.
-analyse-fallback-blocks=no
 
 # Deprecated modules which should not be used, separated by a comma
 deprecated-modules=regsub,TERMIOS,Bastion,rexec
 
-# Create a graph of every dependencies.
-import-graph=
-ext-import-graph=
-int-import-graph=
-
-# import to recognize a module as a standard compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
-
-# Couples of modules and preferred modules, separated by a comma.
-preferred-modules=
-
 [pylint.exceptions]
+
 # Exceptions that will emit a warning when being caught.
 overgeneral-exceptions=Exception
 
-[pylint.typing]
-# app / library does need runtime introspection of type annotations.
-runtime-typing = true
-
 [pylint.deprecated_builtins]
+
 # List of builtins function names that should not be used.
 bad-functions=map,input
 
-[pylint.refactoring]
-# Maximum number of nested blocks for function / method body
-max-nested-blocks=5
-
-# Complete name of functions that never returns.
-never-returning-functions=sys.exit,argparse.parse_error
-
-[pylint.string]
-# inconsistent-quotes generates a warning.
-check-quote-consistency=no
-
-# implicit-str-concat should generate a warning.
-check-str-concat-over-line-jumps=no
-
-[pylint.code_style]
-# Max line length for which to sill emit suggestions.
-#max-line-length-suggestions=
 
 [mypy]
 strict_optional = False


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

Before working on https://github.com/pymodbus-dev/pymodbus/issues/1500, I noticed the `pylint` config was way too verbose (repeated many defaults).  This makes it:
- More arduous to update to newer `pylint` and get updated defaults/args
- Hard to determine what non-default behaviors the config is actually calling out

This PR:
- Removed defaulted options
- Removed some over-constraining options that prevented `pylint` from discerning useless suppressions

To see `pylint` defaults: https://github.com/pylint-dev/pylint/blob/v2.15.10/examples/pylintrc