### PR TITLE
Adding `flake8-pytest-style` to `ruff`

### DIFF
--- a/examples/client_calls.py
+++ b/examples/client_calls.py
@@ -210,12 +210,14 @@ async def _execute_information_requests(client):
     rr = _check_call(
         await client.execute(req_other.GetCommEventCounterRequest(slave=SLAVE))
     )
-    assert rr.status and not rr.count
+    assert rr.status
+    assert not rr.count
 
     rr = _check_call(
         await client.execute(req_other.GetCommEventLogRequest(slave=SLAVE))
     )
-    assert rr.status and not (rr.event_count + rr.message_count + len(rr.events))
+    assert rr.status
+    assert not (rr.event_count + rr.message_count + len(rr.events))
 
 
 async def _execute_diagnostic_requests(client):

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,13 +14,18 @@ ignore = [
 ]
 line-length = 120
 select = [
+    # "B",      # bandit
     "B007",   # Loop control variable {name} not used within loop body
     "B014",   # Exception handler with duplicate exception
     "C",      # complexity
     "D",      # docstrings
     "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
     "F",      # pyflakes
+    "I",      # isort
+    "PGH",    # pygrep-hooks
+    "PLC",    # pylint
+    "PT",     # flake8-pytest-style
+    "RUF",    # ruff builtins
     "SIM105", # flake8-simplify
     "SIM117", #
     "SIM118", #
@@ -28,14 +33,10 @@ select = [
     "SIM212", #
     "SIM300", #
     "SIM401", #
-    "RUF",    # ruff builtins
-    "I",      # isort
     "UP",     # pyupgrade
-    "PLC",    # pylint
-    "PGH",    # pygrep-hooks
+    "W",      # pycodestyle warnings
     # "TRY",    # tryceratops
     "TRY004", # Prefer TypeError exception for invalid type
-    # "B",      # bandit
 ]
 [pydocstyle]
 convention = "pep257"

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,10 +7,11 @@ exclude = [
     "build",
 ]
 ignore = [
-    "D202", # No blank lines allowed after function docstring (to work with black)
-    "E501", # line too long
-    "E731", # lambda expressions
-    "D400"  # docstrings ending in period
+    "D202",  # No blank lines allowed after function docstring (to work with black)
+    "D400",  # docstrings ending in period
+    "E501",  # line too long
+    "E731",  # lambda expressions
+    "PT019",  # Bug: https://github.com/m-burst/flake8-pytest-style/issues/202
 ]
 line-length = 120
 select = [

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -38,7 +38,7 @@ from pymodbus.framer.tls_framer import ModbusTlsFramer
     ],
 )
 @pytest.mark.parametrize(
-    "method, arg, pdu_request",
+    ("method", "arg", "pdu_request"),
     [
         ("read_coils", 1, pdu_bit_read.ReadCoilsRequest),
         ("read_discrete_inputs", 1, pdu_bit_read.ReadDiscreteInputsRequest),
@@ -206,7 +206,7 @@ def test_client_mixin(arglist, method, arg, pdu_request):
     ],
 )
 @pytest.mark.parametrize(
-    "type_args, clientclass",
+    ("type_args", "clientclass"),
     [
         # TBD ("serial", lib_client.AsyncModbusSerialClient),
         # TBD ("serial", lib_client.ModbusSerialClient),
@@ -490,7 +490,7 @@ def test_client_tls_connect():
 
 
 @pytest.mark.parametrize(
-    "datatype,value,registers",
+    ("datatype", "value", "registers"),
     [
         (ModbusClientMixin.DATATYPE.STRING, "abcd", [0x6162, 0x6364]),
         (ModbusClientMixin.DATATYPE.STRING, "a", [0x6100]),

--- a/test/test_client_multidrop.py
+++ b/test/test_client_multidrop.py
@@ -15,12 +15,12 @@ class TestMultidrop:
     good_frame = b"\x02\x03\x00\x01\x00}\xd4\x18"
 
     @pytest.fixture(name="framer")
-    def _framer(self):
+    def fixture_framer(self):
         """Prepare framer."""
         return ModbusRtuFramer(ServerDecoder())
 
     @pytest.fixture(name="callback")
-    def _callback(self):
+    def fixture_callback(self):
         """Prepare dummy callback."""
         return mock.Mock()
 

--- a/test/test_example_client_server.py
+++ b/test/test_example_client_server.py
@@ -74,7 +74,7 @@ def test_get_commandline():
 
 
 @pytest.mark.xdist_group(name="server_serialize")
-@pytest.mark.parametrize("test_comm, test_framer, test_port", TEST_COMMS_FRAMER)
+@pytest.mark.parametrize(("test_comm", "test_framer", "test_port"), TEST_COMMS_FRAMER)
 async def test_exp_async_server_client(
     test_comm,
     test_framer,
@@ -102,7 +102,9 @@ async def test_exp_async_server_client(
 
 
 @pytest.mark.xdist_group(name="server_serialize")
-@pytest.mark.parametrize("test_comm, test_framer, test_port", [TEST_COMMS_FRAMER[0]])
+@pytest.mark.parametrize(
+    ("test_comm", "test_framer", "test_port"), [TEST_COMMS_FRAMER[0]]
+)
 def test_exp_sync_server_client(
     test_comm,
     test_framer,

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -24,9 +24,5 @@ class TestExceptions:  # pylint: disable=too-few-public-methods
     def test_exceptions(self):
         """Test all module exceptions"""
         for exc in self.exceptions:
-            try:
+            with pytest.raises(ModbusException, match="Modbus Error:"):
                 raise exc
-            except ModbusException as exc:
-                assert "Modbus Error:" in str(exc)
-                return
-            pytest.fail("Excepted a ModbusExceptions")

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -96,7 +96,7 @@ class TestFactory:
     )
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def _setup(self):
         """Do common setup function."""
         self.client = ClientDecoder()
         self.server = ServerDecoder()

--- a/test/test_framers.py
+++ b/test/test_framers.py
@@ -16,14 +16,14 @@ from pymodbus.utilities import ModbusTransactionState
 TEST_MESSAGE = b"\x00\x01\x00\x01\x00\n\xec\x1c"
 
 
-@pytest.fixture
-def rtu_framer():
+@pytest.fixture(name="rtu_framer")
+def fixture_rtu_framer():
     """RTU framer."""
     return ModbusRtuFramer(ClientDecoder())
 
 
-@pytest.fixture
-def ascii_framer():
+@pytest.fixture(name="ascii_framer")
+def fixture_ascii_framer():
     """Ascii framer."""
     return ModbusAsciiFramer(ClientDecoder())
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -28,7 +28,7 @@ class TestLogging:
         assert log_txt == txt
 
     @pytest.mark.parametrize(
-        "txt, result, params",
+        ("txt", "result", "params"),
         [
             ("string {} {} {}", "string 101 102 103", (101, 102, 103)),
             ("string {}", "string 0x41 0x42 0x43 0x44", (b"ABCD", ":hex")),

--- a/test/test_server_asyncio.py
+++ b/test/test_server_asyncio.py
@@ -105,7 +105,7 @@ class TestAsyncioServer:  # pylint: disable=too-many-public-methods
     identity = None
 
     @pytest.fixture(autouse=True)
-    async def setup_teardown(self):
+    async def _setup_teardown(self):
         """Initialize the test environment by setting up a dummy store and context."""
         self.loop = asyncio.get_running_loop()
         self.store = ModbusSlaveContext(

--- a/test/test_server_task.py
+++ b/test/test_server_task.py
@@ -149,7 +149,7 @@ async def test_async_task_no_server(comm):
     try:
         await client.connect()
     except Exception as exc:  # pylint: disable=broad-except
-        assert False, f"unexpected exception: {exc}"
+        raise AssertionError(f"unexpected exception: {exc}") from exc
     await asyncio.sleep(0.1)
     with pytest.raises((asyncio.exceptions.TimeoutError, ConnectionException)):
         await client.read_coils(1, 1, slave=0x01)
@@ -247,7 +247,7 @@ async def test_async_task_server_stop(comm):
         await asyncio.sleep(0.1)
         timer_allowed -= 1
         if not timer_allowed:
-            assert False, "client do not reconnect"
+            pytest.fail("client do not reconnect")
     assert client.transport
     on_reconnect_callback.assert_called()
 
@@ -270,7 +270,7 @@ def test_sync_task_no_server(comm):
     try:
         client.connect()
     except Exception as exc:  # pylint: disable=broad-except
-        assert False, f"unexpected exception: {exc}"
+        raise AssertionError(f"unexpected exception: {exc}") from exc
     sleep(0.1)
     if comm == "udp":
         rr = client.read_coils(1, 1, slave=0x01)
@@ -345,7 +345,7 @@ def test_sync_task_server_stop(comm):
         sleep(0.1)
         timer_allowed -= 1
         if not timer_allowed:
-            assert False, "client do not reconnect"
+            pytest.fail("client do not reconnect")
     assert client.socket
 
     rr = client.read_coils(1, 1, slave=0x01)

--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -404,7 +404,7 @@ class TestSimulator:
             assert cell.count_write == str(reg.count_write), f"at register {test_reg}"
 
     @pytest.mark.parametrize(
-        "func,addr",
+        ("func", "addr"),
         [
             (FX_READ_BIT, 12),
             (FX_READ_REG, 16),


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

- Closes https://github.com/pymodbus-dev/pymodbus/issues/1500.
- Alphabetizes some `ruff` config lists