### PR TITLE
Fix missing web content for simulator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,7 @@ del dependencies["required"]
 setup(
     install_requires=install_req,
     extras_require=dependencies,
-    package_data={"pymodbus": ["py.typed"]},
+    package_data={
+        "pymodbus": ["py.typed", "server/simulator/setup.json", "server/simulator/web/**/*"],
+    },
 )


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Running `pymodbus.simulator` after installing pymodbus via pypi results in exceptions that certain files were not found.
Specifically the `simulator/web/generator/*` files. Upon further inspection it seems that these files are not packaged in the actual wheel, the simulator fails to start without these files. 

 Added the needed files for the simulator to `setup.py` to ensure that they're installed in the wheel. Verified locally that this works. 