### PR TITLE
Suppress asyncio error in callback for transport_connect

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -368,8 +368,7 @@ class BaseTransport:
         )
         self.reconnect_timer = self.loop.call_later(
             self.reconnect_delay_current,
-            asyncio.create_task,
-            self.transport_connect(),
+            lambda: asyncio.create_task(self.transport_connect()),
         )
         self.reconnect_delay_current = min(
             2 * self.reconnect_delay_current, self.comm_params.reconnect_delay_max


### PR DESCRIPTION
Closes #1574 

(Supercedes #1575, which was incorrect analysis of the problem).

I do not know why the lamda suppresses the `RuntimeWarning: coroutine 'BaseTransport.transport_connect' was never awaited` warning, but it does :)
