### PR TITLE
Python 3.11, versioning (pep 440).

### DIFF
--- a/pymodbus/__init__.py
+++ b/pymodbus/__init__.py
@@ -12,5 +12,5 @@ __all__ = [
 from pymodbus.logging import pymodbus_apply_logging_config
 
 
-__version__ = "3.4.0alfa"
+__version__ = "3.4.0.dev"
 __version_full__ = f"[pymodbus, version {__version__}]"


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
It seems 3.4.0alfa is no longer allowed in python 3.11, it needs to be 3.4.0.alfa