### PR TITLE
Change to "sync client" in forwarder example

### DIFF
--- a/examples/modbus_forwarder.py
+++ b/examples/modbus_forwarder.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 
 from examples import helper
-from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.datastore.remote import RemoteSlaveContext
 from pymodbus.server import StartAsyncTcpServer
@@ -40,11 +40,11 @@ async def run_forwarder(args):
     txt = f"### start forwarder, listen {args.port}, connect to {args.client_port}"
     _logger.info(txt)
 
-    args.client = AsyncModbusTcpClient(
+    args.client = ModbusTcpClient(
         host="localhost",
         port=args.client_port,
     )
-    await args.client.connect()
+    args.client.connect()
     assert args.client.connected
     # If required to communicate with a specified client use slave=<slave_id>
     # in RemoteSlaveContext
@@ -58,7 +58,7 @@ async def run_forwarder(args):
         store = RemoteSlaveContext(args.client, slave=1)
     args.context = ModbusServerContext(slaves=store, single=True)
 
-    await StartAsyncTcpServer(context=args.context, address=("localhost", args.port))
+    await StartAsyncTcpServer(context=args.context, address=("", args.port))
     # loop forever
 
 

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -112,7 +112,6 @@ class ModbusTcpClient(ModbusBaseClient):
         **kwargs: Any,
     ) -> None:
         """Initialize Modbus TCP Client."""
-        self.transport = None
         super().__init__(framer=framer, **kwargs)
         self.params.host = host
         self.params.port = port
@@ -123,7 +122,7 @@ class ModbusTcpClient(ModbusBaseClient):
     @property
     def connected(self):
         """Connect internal."""
-        return self.transport is not None
+        return self.socket is not None
 
     def connect(self):  # pylint: disable=invalid-overridden-method
         """Connect to the modbus tcp server."""


### PR DESCRIPTION
I replace the `AsyncModbusTcpClient` with `ModbusTcpClient`.
The problems caused with the Async Client are discussed here:
https://github.com/pymodbus-dev/pymodbus/discussions/1593#discussioncomment-6145862
https://github.com/pymodbus-dev/pymodbus/issues/1549#issuecomment-1563466215

An error in the `ModbusTcpClient` in the method `connected` was also fixed.