### PR TITLE
Fix readme status badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ There are challenges small and large not only programming but also documentation
 
 .. image:: https://github.com/pymodbus-dev/pymodbus/actions/workflows/ci.yml/badge.svg?branch=dev
    :target: https://github.com/pymodbus-dev/pymodbus/actions/workflows/ci.yml
- .. image:: https://readthedocs.org/projects/pymodbus/badge/?version=latest
+.. image:: https://readthedocs.org/projects/pymodbus/badge/?version=latest
    :target: https://pymodbus.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 .. image:: https://pepy.tech/badge/pymodbus


### PR DESCRIPTION
Before:
<img width="435" alt="Screenshot 2023-07-20 at 3 44 33 PM" src="https://github.com/pymodbus-dev/pymodbus/assets/52292902/534dcddb-3388-4007-b616-090740c48bb3">

After:
<img width="689" alt="Screenshot 2023-07-20 at 3 44 42 PM" src="https://github.com/pymodbus-dev/pymodbus/assets/52292902/342642ba-428c-45e8-b6fe-a26a1320290e">

