### PR TITLE
Update ruff to 0.0.277

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-added-large-files
 # run ruff with --fix before black
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.263'
+    rev: 'v0.0.277'
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/examples/client_calls.py
+++ b/examples/client_calls.py
@@ -79,7 +79,7 @@ async def async_template_call(client):
         raise ModbusException(txt)
 
     # Validate data
-    txt = f"### Template coils response: {str(rr.bits)}"
+    txt = f"### Template coils response: {rr.bits!s}"
     _logger.debug(txt)
 
 
@@ -102,7 +102,7 @@ def template_call(client):
         raise ModbusException(txt)
 
     # Validate data
-    txt = f"### Template coils response: {str(rr.bits)}"
+    txt = f"### Template coils response: {rr.bits!s}"
     _logger.debug(txt)
 
 

--- a/examples/server_updating.py
+++ b/examples/server_updating.py
@@ -52,7 +52,7 @@ async def updating_task(context):
     address = 0x10
     values = context[slave_id].getValues(fc_as_hex, address, count=5)
     values = [v + 1 for v in values]  # increment by 1.
-    txt = f"new values: {str(values)}"
+    txt = f"new values: {values!s}"
     _logger.debug(txt)
     context[slave_id].setValues(fc_as_hex, address, values)
     await asyncio.sleep(1)

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -176,10 +176,10 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
         """
         if self.use_sync:
             if not self.connected:
-                raise ConnectionException(f"Failed to connect[{str(self)}]")
+                raise ConnectionException(f"Failed to connect[{self!s}]")
             return self.transaction.execute(request)
         if not self.transport:
-            raise ConnectionException(f"Not connected[{str(self)}]")
+            raise ConnectionException(f"Not connected[{self!s}]")
         return self.async_execute(request)
 
     # ----------------------------------------------------------------------- #

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ pytest-asyncio>=0.20.3
 pytest-cov>=4.1.0
 pytest-timeout>=2.1.0
 pytest-xdist>=3.3.1
-ruff>=0.0.261
+ruff>=0.0.277
 types-Pygments
 types-pyserial
 twine>=4.0.2

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,6 +15,8 @@ ignore = [
     "S101",  # Use of `assert`
     "S311",  # PRNG for cryptography
     "S104",  # binding on all interfaces
+    "RUF012",  # typing.ClassVar
+    "RUF013",  # implicit Optional
 ]
 line-length = 120
 select = [


### PR DESCRIPTION
See #1687 and #1685; those should be merged first.

We have decided that implicit Optional is OK already (example `foo: Optional[bar] = None` is 
unnecessary`).  The `typing.ClassVar` rule also seems noisy.
