### PR TITLE
xdist loadscope (test is not split).

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-Copyright (c) 2011 Galen Collins
-All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:

--- a/README.rst
+++ b/README.rst
@@ -288,10 +288,4 @@ We always have more work than time, so feel free to open a discussion / issue on
 License Information
 ------------------------------------------------------------
 
-Pymodbus is built on top of code developed from/by:
-  * Copyright (c) 2001-2005 S.W.A.C. GmbH, Germany.
-  * Copyright (c) 2001-2005 S.W.A.C. Bohemia s.r.o., Czech Republic.
-
-  * Hynek Petrak, https://github.com/HynekPetrak
-
 Released under the `BSD License <LICENSE>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -249,7 +249,7 @@ upload_dir = build/sphinx/html
 [tool:pytest]
 # log_cli = true
 testpaths = test
-addopts = -p no:warnings --dist loadgroup --numprocesses auto
+addopts = -p no:warnings --dist loadscope --numprocesses auto
 asyncio_mode = auto
 timeout = 40
 

--- a/test/sub_transport/conftest.py
+++ b/test/sub_transport/conftest.py
@@ -88,12 +88,13 @@ def prepare_commparams_client(use_port, use_host, use_comm_type):
     """Prepare CommParamsClass object."""
     if use_host == NULLMODEM_HOST and use_comm_type == CommType.SERIAL:
         use_host = f"{NULLMODEM_HOST}:{use_port}"
+    timeout = 10 if not pytest.IS_WINDOWS else 5
     return CommParams(
         comm_name="test comm",
         comm_type=use_comm_type,
         reconnect_delay=1,
         reconnect_delay_max=3.5,
-        timeout_connect=2,
+        timeout_connect=timeout,
         host=use_host,
         port=use_port,
         baudrate=9600,


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
loadgroup (as it was) means define group names
loadscope means each class is run in the same worker.
