### PR TITLE
pymodbus.server: allow strings for "-p" paramter

### DIFF
--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -137,7 +137,7 @@ def run(
         autocompletion=framers,
         help="Modbus framer to use",
     ),
-    modbus_port: int = typer.Option(5020, "--modbus-port", "-p", help="Modbus port"),
+    modbus_port: str = typer.Option("5020", "--modbus-port", "-p", help="Modbus port"),
     modbus_slave_id: List[int] = typer.Option(
         [1], "--slave-id", "-u", help="Supported Modbus slave id's"
     ),


### PR DESCRIPTION
The parameter "-p" is used for both, ModbusTcpServer as well as ModbusSerialServer.

In case of the serial server, the paramter is used to specify the serial port which is typically a string (and not an integer).

Fixes issue #1712.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
