### PR TITLE
RFC: Reduce parameters for REPL server classes

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -8,6 +8,7 @@ Version 3.5.0 (future)
 - Remove handler parameter from ModbusUdpServer
 - Remove handler from default config
 - Remove allow_reuse_port from default config
+- Remove loop parameter from ModbusSerialServer
 
 -------------
 Version 3.4.2

--- a/API_changes.rst
+++ b/API_changes.rst
@@ -6,7 +6,7 @@ PyModbus - API changes.
 Version 3.5.0 (future)
 -------------
 - Remove handler parameter from ModbusUdpServer
-- Remove handler from default config
+- Remove handler from repl default config
 - Remove allow_reuse_port from default config
 - Remove loop parameter from ModbusSerialServer
 

--- a/API_changes.rst
+++ b/API_changes.rst
@@ -3,6 +3,13 @@ PyModbus - API changes.
 =======================
 
 -------------
+Version 3.5.0 (future)
+-------------
+- Remove handler parameter from ModbusUdpServer
+- Remove handler from default config
+- Remove allow_reuse_port from default config
+
+-------------
 Version 3.4.2
 -------------
 -ModbusSerialServer now accepts request_tracer=.

--- a/API_changes.rst
+++ b/API_changes.rst
@@ -7,7 +7,7 @@ Version 3.5.0 (future)
 -------------
 - Remove handler parameter from ModbusUdpServer
 - Remove handler from repl default config
-- Remove allow_reuse_port from default config
+- Remove allow_reuse_port from repl default config
 - Remove loop parameter from ModbusSerialServer
 
 -------------

--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -185,7 +185,6 @@ def run(
         framer,
         modbus_port=modbus_port,
         slave=modbus_slave_id,
-        loop=loop,
         single=False,
         data_block_settings=data_block_settings,
         **web_app_config,

--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -16,7 +16,6 @@ from pymodbus.repl.server.cli import run_repl
 from pymodbus.server.reactive.default_config import DEFAULT_CONFIG
 from pymodbus.server.reactive.main import (
     DEFAULT_FRAMER,
-    DEFUALT_HANDLERS,
     ReactiveServer,
 )
 
@@ -114,7 +113,7 @@ def server(
         "repl": repl,
         "host": host,
         "web_port": web_port,
-        "broadcast": broadcast_support,
+        "broadcast_enable": broadcast_support,
     }
 
 
@@ -178,13 +177,7 @@ def run(
     data_block_settings = modbus_config.pop("data_block_settings", {})
     modbus_config = modbus_config.get(modbus_server, {})
     modbus_config = process_extra_args(extra_args, modbus_config)
-    if modbus_server != "serial":
-        handler = modbus_config.pop("handler", "ModbusConnectedRequestHandler")
-    else:
-        handler = modbus_config.pop("handler", "ModbusSingleRequestHandler")
-    handler = DEFUALT_HANDLERS.get(handler.strip())
 
-    modbus_config["handler"] = handler
     modbus_config["randomize"] = randomize
     modbus_config["change_rate"] = change_rate
     app = ReactiveServer.factory(

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -572,7 +572,7 @@ class ModbusSerialServer(ModbusProtocol):
             True,
         )
 
-        self.loop = kwargs.get("loop") or asyncio.get_event_loop()
+        self.loop = asyncio.get_running_loop()
         self.handle_local_echo = kwargs.get("handle_local_echo", False)
         self.ignore_missing_slaves = kwargs.get("ignore_missing_slaves", False)
         self.broadcast_enable = kwargs.get("broadcast_enable", False)

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -449,8 +449,6 @@ class ModbusUdpServer(ModbusProtocol):
         :param framer: The framer strategy to use
         :param identity: An optional identify structure
         :param address: An optional (interface, port) to bind to.
-        :param handler: A handler for each client session; default is
-                            ModbusDisonnectedRequestHandler
         :param ignore_missing_slaves: True to not send errors on a request
                             to a missing slave
         :param broadcast_enable: True to treat slave_id 0 as broadcast address,

--- a/pymodbus/server/reactive/default_config.py
+++ b/pymodbus/server/reactive/default_config.py
@@ -2,12 +2,9 @@
 
 DEFAULT_CONFIG = {
     "tcp": {
-        "handler": "ModbusConnectedRequestHandler",
-        "allow_reuse_port": True,
         "ignore_missing_slaves": False,
     },
     "serial": {
-        "handler": "ModbusSingleRequestHandler",
         "stopbits": 1,
         "bytesize": 8,
         "parity": "N",
@@ -16,14 +13,11 @@ DEFAULT_CONFIG = {
         "reconnect_delay": 2,
     },
     "tls": {
-        "handler": "ModbusConnectedRequestHandler",
         "certfile": None,
         "keyfile": None,
-        "allow_reuse_port": True,
         "ignore_missing_slaves": False,
     },
     "udp": {
-        "handler": "ModbusDisonnectedRequestHandler",
         "ignore_missing_slaves": False,
     },
     "data_block_settings": {

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -33,7 +33,6 @@ from pymodbus.logging import Log
 from pymodbus.pdu import ExceptionResponse, ModbusExceptions
 from pymodbus.server.async_io import (
     ModbusSerialServer,
-    ModbusServerRequestHandler,
     ModbusTcpServer,
     ModbusTlsServer,
     ModbusUdpServer,
@@ -68,11 +67,6 @@ DEFAULT_MANIPULATOR = {
     "delay_by": 0,
     "error_code": ModbusExceptions.IllegalAddress,
     "clear_after": 5,  # request count
-}
-DEFUALT_HANDLERS = {
-    "ModbusSingleRequestHandler": ModbusServerRequestHandler,
-    "ModbusConnectedRequestHandler": ModbusServerRequestHandler,
-    "ModbusDisconnectedRequestHandler": ModbusServerRequestHandler,
 }
 DEFAULT_MODBUS_MAP = {
     "block_start": 0,


### PR DESCRIPTION
In order to avoid using **kwargs in Modbus{Tcp,Tls,Udp}Server, I had to remove all superfluous arguments. I did a little bit of testing, but I don't have the full overview of the impact of all changes. Please review and let me know your thoughts!


- allows to run "modbus.server run" with server classes which use specific argument list without "**kwargs" in their init methods
- remove "handler" (all handles are now mapped to ModbusServerRequestHandler)
- remove "allow_reuse_port" (not used otherwise)
- loop (not used anymore)
- rename paramter "broadcast" to "broadcast_enable" as used in server classes
- fixes issue #1711

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
