### PR TITLE
Request tracer

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -3,6 +3,12 @@ PyModbus - API changes.
 =======================
 
 -------------
+Version 3.4.2
+-------------
+-ModbusSerialServer now accepts request_tracer=.
+
+
+-------------
 Version 3.4.1
 -------------
 

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -556,6 +556,7 @@ class ModbusSerialServer(ModbusProtocol):
         :param reconnect_delay: reconnect delay in seconds
         :param response_manipulator: Callback method for
                     manipulating the response
+        :param request_tracer: Callback method for tracing
         """
         super().__init__(
             CommParams(
@@ -584,7 +585,7 @@ class ModbusSerialServer(ModbusProtocol):
         self.control = ModbusControlBlock()
         if isinstance(identity, ModbusDeviceIdentification):
             self.control.Identity.update(identity)
-        self.request_tracer = None
+        self.request_tracer = kwargs.get("request_tracer", None)
         self.server = None
         self.control = ModbusControlBlock()
         identity = kwargs.get("identity")

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -487,7 +487,6 @@ class ModbusUdpServer(ModbusProtocol):
         # asyncio future that will be done once server has started
         self.serving = asyncio.Future()
         self.serving_done = asyncio.Future()
-        self.request_tracer = None
         self.handle_local_echo = False
 
     def handle_new_connection(self):


### PR DESCRIPTION
Getting the request_tracer from kwargs instead of setting it to None in ModbusSerialServer. Works as expected.
Removed line from ModbusUdpServer that overwrote the request_tracer set on line 483 with None.

If there was a reason for disabling the request_tracer in the Serail and UDP server please let me know as I use it in my project.