### PR TITLE
Fix custom message parsing in RTU framer

### DIFF
--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -62,7 +62,7 @@ class ModbusRtuFramer(ModbusFramer):
         self._hsize = 0x01
         self._end = b"\x0d\x0a"
         self._min_frame_size = 4
-        self.function_codes = set(self.decoder.lookup) if self.decoder else {}
+        self.function_codes = decoder.lookup.keys() if decoder else {}
 
     # ----------------------------------------------------------------------- #
     # Private Helper Functions


### PR DESCRIPTION
As the regression reported in #1695 still isn't resolved in pyModbus 3.4.1, I've been tinkering with the code to try to reproduce the issue.

I noticed that `ModbusRtuFramer` caches the function codes registered in the decoder lookup table. As the framer is already initialized before a client can call the `register()` function to register custom Modbus message types, this prevents those custom Modbus messages from being processed correctly.

This PR uses `.keys()` instead of `set()` which prevents `function_codes` from becoming outdated if a custom message class is registered.

Open question: if there a valid case for the decoder being None? Otherwise we can drop the fallback to `{}`?