### PR TITLE
Fix faulty not check

### DIFF
--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -185,7 +185,7 @@ class WriteMultipleCoilsRequest(ModbusRequest):
         """
         ModbusRequest.__init__(self, slave=slave, **kwargs)
         self.address = address
-        if not values:
+        if values is None:
             values = []
         elif not hasattr(values, "__iter__"):
             values = [values]

--- a/test/test_bit_write_messages.py
+++ b/test/test_bit_write_messages.py
@@ -140,3 +140,8 @@ class TestModbusBitMessage:
         for request in requests:
             result = str(request)
             assert result
+
+    def test_pass_falsy_value_in_write_multiple_coils_request(self):
+        """Test pass falsy invalid multiple coils."""
+        request = WriteMultipleCoilsRequest(1, 0)
+        assert request.values == [0]

--- a/test/test_bit_write_messages.py
+++ b/test/test_bit_write_messages.py
@@ -142,6 +142,6 @@ class TestModbusBitMessage:
             assert result
 
     def test_pass_falsy_value_in_write_multiple_coils_request(self):
-        """Test pass falsy invalid multiple coils."""
+        """Test pass falsy value to write multiple coils."""
         request = WriteMultipleCoilsRequest(1, 0)
         assert request.values == [0]


### PR DESCRIPTION
### Issue:
If you check how you're handling writing to multiple registers, you notice you're using [explicit `is None` check](https://github.com/pymodbus-dev/pymodbus/blob/dev/pymodbus/register_write_message.py#L171), which allows passing "falsy" values.

However for coils, you're doing [`not` check](https://github.com/pymodbus-dev/pymodbus/blob/dev/pymodbus/bit_write_message.py#L188), which means it's impossible to write `0` as it will get converted to an empty `list`.

It's not a big deal and it's a good practice to explicitly wrap values into a list, but since you do support it for input registers, can make sense to support for coils as well.

### Changelog:
- replaces `not` check with explicit `is None`
- added a test case for this

### Note:
I'm not too familiar with `pytest`, but I hope I added a valid test case for this.