### PR TITLE
Broadcast with Handle Local Echo

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -296,6 +296,9 @@ class ModbusTransactionManager:
                 )
                 self.client.state = ModbusTransactionState.PROCESSING_REPLY
                 return size, None
+            if self.client.comm_params.handle_local_echo is True:
+                if self._recv(size, full) != packet:
+                    return b"", "Wrong local echo"
             if broadcast:
                 if size:
                     Log.debug(
@@ -310,9 +313,6 @@ class ModbusTransactionManager:
                     'to "WAITING FOR REPLY"'
                 )
                 self.client.state = ModbusTransactionState.WAITING_FOR_REPLY
-            if self.client.comm_params.handle_local_echo is True:
-                if self._recv(size, full) != packet:
-                    return b"", "Wrong local echo"
             result = self._recv(response_length, full)
             # result2 = self._recv(response_length, full)
             Log.debug("RECV: {}", result, ":hex")

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -192,6 +192,18 @@ class TestTransaction:  # pylint: disable=too-many-public-methods
         response = trans.execute(request)
         assert response == b"Broadcast write sent - no response expected"
 
+        # Broadcast w/ Local echo
+        client.comm_params.handle_local_echo = True
+        client.params.broadcast_enable = True
+        recv = trans._recv = mock.MagicMock(  # pylint: disable=protected-access
+            return_value=b"deadbeef"
+        )
+        request.slave_id = 0
+        response = trans.execute(request)
+        assert response == b"Broadcast write sent - no response expected"
+        recv.assert_called_once_with(8, False)
+        client.comm_params.handle_local_echo = False
+
     # ----------------------------------------------------------------------- #
     # Dictionary based transaction manager
     # ----------------------------------------------------------------------- #


### PR DESCRIPTION
When using a broadcast transaction with handle_local_echo=True the broadcast skips reading a the local echo and leaves
the echo in the receive buffer. This results in a "Cleanup recv buffer before send" warning on the next transaction.

Fix this by ensuring the local echo is read for broadcast transactions.

Also add a test for this behaviour.