### PR TITLE
Use enums for constants

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -8,6 +8,12 @@ Version 3.5.0 (future)
 - Remove handler parameter from ModbusUdpServer
 - Remove loop parameter from ModbusSerialServer
 - Remove handler and allow_reuse_port from repl default config
+- Static classes from the :code:`constants` module are now inheriting from :code:`enum.Enum` and using `UPPER_CASE` naming scheme, this affects:
+  - :code:`MoreData`
+  - :code:`DeviceInformation`
+  - :code:`ModbusPlusOperation`
+  - :code:`Endian`
+  - :code:`ModbusStatus`
 
 -------------
 Version 3.4.2

--- a/examples/client_payload.py
+++ b/examples/client_payload.py
@@ -43,10 +43,10 @@ async def run_payload_calls(client):
     ++++++++++++++++++++++++++++++++++++++++++++
     """
     for word_endian, byte_endian in (
-        (Endian.Big, Endian.Big),
-        (Endian.Big, Endian.Little),
-        (Endian.Little, Endian.Big),
-        (Endian.Little, Endian.Little),
+        (Endian.BIG, Endian.BIG),
+        (Endian.BIG, Endian.LITTLE),
+        (Endian.LITTLE, Endian.BIG),
+        (Endian.LITTLE, Endian.LITTLE),
     ):
         print("-" * 60)
         print(f"Word Order: {ORDER_DICT[word_endian]}")

--- a/examples/server_payload.py
+++ b/examples/server_payload.py
@@ -26,7 +26,7 @@ def setup_payload_server(cmdline=None):
     # ----------------------------------------------------------------------- #
     # build your payload
     # ----------------------------------------------------------------------- #
-    builder = BinaryPayloadBuilder(byteorder=Endian.Little, wordorder=Endian.Little)
+    builder = BinaryPayloadBuilder(byteorder=Endian.LITTLE, wordorder=Endian.LITTLE)
     builder.add_string("abcdefgh")
     builder.add_bits([0, 1, 0, 1, 1, 0, 1, 0])
     builder.add_8bit_int(-0x12)

--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -24,8 +24,8 @@ from pymodbus.utilities import pack_bitstring, unpack_bitstring
 # ---------------------------------------------------------------------------#
 #  These are defined in the spec to turn a coil on/off
 # ---------------------------------------------------------------------------#
-_turn_coil_on = struct.pack(">H", ModbusStatus.On)
-_turn_coil_off = struct.pack(">H", ModbusStatus.Off)
+_turn_coil_on = struct.pack(">H", ModbusStatus.ON)
+_turn_coil_off = struct.pack(">H", ModbusStatus.OFF)
 
 
 class WriteSingleCoilRequest(ModbusRequest):
@@ -77,7 +77,7 @@ class WriteSingleCoilRequest(ModbusRequest):
         :param data: The packet data to decode
         """
         self.address, value = struct.unpack(">HH", data)
-        self.value = value == ModbusStatus.On
+        self.value = value == ModbusStatus.ON
 
     def execute(self, context):
         """Run a write coil request against a datastore.
@@ -151,7 +151,7 @@ class WriteSingleCoilResponse(ModbusResponse):
         :param data: The packet data to decode
         """
         self.address, value = struct.unpack(">HH", data)
-        self.value = value == ModbusStatus.On
+        self.value = value == ModbusStatus.ON
 
     def __str__(self):
         """Return a string representation of the instance.

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -11,39 +11,39 @@ INTERNAL_ERROR = "Pymodbus internal error"
 class ModbusStatus(int, enum.Enum):
     """These represent various status codes in the modbus protocol.
 
-    .. attribute:: Waiting
+    .. attribute:: WAITING
 
        This indicates that a modbus device is currently
        waiting for a given request to finish some running task.
 
-    .. attribute:: Ready
+    .. attribute:: READY
 
        This indicates that a modbus device is currently
        free to perform the next request task.
 
-    .. attribute:: On
+    .. attribute:: ON
 
        This indicates that the given modbus entity is on
 
-    .. attribute:: Off
+    .. attribute:: OFF
 
        This indicates that the given modbus entity is off
 
-    .. attribute:: SlaveOn
+    .. attribute:: SLAVE_ON
 
        This indicates that the given modbus slave is running
 
-    .. attribute:: SlaveOff
+    .. attribute:: SLAVE_OFF
 
        This indicates that the given modbus slave is not running
     """
 
-    Waiting = 0xFFFF
-    Ready = 0x0000
-    On = 0xFF00
-    Off = 0x0000
-    SlaveOn = 0xFF
-    SlaveOff = 0x00
+    WAITING = 0xFFFF
+    READY = 0x0000
+    ON = 0xFF00
+    OFF = 0x0000
+    SLAVE_ON = 0xFF
+    SLAVE_OFF = 0x00
 
     def __str__(self):
        return str(int(self))
@@ -52,16 +52,16 @@ class ModbusStatus(int, enum.Enum):
 class Endian(str, enum.Enum):
     """An enumeration representing the various byte endianness.
 
-    .. attribute:: Auto
+    .. attribute:: AUTO
 
        This indicates that the byte order is chosen by the
        current native environment.
 
-    .. attribute:: Big
+    .. attribute:: BIG
 
        This indicates that the bytes are in big endian format
 
-    .. attribute:: Little
+    .. attribute:: LITTLE
 
        This indicates that the bytes are in little endian format
 
@@ -69,9 +69,9 @@ class Endian(str, enum.Enum):
        python struct module for my convenience.
     """
 
-    Auto = "@"
-    Big = ">"
-    Little = "<"
+    AUTO = "@"
+    BIG = ">"
+    LITTLE = "<"
 
     def __str__(self):
        return str.__str__(self)
@@ -80,19 +80,19 @@ class Endian(str, enum.Enum):
 class ModbusPlusOperation(int, enum.Enum):
     """Represents the type of modbus plus request.
 
-    .. attribute:: GetStatistics
+    .. attribute:: GET_STATISTICS
 
        Operation requesting that the current modbus plus statistics
        be returned in the response.
 
-    .. attribute:: ClearStatistics
+    .. attribute:: CLEAR_STATISTICS
 
        Operation requesting that the current modbus plus statistics
        be cleared and not returned in the response.
     """
 
-    GetStatistics = 0x0003
-    ClearStatistics = 0x0004
+    GET_STATISTICS = 0x0003
+    CLEAR_STATISTICS = 0x0004
 
     def __str__(self):
        return str(int(self))
@@ -101,34 +101,34 @@ class ModbusPlusOperation(int, enum.Enum):
 class DeviceInformation(int, enum.Enum):
     """Represents what type of device information to read.
 
-    .. attribute:: Basic
+    .. attribute:: BASIC
 
        This is the basic (required) device information to be returned.
        This includes VendorName, ProductCode, and MajorMinorRevision
        code.
 
-    .. attribute:: Regular
+    .. attribute:: REGULAR
 
        In addition to basic data objects, the device provides additional
        and optional identification and description data objects. All of
        the objects of this category are defined in the standard but their
        implementation is optional.
 
-    .. attribute:: Extended
+    .. attribute:: EXTENDED
 
        In addition to regular data objects, the device provides additional
        and optional identification and description private data about the
        physical device itself. All of these data are device dependent.
 
-    .. attribute:: Specific
+    .. attribute:: SPECIFIC
 
        Request to return a single data object.
     """
 
-    Basic = 0x01
-    Regular = 0x02
-    Extended = 0x03
-    Specific = 0x04
+    BASIC = 0x01
+    REGULAR = 0x02
+    EXTENDED = 0x03
+    SPECIFIC = 0x04
 
     def __str__(self):
        return str(int(self))
@@ -137,17 +137,17 @@ class DeviceInformation(int, enum.Enum):
 class MoreData(int, enum.Enum):
     """Represents the more follows condition.
 
-    .. attribute:: Nothing
+    .. attribute:: NOTHING
 
        This indicates that no more objects are going to be returned.
 
-    .. attribute:: KeepReading
+    .. attribute:: KEEP_READING
 
        This indicates that there are more objects to be returned.
     """
 
-    Nothing = 0x00
-    KeepReading = 0xFF
+    NOTHING = 0x00
+    KEEP_READING = 0xFF
 
     def __str__(self):
        return str(int(self))

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -45,6 +45,9 @@ class ModbusStatus(int, enum.Enum):
     SlaveOn = 0xFF
     SlaveOff = 0x00
 
+    def __str__(self):
+       return str(int(self))
+
 
 class Endian(str, enum.Enum):
     """An enumeration representing the various byte endianness.
@@ -70,6 +73,9 @@ class Endian(str, enum.Enum):
     Big = ">"
     Little = "<"
 
+    def __str__(self):
+       return str.__str__(self)
+
 
 class ModbusPlusOperation(int, enum.Enum):
     """Represents the type of modbus plus request.
@@ -87,6 +93,9 @@ class ModbusPlusOperation(int, enum.Enum):
 
     GetStatistics = 0x0003
     ClearStatistics = 0x0004
+
+    def __str__(self):
+       return str(int(self))
 
 
 class DeviceInformation(int, enum.Enum):
@@ -121,6 +130,9 @@ class DeviceInformation(int, enum.Enum):
     Extended = 0x03
     Specific = 0x04
 
+    def __str__(self):
+       return str(int(self))
+
 
 class MoreData(int, enum.Enum):
     """Represents the more follows condition.
@@ -136,3 +148,6 @@ class MoreData(int, enum.Enum):
 
     Nothing = 0x00
     KeepReading = 0xFF
+
+    def __str__(self):
+       return str(int(self))

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -46,8 +46,8 @@ class ModbusStatus(int, enum.Enum):
     SLAVE_OFF = 0x00
 
     def __str__(self):
-       """Override to force int representation for enum members"""
-       return str(int(self))
+        """Override to force int representation for enum members"""
+        return str(int(self))
 
 
 class Endian(str, enum.Enum):
@@ -75,8 +75,8 @@ class Endian(str, enum.Enum):
     LITTLE = "<"
 
     def __str__(self):
-       """Override to force str representation for enum members"""
-       return str.__str__(self)
+        """Override to force str representation for enum members"""
+        return str.__str__(self)
 
 
 class ModbusPlusOperation(int, enum.Enum):
@@ -97,8 +97,8 @@ class ModbusPlusOperation(int, enum.Enum):
     CLEAR_STATISTICS = 0x0004
 
     def __str__(self):
-       """Override to force int representation for enum members"""
-       return str(int(self))
+        """Override to force int representation for enum members"""
+        return str(int(self))
 
 
 class DeviceInformation(int, enum.Enum):
@@ -134,8 +134,8 @@ class DeviceInformation(int, enum.Enum):
     SPECIFIC = 0x04
 
     def __str__(self):
-       """Override to force int representation for enum members"""
-       return str(int(self))
+        """Override to force int representation for enum members"""
+        return str(int(self))
 
 
 class MoreData(int, enum.Enum):
@@ -154,5 +154,5 @@ class MoreData(int, enum.Enum):
     KEEP_READING = 0xFF
 
     def __str__(self):
-       """Override to force int representation for enum members"""
-       return str(int(self))
+        """Override to force int representation for enum members"""
+        return str(int(self))

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -46,6 +46,7 @@ class ModbusStatus(int, enum.Enum):
     SLAVE_OFF = 0x00
 
     def __str__(self):
+       """Override to force int representation for enum members"""
        return str(int(self))
 
 
@@ -74,6 +75,7 @@ class Endian(str, enum.Enum):
     LITTLE = "<"
 
     def __str__(self):
+       """Override to force str representation for enum members"""
        return str.__str__(self)
 
 
@@ -95,6 +97,7 @@ class ModbusPlusOperation(int, enum.Enum):
     CLEAR_STATISTICS = 0x0004
 
     def __str__(self):
+       """Override to force int representation for enum members"""
        return str(int(self))
 
 
@@ -131,6 +134,7 @@ class DeviceInformation(int, enum.Enum):
     SPECIFIC = 0x04
 
     def __str__(self):
+       """Override to force int representation for enum members"""
        return str(int(self))
 
 
@@ -150,4 +154,5 @@ class MoreData(int, enum.Enum):
     KEEP_READING = 0xFF
 
     def __str__(self):
+       """Override to force int representation for enum members"""
        return str(int(self))

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -5,6 +5,7 @@ values for the servers and clients.
 """
 import enum
 
+
 INTERNAL_ERROR = "Pymodbus internal error"
 
 

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -3,11 +3,12 @@
 This is the single location for storing default
 values for the servers and clients.
 """
+import enum
 
 INTERNAL_ERROR = "Pymodbus internal error"
 
 
-class ModbusStatus:  # pylint: disable=too-few-public-methods
+class ModbusStatus(int, enum.Enum):  # pylint: disable=too-few-public-methods
     """These represent various status codes in the modbus protocol.
 
     .. attribute:: Waiting
@@ -44,12 +45,8 @@ class ModbusStatus:  # pylint: disable=too-few-public-methods
     SlaveOn = 0xFF
     SlaveOff = 0x00
 
-    def __init__(self):
-        """Prohibit objects."""
-        raise RuntimeError(INTERNAL_ERROR)
 
-
-class Endian:  # pylint: disable=too-few-public-methods
+class Endian(str, enum.Enum):  # pylint: disable=too-few-public-methods
     """An enumeration representing the various byte endianness.
 
     .. attribute:: Auto
@@ -73,12 +70,8 @@ class Endian:  # pylint: disable=too-few-public-methods
     Big = ">"
     Little = "<"
 
-    def __init__(self):
-        """Prohibit objects."""
-        raise RuntimeError(INTERNAL_ERROR)
 
-
-class ModbusPlusOperation:  # pylint: disable=too-few-public-methods
+class ModbusPlusOperation(int, enum.Enum):  # pylint: disable=too-few-public-methods
     """Represents the type of modbus plus request.
 
     .. attribute:: GetStatistics
@@ -95,12 +88,8 @@ class ModbusPlusOperation:  # pylint: disable=too-few-public-methods
     GetStatistics = 0x0003
     ClearStatistics = 0x0004
 
-    def __init__(self):
-        """Prohibit objects."""
-        raise RuntimeError(INTERNAL_ERROR)
 
-
-class DeviceInformation:  # pylint: disable=too-few-public-methods
+class DeviceInformation(int, enum.Enum):  # pylint: disable=too-few-public-methods
     """Represents what type of device information to read.
 
     .. attribute:: Basic
@@ -132,12 +121,8 @@ class DeviceInformation:  # pylint: disable=too-few-public-methods
     Extended = 0x03
     Specific = 0x04
 
-    def __init__(self):
-        """Prohibit objects."""
-        raise RuntimeError(INTERNAL_ERROR)
 
-
-class MoreData:  # pylint: disable=too-few-public-methods
+class MoreData(int, enum.Enum):  # pylint: disable=too-few-public-methods
     """Represents the more follows condition.
 
     .. attribute:: Nothing
@@ -151,7 +136,3 @@ class MoreData:  # pylint: disable=too-few-public-methods
 
     Nothing = 0x00
     KeepReading = 0xFF
-
-    def __init__(self):
-        """Prohibit objects."""
-        raise RuntimeError(INTERNAL_ERROR)

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -8,7 +8,7 @@ import enum
 INTERNAL_ERROR = "Pymodbus internal error"
 
 
-class ModbusStatus(int, enum.Enum):  # pylint: disable=too-few-public-methods
+class ModbusStatus(int, enum.Enum):
     """These represent various status codes in the modbus protocol.
 
     .. attribute:: Waiting
@@ -46,7 +46,7 @@ class ModbusStatus(int, enum.Enum):  # pylint: disable=too-few-public-methods
     SlaveOff = 0x00
 
 
-class Endian(str, enum.Enum):  # pylint: disable=too-few-public-methods
+class Endian(str, enum.Enum):
     """An enumeration representing the various byte endianness.
 
     .. attribute:: Auto
@@ -71,7 +71,7 @@ class Endian(str, enum.Enum):  # pylint: disable=too-few-public-methods
     Little = "<"
 
 
-class ModbusPlusOperation(int, enum.Enum):  # pylint: disable=too-few-public-methods
+class ModbusPlusOperation(int, enum.Enum):
     """Represents the type of modbus plus request.
 
     .. attribute:: GetStatistics
@@ -89,7 +89,7 @@ class ModbusPlusOperation(int, enum.Enum):  # pylint: disable=too-few-public-met
     ClearStatistics = 0x0004
 
 
-class DeviceInformation(int, enum.Enum):  # pylint: disable=too-few-public-methods
+class DeviceInformation(int, enum.Enum):
     """Represents what type of device information to read.
 
     .. attribute:: Basic
@@ -122,7 +122,7 @@ class DeviceInformation(int, enum.Enum):  # pylint: disable=too-few-public-metho
     Specific = 0x04
 
 
-class MoreData(int, enum.Enum):  # pylint: disable=too-few-public-methods
+class MoreData(int, enum.Enum):
     """Represents the more follows condition.
 
     .. attribute:: Nothing

--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -248,28 +248,28 @@ class DeviceInformationFactory:  # pylint: disable=too-few-public-methods
     """
 
     __lookup = {
-        DeviceInformation.Basic: lambda c, r, i: c.__gets(  # pylint: disable=protected-access
+        DeviceInformation.BASIC: lambda c, r, i: c.__gets(  # pylint: disable=protected-access
             r, list(range(i, 0x03))
         ),
-        DeviceInformation.Regular: lambda c, r, i: c.__gets(  # pylint: disable=protected-access
+        DeviceInformation.REGULAR: lambda c, r, i: c.__gets(  # pylint: disable=protected-access
             r,
             list(range(i, 0x07))
             if c.__get(r, i)[i]  # pylint: disable=protected-access
             else list(range(0, 0x07)),
         ),
-        DeviceInformation.Extended: lambda c, r, i: c.__gets(  # pylint: disable=protected-access
+        DeviceInformation.EXTENDED: lambda c, r, i: c.__gets(  # pylint: disable=protected-access
             r,
             [x for x in range(i, 0x100) if x not in range(0x07, 0x80)]
             if c.__get(r, i)[i]  # pylint: disable=protected-access
             else [x for x in range(0, 0x100) if x not in range(0x07, 0x80)],
         ),
-        DeviceInformation.Specific: lambda c, r, i: c.__get(  # pylint: disable=protected-access
+        DeviceInformation.SPECIFIC: lambda c, r, i: c.__get(  # pylint: disable=protected-access
             r, i
         ),
     }
 
     @classmethod
-    def get(cls, control, read_code=DeviceInformation.Basic, object_id=0x00):
+    def get(cls, control, read_code=DeviceInformation.BASIC, object_id=0x00):
         """Get the requested device data from the system.
 
         :param control: The control block to pull data from

--- a/pymodbus/diag_message.py
+++ b/pymodbus/diag_message.py
@@ -297,9 +297,9 @@ class RestartCommunicationsOptionRequest(DiagnosticStatusRequest):
         """
         DiagnosticStatusRequest.__init__(self, slave=slave, **kwargs)
         if toggle:
-            self.message = [ModbusStatus.On]
+            self.message = [ModbusStatus.ON]
         else:
-            self.message = [ModbusStatus.Off]
+            self.message = [ModbusStatus.OFF]
 
     def execute(self, *_args):
         """Clear event log and restart.
@@ -330,9 +330,9 @@ class RestartCommunicationsOptionResponse(DiagnosticStatusResponse):
         """
         DiagnosticStatusResponse.__init__(self, **kwargs)
         if toggle:
-            self.message = [ModbusStatus.On]
+            self.message = [ModbusStatus.ON]
         else:
-            self.message = [ModbusStatus.Off]
+            self.message = [ModbusStatus.OFF]
 
 
 # ---------------------------------------------------------------------------#
@@ -828,7 +828,7 @@ class GetClearModbusPlusRequest(DiagnosticStatusSimpleRequest):
         Func_code (1 byte) + Sub function code (2 byte) + Operation (2 byte) + Data (108 bytes)
         :return:
         """
-        if self.message == ModbusPlusOperation.GetStatistics:
+        if self.message == ModbusPlusOperation.GET_STATISTICS:
             data = 2 + 108  # byte count(2) + data (54*2)
         else:
             data = 0
@@ -840,7 +840,7 @@ class GetClearModbusPlusRequest(DiagnosticStatusSimpleRequest):
         :returns: The initialized response message
         """
         message = None  # the clear operation does not return info
-        if self.message == ModbusPlusOperation.ClearStatistics:
+        if self.message == ModbusPlusOperation.CLEAR_STATISTICS:
             _MCB.Plus.reset()
             message = self.message
         else:

--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -63,7 +63,7 @@ class ReadDeviceInformationRequest(ModbusRequest):
         :param object_id: The object to read from
         """
         ModbusRequest.__init__(self, **kwargs)
-        self.read_code = read_code or DeviceInformation.Basic
+        self.read_code = read_code or DeviceInformation.BASIC
         self.object_id = object_id
 
     def encode(self):
@@ -141,12 +141,12 @@ class ReadDeviceInformationResponse(ModbusResponse):
         :param information: The requested information request
         """
         ModbusResponse.__init__(self, **kwargs)
-        self.read_code = read_code or DeviceInformation.Basic
+        self.read_code = read_code or DeviceInformation.BASIC
         self.information = information or {}
         self.number_of_objects = 0
         self.conformity = 0x83  # I support everything right now
         self.next_object_id = 0x00
-        self.more_follows = MoreData.Nothing
+        self.more_follows = MoreData.NOTHING
         self.space_left = None
 
     def _encode_object(self, object_id, data):
@@ -181,7 +181,7 @@ class ReadDeviceInformationResponse(ModbusResponse):
                     objects += self._encode_object(object_id, data)
         except _OutOfSpaceException as exc:
             self.next_object_id = exc.oid
-            self.more_follows = MoreData.KeepReading
+            self.more_follows = MoreData.KEEP_READING
 
         packet += struct.pack(
             ">BBB", self.more_follows, self.next_object_id, self.number_of_objects

--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -203,9 +203,9 @@ class GetCommEventCounterResponse(ModbusResponse):
         :returns: The byte encoded message
         """
         if self.status:
-            ready = ModbusStatus.Ready
+            ready = ModbusStatus.READY
         else:
-            ready = ModbusStatus.Waiting
+            ready = ModbusStatus.WAITING
         return struct.pack(">HH", ready, self.count)
 
     def decode(self, data):
@@ -214,7 +214,7 @@ class GetCommEventCounterResponse(ModbusResponse):
         :param data: The packet data to decode
         """
         ready, self.count = struct.unpack(">HH", data)
-        self.status = ready == ModbusStatus.Ready
+        self.status = ready == ModbusStatus.READY
 
     def __str__(self):
         """Build a representation of the response.
@@ -323,9 +323,9 @@ class GetCommEventLogResponse(ModbusResponse):
         :returns: The byte encoded message
         """
         if self.status:
-            ready = ModbusStatus.Ready
+            ready = ModbusStatus.READY
         else:
-            ready = ModbusStatus.Waiting
+            ready = ModbusStatus.WAITING
         packet = struct.pack(">B", 6 + len(self.events))
         packet += struct.pack(">H", ready)
         packet += struct.pack(">HH", self.event_count, self.message_count)
@@ -339,7 +339,7 @@ class GetCommEventLogResponse(ModbusResponse):
         """
         length = int(data[0])
         status = struct.unpack(">H", data[1:3])[0]
-        self.status = status == ModbusStatus.Ready
+        self.status = status == ModbusStatus.READY
         self.event_count = struct.unpack(">H", data[3:5])[0]
         self.message_count = struct.unpack(">H", data[5:7])[0]
 
@@ -453,9 +453,9 @@ class ReportSlaveIdResponse(ModbusResponse):
         :returns: The byte encoded message
         """
         if self.status:
-            status = ModbusStatus.SlaveOn
+            status = ModbusStatus.SLAVE_ON
         else:
-            status = ModbusStatus.SlaveOff
+            status = ModbusStatus.SLAVE_OFF
         length = len(self.identifier) + 1
         packet = struct.pack(">B", length)
         packet += self.identifier  # we assume it is already encoded
@@ -473,7 +473,7 @@ class ReportSlaveIdResponse(ModbusResponse):
         self.byte_count = int(data[0])
         self.identifier = data[1 : self.byte_count + 1]
         status = int(data[-1])
-        self.status = status == ModbusStatus.SlaveOn
+        self.status = status == ModbusStatus.SLAVE_ON
 
     def __str__(self) -> str:
         """Build a representation of the response.

--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -39,7 +39,7 @@ class BinaryPayloadBuilder:
     """
 
     def __init__(
-        self, payload=None, byteorder=Endian.Little, wordorder=Endian.Big, repack=False
+        self, payload=None, byteorder=Endian.LITTLE, wordorder=Endian.BIG, repack=False
     ):
         """Initialize a new instance of the payload builder.
 
@@ -72,7 +72,7 @@ class BinaryPayloadBuilder:
         upperbyte = f"!{wordorder}H"
         payload = unpack(upperbyte, value)
 
-        if self._wordorder == Endian.Little:
+        if self._wordorder == Endian.LITTLE:
             payload = list(reversed(payload))
 
         fstring = self._byteorder + "H"
@@ -262,7 +262,7 @@ class BinaryPayloadDecoder:
         second  = decoder.decode_16bit_uint()
     """
 
-    def __init__(self, payload, byteorder=Endian.Little, wordorder=Endian.Big):
+    def __init__(self, payload, byteorder=Endian.LITTLE, wordorder=Endian.BIG):
         """Initialize a new payload decoder.
 
         :param payload: The payload to decode with
@@ -278,8 +278,8 @@ class BinaryPayloadDecoder:
     def fromRegisters(
         cls,
         registers,
-        byteorder=Endian.Little,
-        wordorder=Endian.Big,
+        byteorder=Endian.LITTLE,
+        wordorder=Endian.BIG,
     ):
         """Initialize a payload decoder.
 
@@ -311,8 +311,8 @@ class BinaryPayloadDecoder:
     def fromCoils(
         cls,
         coils,
-        byteorder=Endian.Little,
-        _wordorder=Endian.Big,
+        byteorder=Endian.LITTLE,
+        _wordorder=Endian.BIG,
     ):
         """Initialize a payload decoder with the result of reading of coils."""
         if isinstance(coils, list):
@@ -340,7 +340,7 @@ class BinaryPayloadDecoder:
         """
         wc_value = WC.get(fstring.lower()) // 2
         handle = unpack(f"!{wc_value}H", handle)
-        if self._wordorder == Endian.Little:
+        if self._wordorder == Endian.LITTLE:
             handle = list(reversed(handle))
 
         # Repack as unsigned Integer

--- a/pymodbus/repl/client/helper.py
+++ b/pymodbus/repl/client/helper.py
@@ -262,10 +262,10 @@ class Result:
             print_formatted_text(HTML("<red>Decoder works only for registers!!</red>"))
             return
         byte_order = (
-            Endian.Little if byte_order.strip().lower() == "little" else Endian.Big
+            Endian.LITTLE if byte_order.strip().lower() == "little" else Endian.BIG
         )
         word_order = (
-            Endian.Little if word_order.strip().lower() == "little" else Endian.Big
+            Endian.LITTLE if word_order.strip().lower() == "little" else Endian.BIG
         )
         decoder = BinaryPayloadDecoder.fromRegisters(
             self.data.get("registers"), byteorder=byte_order, wordorder=word_order

--- a/test/sub_messages/test_diag_messages.py
+++ b/test/sub_messages/test_diag_messages.py
@@ -192,11 +192,11 @@ class TestDataStore:
 
     def test_get_clear_modbus_plus_request_execute(self):
         """Testing diagnostic message execution"""
-        request = GetClearModbusPlusRequest(data=ModbusPlusOperation.ClearStatistics)
+        request = GetClearModbusPlusRequest(data=ModbusPlusOperation.CLEAR_STATISTICS)
         response = request.execute()
-        assert response.message == ModbusPlusOperation.ClearStatistics
+        assert response.message == ModbusPlusOperation.CLEAR_STATISTICS
 
-        request = GetClearModbusPlusRequest(data=ModbusPlusOperation.GetStatistics)
+        request = GetClearModbusPlusRequest(data=ModbusPlusOperation.GET_STATISTICS)
         response = request.execute()
-        resp = [ModbusPlusOperation.GetStatistics]
+        resp = [ModbusPlusOperation.GET_STATISTICS]
         assert response.message == resp + [0x00] * 55

--- a/test/sub_messages/test_mei_messages.py
+++ b/test/sub_messages/test_mei_messages.py
@@ -93,7 +93,6 @@ class TestMeiMessage:
         )
         result = handle.encode()
         assert result == message
-        assert str(handle) == "ReadDeviceInformationResponse(1)"
 
         dataset = {
             0x00: "Company",
@@ -133,7 +132,6 @@ class TestMeiMessage:
         )
         result = handle.encode()
         assert result == message
-        assert str(handle) == "ReadDeviceInformationResponse(1)"
 
     def test_read_device_information_decode(self):
         """Test that the read device information response can decode"""

--- a/test/sub_messages/test_mei_messages.py
+++ b/test/sub_messages/test_mei_messages.py
@@ -93,6 +93,7 @@ class TestMeiMessage:
         )
         result = handle.encode()
         assert result == message
+        assert str(handle) == "ReadDeviceInformationResponse(1)"
 
         dataset = {
             0x00: "Company",
@@ -132,6 +133,7 @@ class TestMeiMessage:
         )
         result = handle.encode()
         assert result == message
+        assert str(handle) == "ReadDeviceInformationResponse(1)"
 
     def test_read_device_information_decode(self):
         """Test that the read device information response can decode"""

--- a/test/sub_messages/test_mei_messages.py
+++ b/test/sub_messages/test_mei_messages.py
@@ -30,7 +30,7 @@ class TestMeiMessage:
 
     def test_read_device_information_request_encode(self):
         """Test basic bit message encoding/decoding"""
-        params = {"read_code": DeviceInformation.Basic, "object_id": 0x00}
+        params = {"read_code": DeviceInformation.BASIC, "object_id": 0x00}
         handle = ReadDeviceInformationRequest(**params)
         result = handle.encode()
         assert result == b"\x0e\x01\x00"
@@ -40,7 +40,7 @@ class TestMeiMessage:
         """Test basic bit message encoding/decoding"""
         handle = ReadDeviceInformationRequest()
         handle.decode(b"\x0e\x01\x00")
-        assert handle.read_code == DeviceInformation.Basic
+        assert handle.read_code == DeviceInformation.BASIC
         assert not handle.object_id
 
     def test_read_device_information_request(self):
@@ -62,7 +62,7 @@ class TestMeiMessage:
             _ = result.information[0x81]
 
         handle = ReadDeviceInformationRequest(
-            read_code=DeviceInformation.Extended, object_id=0x80
+            read_code=DeviceInformation.EXTENDED, object_id=0x80
         )
         result = handle.execute(context)
         assert result.information[0x81] == ["Test", "Repeated"]
@@ -89,7 +89,7 @@ class TestMeiMessage:
             0x02: TEST_VERSION,
         }
         handle = ReadDeviceInformationResponse(
-            read_code=DeviceInformation.Basic, information=dataset
+            read_code=DeviceInformation.BASIC, information=dataset
         )
         result = handle.encode()
         assert result == message
@@ -105,7 +105,7 @@ class TestMeiMessage:
         message += TEST_MESSAGE
         message += b"\x81\x04Test\x81\x08Repeated"
         handle = ReadDeviceInformationResponse(
-            read_code=DeviceInformation.Extended, information=dataset
+            read_code=DeviceInformation.EXTENDED, information=dataset
         )
         result = handle.encode()
         assert result == message
@@ -129,7 +129,7 @@ class TestMeiMessage:
             0x80: longstring,
         }
         handle = ReadDeviceInformationResponse(
-            read_code=DeviceInformation.Basic, information=dataset
+            read_code=DeviceInformation.BASIC, information=dataset
         )
         result = handle.encode()
         assert result == message
@@ -142,7 +142,7 @@ class TestMeiMessage:
         message += b"\x81\x04Test\x81\x08Repeated\x81\x07Another"
         handle = ReadDeviceInformationResponse(read_code=0x00, information=[])
         handle.decode(message)
-        assert handle.read_code == DeviceInformation.Basic
+        assert handle.read_code == DeviceInformation.BASIC
         assert handle.conformity == 0x01
         assert handle.information[0x00] == b"Company"
         assert handle.information[0x01] == b"Product"

--- a/test/sub_messages/test_register_write_messages.py
+++ b/test/sub_messages/test_register_write_messages.py
@@ -38,7 +38,7 @@ class TestWriteRegisterMessages:
         """Initialize the test environment and builds request/result encoding pairs."""
         self.value = 0xABCD
         self.values = [0xA, 0xB, 0xC]
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG)
         builder.add_16bit_uint(0x1234)
         self.payload = builder.build()
         self.write = {

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -61,19 +61,19 @@ class TestDataStore:
         """Test device identification reading"""
         self.control.Identity.update(self.ident)
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Specific, 0x00
+            self.control, DeviceInformation.SPECIFIC, 0x00
         )
         assert result[0x00] == "Bashwork"
 
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Basic, 0x00
+            self.control, DeviceInformation.BASIC, 0x00
         )
         assert result[0x00] == "Bashwork"
         assert result[0x01] == "PTM"
         assert result[0x02] == "1.0"
 
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Regular, 0x00
+            self.control, DeviceInformation.REGULAR, 0x00
         )
         assert result[0x00] == "Bashwork"
         assert result[0x01] == "PTM"
@@ -86,27 +86,27 @@ class TestDataStore:
     def test_device_identification_factory_lookup(self):
         """Test device identification factory lookup."""
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Basic, 0x00
+            self.control, DeviceInformation.BASIC, 0x00
         )
         assert sorted(result.keys()) == [0x00, 0x01, 0x02]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Basic, 0x02
+            self.control, DeviceInformation.BASIC, 0x02
         )
         assert sorted(result.keys()) == [0x02]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Regular, 0x00
+            self.control, DeviceInformation.REGULAR, 0x00
         )
         assert sorted(result.keys()) == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Regular, 0x01
+            self.control, DeviceInformation.REGULAR, 0x01
         )
         assert sorted(result.keys()) == [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Regular, 0x05
+            self.control, DeviceInformation.REGULAR, 0x05
         )
         assert sorted(result.keys()) == [0x05, 0x06]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Extended, 0x00
+            self.control, DeviceInformation.EXTENDED, 0x00
         )
         assert sorted(result.keys()) == [
             0x00,
@@ -121,23 +121,23 @@ class TestDataStore:
             0xFF,
         ]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Extended, 0x02
+            self.control, DeviceInformation.EXTENDED, 0x02
         )
         assert sorted(result.keys()) == [0x02, 0x03, 0x04, 0x05, 0x06, 0x80, 0x82, 0xFF]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Extended, 0x06
+            self.control, DeviceInformation.EXTENDED, 0x06
         )
         assert sorted(result.keys()) == [0x06, 0x80, 0x82, 0xFF]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Extended, 0x80
+            self.control, DeviceInformation.EXTENDED, 0x80
         )
         assert sorted(result.keys()) == [0x80, 0x82, 0xFF]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Extended, 0x82
+            self.control, DeviceInformation.EXTENDED, 0x82
         )
         assert sorted(result.keys()) == [0x82, 0xFF]
         result = DeviceInformationFactory.get(
-            self.control, DeviceInformation.Extended, 0x81
+            self.control, DeviceInformation.EXTENDED, 0x81
         )
         assert sorted(result.keys()) == [
             0x00,

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -45,7 +45,7 @@ class TestPayloadUtility:
 
     def test_little_endian_payload_builder(self):
         """Test basic bit message encoding/decoding"""
-        builder = BinaryPayloadBuilder(byteorder=Endian.Little, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.LITTLE, wordorder=Endian.LITTLE)
         builder.add_8bit_uint(1)
         builder.add_16bit_uint(2)
         builder.add_32bit_uint(3)
@@ -63,7 +63,7 @@ class TestPayloadUtility:
 
     def test_big_endian_payload_builder(self):
         """Test basic bit message encoding/decoding"""
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG)
         builder.add_8bit_uint(1)
         builder.add_16bit_uint(2)
         builder.add_32bit_uint(3)
@@ -172,7 +172,7 @@ class TestPayloadUtility:
         assert _coils1 == coils
 
         builder = BinaryPayloadBuilder(
-            [b"\x12", b"\x34", b"\x56", b"\x78"], byteorder=Endian.Big
+            [b"\x12", b"\x34", b"\x56", b"\x78"], byteorder=Endian.BIG
         )
         assert builder.encode() == b"\x12\x34\x56\x78"
         assert builder.to_registers() == [4660, 22136]
@@ -187,7 +187,7 @@ class TestPayloadUtility:
     def test_little_endian_payload_decoder(self):
         """Test basic bit message encoding/decoding"""
         decoder = BinaryPayloadDecoder(
-            self.little_endian_payload, byteorder=Endian.Little, wordorder=Endian.Little
+            self.little_endian_payload, byteorder=Endian.LITTLE, wordorder=Endian.LITTLE
         )
         assert decoder.decode_8bit_uint() == 1
         assert decoder.decode_16bit_uint() == 2
@@ -205,7 +205,7 @@ class TestPayloadUtility:
 
     def test_big_endian_payload_decoder(self):
         """Test basic bit message encoding/decoding"""
-        decoder = BinaryPayloadDecoder(self.big_endian_payload, byteorder=Endian.Big)
+        decoder = BinaryPayloadDecoder(self.big_endian_payload, byteorder=Endian.BIG)
         assert decoder.decode_8bit_uint() == 1
         assert decoder.decode_16bit_uint() == 2
         assert decoder.decode_32bit_uint() == 3
@@ -231,11 +231,11 @@ class TestPayloadUtility:
     def test_payload_decoder_register_factory(self):
         """Test the payload decoder reset functionality"""
         payload = [1, 2, 3, 4]
-        decoder = BinaryPayloadDecoder.fromRegisters(payload, byteorder=Endian.Little)
+        decoder = BinaryPayloadDecoder.fromRegisters(payload, byteorder=Endian.LITTLE)
         encoded = b"\x00\x01\x00\x02\x00\x03\x00\x04"
         assert encoded == decoder.decode_string(8)
 
-        decoder = BinaryPayloadDecoder.fromRegisters(payload, byteorder=Endian.Big)
+        decoder = BinaryPayloadDecoder.fromRegisters(payload, byteorder=Endian.BIG)
         encoded = b"\x00\x01\x00\x02\x00\x03\x00\x04"
         assert encoded == decoder.decode_string(8)
         with pytest.raises(ParameterException):
@@ -244,11 +244,11 @@ class TestPayloadUtility:
     def test_payload_decoder_coil_factory(self):
         """Test the payload decoder reset functionality"""
         payload = [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1]
-        decoder = BinaryPayloadDecoder.fromCoils(payload, byteorder=Endian.Little)
+        decoder = BinaryPayloadDecoder.fromCoils(payload, byteorder=Endian.LITTLE)
         encoded = b"\x88\x11"
         assert encoded == decoder.decode_string(2)
 
-        decoder = BinaryPayloadDecoder.fromCoils(payload, byteorder=Endian.Big)
+        decoder = BinaryPayloadDecoder.fromCoils(payload, byteorder=Endian.BIG)
         encoded = b"\x88\x11"
         assert encoded == decoder.decode_string(2)
 


### PR DESCRIPTION
Closes #1741, went a bit further and converted all static classes to enums. This should provide type safety while maintaining compatibility with raw ints and strings.

### Changelog:
- `ModbusStatus` > inherits from `int` and `enum.Enum`
- `Endian` > inherits from `str` and `enum.Enum`
- `ModbusPlusOperation` > inherits from `int` and `enum.Enum`
- `DeviceInformation` > inherits from `int` and `enum.Enum`
- `MoreData` > inherits from `int` and `enum.Enum`