### PR TITLE
Local Echo Broadcast with Async Clients

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -391,7 +391,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
         """
         Log.debug("send: {}", data, ":hex")
         if self.comm_params.handle_local_echo:
-            self.sent_buffer = data
+            self.sent_buffer += data
         if self.comm_params.comm_type == CommType.UDP:
             if addr:
                 self.transport.sendto(data, addr=addr)  # type: ignore[attr-defined]

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -312,10 +312,23 @@ class ModbusProtocol(asyncio.BaseProtocol):
     def datagram_received(self, data: bytes, addr: tuple):
         """Receive datagram (UDP connections)."""
         if self.comm_params.handle_local_echo and self.sent_buffer:
-            Log.debug("recv skipping (local_echo): {} addr={}", data, ":hex", addr)
-            if self.sent_buffer in data:
-                data, self.sent_buffer = data.replace(self.sent_buffer, b"", 1), b""
+            if data.startswith(self.sent_buffer):
+                Log.debug(
+                    "recv skipping (local_echo): {} addr={}",
+                    self.sent_buffer,
+                    ":hex",
+                    addr,
+                )
+                data = data[len(self.sent_buffer) :]
+                self.sent_buffer = b""
+            elif self.sent_buffer.startswith(data):
+                Log.debug(
+                    "recv skipping (partial local_echo): {} addr={}", data, ":hex", addr
+                )
+                self.sent_buffer = self.sent_buffer[len(data) :]
+                return
             else:
+                Log.debug("did not receive local echo: {} addr={}", data, ":hex", addr)
                 self.sent_buffer = b""
             if not data:
                 return

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -155,6 +155,12 @@ class TestBasicModbusProtocol:
         client.datagram_received(test_data, ("127.0.0.1", 502))
         assert client.recv_buffer == test_data + test_data
         assert not client.sent_buffer
+        client.recv_buffer = b""
+        client.transport_send(b"partial")
+        client.datagram_received(b"par", ("127.0.0.1", 502))
+        client.datagram_received(b"tialresponse", ("127.0.0.1", 502))
+        assert client.recv_buffer == b"response"
+        assert not client.sent_buffer
 
     async def test_transport_close(self, server, dummy_protocol):
         """Test transport_close()."""

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -162,6 +162,31 @@ class TestBasicModbusProtocol:
         assert client.recv_buffer == b"response"
         assert not client.sent_buffer
 
+    async def test_broadcast_local_echo(self, client):
+        """Test transport_send() with broadcast and echo packets"""
+        client.comm_params.handle_local_echo = True
+        client.transport = mock.Mock()
+        client.recv_buffer = b""
+        client.transport_send(b"broadcast")
+        client.transport_send(b"message")
+        client.datagram_received(b"broadcast", ("127.0.0.1", 502))
+        client.datagram_received(b"messageresponse", ("127.0.0.1", 502))
+        assert client.recv_buffer == b"response"
+        assert not client.sent_buffer
+        client.recv_buffer = b""
+        client.transport_send(b"broadcast")
+        client.transport_send(b"message")
+        client.datagram_received(b"broadcastmessageresponse", ("127.0.0.1", 502))
+        assert client.recv_buffer == b"response"
+        assert not client.sent_buffer
+        client.recv_buffer = b""
+        client.transport_send(b"broadcast")
+        client.transport_send(b"message")
+        client.datagram_received(b"broadcastmessa", ("127.0.0.1", 502))
+        client.datagram_received(b"geresponse", ("127.0.0.1", 502))
+        assert client.recv_buffer == b"response"
+        assert not client.sent_buffer
+
     async def test_transport_close(self, server, dummy_protocol):
         """Test transport_close()."""
         dummy_protocol.abort = mock.MagicMock()


### PR DESCRIPTION
Using broadcast messages with local echo almost works with asynchronous clients but it is racy.

If the echo for a broadcast comes in after the next transaction has been sent, then the sent_buffer gets overridden and the echo of the broadcast is forgotten. This corrupts the data stream.

This PR has a couple commits to make it more robust: for one allow the echo to be split along multiple packets, then ensure a broadcast waits for the echo before returning from async_execute.

The last two commits add tests for both these issues.
