### PR TITLE
transport: Don't raise a RunTimeError in ModbusProtocol.error_received()

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -357,7 +357,6 @@ class ModbusProtocol(asyncio.BaseProtocol):
     def error_received(self, exc):
         """Get error detected in UDP."""
         Log.debug("-> error_received {}", exc)
-        raise RuntimeError(str(exc))
 
     # --------- #
     # callbacks #

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -111,11 +111,6 @@ class TestBasicModbusProtocol:
         """Test eof_received."""
         client.eof_received()
 
-    async def test_error_received(self, client):
-        """Test error_received."""
-        with pytest.raises(RuntimeError):
-            client.error_received(Exception("test call"))
-
     async def test_callbacks(self, use_clc):
         """Test callbacks."""
         client = ModbusProtocol(use_clc, False)


### PR DESCRIPTION
When using the UDP asynchronous client and the server doesn't respond (for example it may not be running), an exception may be thrown by sock.recvfrom(). When this happens the exception handler, in the asyncio layer will call ModbusProtocol.error_received() which then raises a RuntimeError.

This causes a lot of noise on the command line and results in a RuntimeError being thrown which can't easily be caught by client code, nor would it typically be expecting a RuntimeError:

```
  Exception in callback _SelectorDatagramTransport._read_ready()
    handle: <Handle _SelectorDatagramTransport._read_ready()>
    Traceback (most recent call last):
        File "/usr/lib/python3.9/asyncio/selector_events.py", line 1019, in _read_ready
            data, addr = self._sock.recvfrom(self.max_size)
  ConnectionRefusedError: [Errno 111] Connection refused

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/usr/lib/python3.9/asyncio/events.py", line 80, in _run
      self._context.run(self._callback, *self._args)
    File "/usr/lib/python3.9/asyncio/selector_events.py", line 1023, in _read_ready
      self._protocol.error_received(exc)
    File "/home/usgm/src/pymodbus/pymodbus/transport/transport.py", line 360, in error_received
      raise RuntimeError(str(exc))
  RuntimeError: [Errno 111] Connection refused
```

This is less than helpful. If the raise of the RuntimeError is removed, then the receive will fail and a ModbusIOException will be raised with a "No response received" message (after a timeout) which can be handled in the normal way by user code.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
