### PR TITLE
Remove references to ModbusSerialServer.start (#1759)

### DIFF
--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -237,18 +237,10 @@ class ReactiveServer:
         """
         try:
             if hasattr(asyncio, "create_task"):
-                if isinstance(self._modbus_server, ModbusSerialServer):
-                    app["modbus_serial_server"] = asyncio.create_task(
-                        self._modbus_server.start()
-                    )
                 app["modbus_server"] = asyncio.create_task(
                     self._modbus_server.serve_forever()
                 )
             else:
-                if isinstance(self._modbus_server, ModbusSerialServer):
-                    app["modbus_serial_server"] = asyncio.ensure_future(
-                        self._modbus_server.start()
-                    )
                 app["modbus_server"] = asyncio.ensure_future(
                     self._modbus_server.serve_forever()
                 )


### PR DESCRIPTION
- the start method was empty and was completely removed in commit 3d71883da1c71b4b31d
- fixes Issue #1759 
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
