### PR TITLE
Update ruff to 0.0.287

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 # run ruff with --fix before black
--   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.277'
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.0.287'
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -203,7 +203,7 @@ class ReadDeviceInformationResponse(ModbusResponse):
         while count < len(data):
             object_id, object_length = struct.unpack(">BB", data[count : count + 2])
             count += object_length + 2
-            if object_id not in self.information.keys():
+            if object_id not in self.information:
                 self.information[object_id] = data[count - object_length : count]
             elif isinstance(self.information[object_id], list):
                 self.information[object_id].append(data[count - object_length : count])

--- a/pymodbus/repl/client/helper.py
+++ b/pymodbus/repl/client/helper.py
@@ -147,9 +147,7 @@ class Command:
     def __str__(self):
         """Return string representation."""
         if self.doc:
-            return "Command {:>50}{:<20}".format(  # pylint: disable=consider-using-f-string
-                self.name, self.doc
-            )
+            return f"Command {self.name:>50}{self.doc:<20}"
         return f"Command {self.name}"
 
 

--- a/pymodbus/repl/client/main.py
+++ b/pymodbus/repl/client/main.py
@@ -191,9 +191,9 @@ class CLI:  # pylint: disable=too-few-public-methods
             if cmd != "help":
                 print_formatted_text(
                     HTML(
-                        "<skyblue>{:45s}</skyblue>"  # pylint: disable=consider-using-f-string
-                        "<seagreen>{:100s}"
-                        "</seagreen>".format(cmd, obj.help_text)
+                        f"<skyblue>{cmd:45s}</skyblue>"
+                        f"<seagreen>{obj.help_text:100s}"
+                        "</seagreen>"
                     )
                 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ pytest-asyncio>=0.20.3
 pytest-cov>=4.1.0
 pytest-timeout>=2.1.0
 pytest-xdist>=3.3.1
-ruff>=0.0.277
+ruff>=0.0.287
 types-Pygments
 types-pyserial
 twine>=4.0.2

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,7 @@ ignore = [
     "S104",  # binding on all interfaces
     "RUF012",  # typing.ClassVar
     "RUF013",  # implicit Optional
+    "RUF015"  # next(iter(list)) instead of list[0]
 ]
 line-length = 120
 select = [


### PR DESCRIPTION
The new ruff version caught a few simplications.

However, the new rule [`RUF015`](https://beta.ruff.rs/docs/rules/unnecessary-iterable-allocation-for-first-element/) is obnoxious, so I disabled it.

Also, the repo has been [renamed](https://astral.sh/blog/announcing-astral-the-company-behind-ruff).
