### PR TITLE
Allow repr(ModbusException) to return complete information

### DIFF
--- a/pymodbus/exceptions.py
+++ b/pymodbus/exceptions.py
@@ -24,7 +24,7 @@ class ModbusException(Exception):
         :param string: The message to append to the error
         """
         self.string = string
-        super().__init__()
+        super().__init__(string)
 
     def __str__(self):
         """Return string representation."""


### PR DESCRIPTION
The reason behind this is to somewhat simplify logging and reporting exceptions.

For built-in exceptions, str(ex) includes only 'detail' part of an exception, for example for KeyError it is the name of the key. But repr(ex) includes the type of an exception, in the form of 'KeyError("missing_key")'. So using repr(ex) is more useful in logging.

But for ModbusException() right now repr(ex) only returns type of the exception, since base constructor is called with no arguments.