### PR TITLE
fixes access to asyncio loop via loop property of SerialTransport

### DIFF
--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -16,7 +16,7 @@ class SerialTransport(asyncio.Transport):
         """Initialize."""
         super().__init__()
         self.async_loop = loop
-        self._protocol:asyncio.BaseProtocol = protocol
+        self._protocol: asyncio.BaseProtocol = protocol
         self.sync_serial = serial.serial_for_url(*args, **kwargs)
         self._closing = False
         self._write_buffer = []

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -37,7 +37,7 @@ class SerialTransport(asyncio.Transport):
     @property
     def loop(self):
         """Return asyncio event loop."""
-        return self.async_loop._loop
+        return self.async_loop
 
     def get_protocol(self) -> asyncio.BaseProtocol:
         """Return protocol"""

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -37,7 +37,7 @@ class SerialTransport(asyncio.Transport):
     @property
     def loop(self):
         """Return asyncio event loop."""
-        return self._protocol._loop
+        return self.async_loop._loop
 
     def get_protocol(self) -> asyncio.BaseProtocol:
         """Return protocol"""
@@ -95,7 +95,7 @@ class SerialTransport(asyncio.Transport):
         try:
             data = self.sync_serial.read(1024)
         except serial.SerialException as exc:
-            self._protocol._loop.call_soon(self._call_connection_lost, exc)
+            self.async_loop.call_soon(self._call_connection_lost, exc)
             self.close()
         else:
             if data:
@@ -130,7 +130,7 @@ class SerialTransport(asyncio.Transport):
         except (BlockingIOError, InterruptedError):
             self._write_buffer.append(data)
         except serial.SerialException as exc:
-            self._protocol._loop.call_soon(self._call_connection_lost, exc)
+            self.async_loop.call_soon(self._call_connection_lost, exc)
             self.abort()
         else:
             if nlen == len(data):

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -16,7 +16,7 @@ class SerialTransport(asyncio.Transport):
         """Initialize."""
         super().__init__()
         self.async_loop = loop
-        self._protocol = protocol
+        self._protocol:asyncio.BaseProtocol = protocol
         self.sync_serial = serial.serial_for_url(*args, **kwargs)
         self._closing = False
         self._write_buffer = []
@@ -37,7 +37,7 @@ class SerialTransport(asyncio.Transport):
     @property
     def loop(self):
         """Return asyncio event loop."""
-        return self._protocol.loop
+        return self._protocol._loop
 
     def get_protocol(self) -> asyncio.BaseProtocol:
         """Return protocol"""
@@ -95,7 +95,7 @@ class SerialTransport(asyncio.Transport):
         try:
             data = self.sync_serial.read(1024)
         except serial.SerialException as exc:
-            self._protocol.loop.call_soon(self._call_connection_lost, exc)
+            self._protocol._loop.call_soon(self._call_connection_lost, exc)
             self.close()
         else:
             if data:
@@ -130,7 +130,7 @@ class SerialTransport(asyncio.Transport):
         except (BlockingIOError, InterruptedError):
             self._write_buffer.append(data)
         except serial.SerialException as exc:
-            self._protocol.loop.call_soon(self._call_connection_lost, exc)
+            self._protocol._loop.call_soon(self._call_connection_lost, exc)
             self.abort()
         else:
             if nlen == len(data):

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -292,17 +292,6 @@ class TestBasicSerial:
         """Test null modem init"""
         SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy")
 
-    async def test_loop(self):
-        """Test access to asyncio event loop of the underlying protocol"""
-        loop = asyncio.get_event_loop()
-        reader = asyncio.StreamReader(loop=loop)
-        comm = SerialTransport(loop, asyncio.StreamReaderProtocol(reader, loop=loop))
-        assert isinstance(comm.loop, asyncio.AbstractEventLoop)
-        protocol = comm.get_protocol()
-        assert isinstance(protocol, asyncio.protocols.BaseProtocol)
-        assert not hasattr(protocol, "loop")
-        assert hasattr(protocol, "_loop")
-
     async def test_abstract_methods(self):
         """Test asyncio abstract methods."""
         comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy")

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -302,7 +302,6 @@ class TestBasicSerial:
         assert isinstance(protocol, asyncio.protocols.BaseProtocol)
         assert not hasattr(protocol, 'loop')
         assert hasattr(protocol, '_loop')
-        assert isinstance(protocol._loop, asyncio.selector_events.BaseSelectorEventLoop)
 
     async def test_abstract_methods(self):
         """Test asyncio abstract methods."""

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -297,7 +297,7 @@ class TestBasicSerial:
         loop = asyncio.get_event_loop()
         reader = asyncio.StreamReader(loop=loop)
         comm = SerialTransport(loop, asyncio.StreamReaderProtocol(reader, loop=loop))
-        assert isinstance(comm.loop, asyncio.selector_events.BaseSelectorEventLoop)
+        assert isinstance(comm.loop, asyncio.AbstractEventLoop)
         protocol = comm.get_protocol()
         assert isinstance(protocol, asyncio.protocols.BaseProtocol)
         assert not hasattr(protocol, "loop")

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -291,6 +291,18 @@ class TestBasicSerial:
     async def test_init(self):
         """Test null modem init"""
         SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy")
+    
+    async def test_loop(self):
+        """Test access to asyncio event loop of the underlying protocol"""
+        loop = asyncio.get_event_loop()
+        reader = asyncio.StreamReader(loop=loop)
+        comm = SerialTransport(loop, asyncio.StreamReaderProtocol(reader, loop=loop))
+        assert isinstance(comm.loop, asyncio.selector_events.BaseSelectorEventLoop)
+        protocol = comm.get_protocol()
+        assert isinstance(protocol, asyncio.protocols.BaseProtocol)
+        assert not hasattr(protocol, 'loop')
+        assert hasattr(protocol, '_loop')
+        assert isinstance(protocol._loop, asyncio.selector_events.BaseSelectorEventLoop)
 
     async def test_abstract_methods(self):
         """Test asyncio abstract methods."""

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -291,7 +291,7 @@ class TestBasicSerial:
     async def test_init(self):
         """Test null modem init"""
         SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy")
-    
+
     async def test_loop(self):
         """Test access to asyncio event loop of the underlying protocol"""
         loop = asyncio.get_event_loop()
@@ -300,8 +300,8 @@ class TestBasicSerial:
         assert isinstance(comm.loop, asyncio.selector_events.BaseSelectorEventLoop)
         protocol = comm.get_protocol()
         assert isinstance(protocol, asyncio.protocols.BaseProtocol)
-        assert not hasattr(protocol, 'loop')
-        assert hasattr(protocol, '_loop')
+        assert not hasattr(protocol, "loop")
+        assert hasattr(protocol, "_loop")
 
     async def test_abstract_methods(self):
         """Test asyncio abstract methods."""


### PR DESCRIPTION
The property loop of SerialTransport (`transport_seria.py`) is defined as

```
    @property
    def loop(self):
        """Return asyncio event loop."""
        return self._protocol.loop
```

with `self._protocol` of type `asyncio.protocols.BaseProtocol` which does not feature an attribute `loop`, but instead holds the asyncio event loop in the attribute `_loop` thus this definition should read correctly

```
    @property
    def loop(self):
        """Return asyncio event loop."""
        return self._protocol._loop
```

There are two further occurrences of accessing the event loop of the `_protocol` instances via the attribute `loop` instead of `_loop` (in `_read_ready` and `_write_ready`). This PR fixes those and adds a test that demonstrates the issue.