### PR TITLE
eliminates implicit Optional

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -22,7 +22,7 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
 
     **Parameters common to all clients**:
 
-    :param framer: (optional) Modbus Framer class.
+    :param framer: Modbus Framer class.
     :param timeout: (optional) Timeout for a request, in seconds.
     :param retries: (optional) Max number of retries per request.
     :param retry_on_empty: (optional) Retry on empty response.
@@ -66,7 +66,7 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        framer: type[ModbusFramer] | None = None,
+        framer: type[ModbusFramer],
         timeout: float = 3,
         retries: int = 3,
         retry_on_empty: bool = False,
@@ -118,7 +118,7 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
         self.slaves: list[int] = []
 
         # Common variables.
-        self.framer = cast(type[ModbusFramer], framer)(ClientDecoder(), self)
+        self.framer = framer(ClientDecoder(), self)
         self.transaction = DictTransactionManager(
             self, retries=retries, retry_on_empty=retry_on_empty, **kwargs
         )

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -502,7 +502,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     # code 0x2B sub 0x0D: CANopen General Reference Request and Response, NOT IMPLEMENTED
 
     def read_device_information(
-        self, read_code: int = None, object_id: int = 0x00, **kwargs: Any
+        self, read_code: Union[int, None] = None, object_id: int = 0x00, **kwargs: Any
     ) -> ModbusResponse:
         """Read FIFO queue (code 0x2B sub 0x0E).
 

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -141,6 +141,7 @@ class ModbusSerialClient(ModbusBaseClient):
 
         self.last_frame_end = None
 
+        assert isinstance(self.comm_params.baudrate, int)
         self._t0 = float(1 + bytesize + stopbits) / self.comm_params.baudrate
 
         # Check every 4 bytes / 2 registers if the reading is ready

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -3,7 +3,7 @@ import asyncio
 import select
 import socket
 import time
-from typing import Any, Tuple, Type
+from typing import Any, Optional, Tuple, Type
 
 from pymodbus.client.base import ModbusBaseClient
 from pymodbus.exceptions import ConnectionException
@@ -40,7 +40,7 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
         host: str,
         port: int = 502,
         framer: Type[ModbusFramer] = ModbusSocketFramer,
-        source_address: Tuple[str, int] = None,
+        source_address: Optional[Tuple[str, int]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus TCP Client."""
@@ -102,7 +102,7 @@ class ModbusTcpClient(ModbusBaseClient):
         host: str,
         port: int = 502,
         framer: Type[ModbusFramer] = ModbusSocketFramer,
-        source_address: Tuple[str, int] = None,
+        source_address: Optional[Tuple[str, int]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Modbus TCP Client."""

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -1,7 +1,7 @@
 """Modbus client async TLS communication."""
 import socket
 import ssl
-from typing import Any, Type
+from typing import Any, Optional, Type
 
 from pymodbus.client.tcp import AsyncModbusTcpClient, ModbusTcpClient
 from pymodbus.framer import ModbusFramer
@@ -44,11 +44,11 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
         host: str,
         port: int = 802,
         framer: Type[ModbusFramer] = ModbusTlsFramer,
-        sslctx: ssl.SSLContext = None,
-        certfile: str = None,
-        keyfile: str = None,
-        password: str = None,
-        server_hostname: str = None,
+        sslctx: Optional[ssl.SSLContext] = None,
+        certfile: Optional[str] = None,
+        keyfile: Optional[str] = None,
+        password: Optional[str] = None,
+        server_hostname: Optional[str] = None,
         **kwargs: Any,
     ):
         """Initialize Asyncio Modbus TLS Client."""
@@ -113,11 +113,11 @@ class ModbusTlsClient(ModbusTcpClient):
         host: str,
         port: int = 802,
         framer: Type[ModbusFramer] = ModbusTlsFramer,
-        sslctx: ssl.SSLContext = None,
-        certfile: str = None,
-        keyfile: str = None,
-        password: str = None,
-        server_hostname: str = None,
+        sslctx: Optional[ssl.SSLContext] = None,
+        certfile: Optional[str] = None,
+        keyfile: Optional[str] = None,
+        password: Optional[str] = None,
+        server_hostname: Optional[str] = None,
         **kwargs: Any,
     ):
         """Initialize Modbus TLS Client."""

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -1,7 +1,7 @@
 """Modbus client async UDP communication."""
 import asyncio
 import socket
-from typing import Any, Tuple, Type
+from typing import Any, Optional, Tuple, Type
 
 from pymodbus.client.base import ModbusBaseClient
 from pymodbus.exceptions import ConnectionException
@@ -45,7 +45,7 @@ class AsyncModbusUdpClient(
         host: str,
         port: int = 502,
         framer: Type[ModbusFramer] = ModbusSocketFramer,
-        source_address: Tuple[str, int] = None,
+        source_address: Optional[Tuple[str, int]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus UDP Client."""
@@ -106,7 +106,7 @@ class ModbusUdpClient(ModbusBaseClient):
         host: str,
         port: int = 502,
         framer: Type[ModbusFramer] = ModbusSocketFramer,
-        source_address: Tuple[str, int] = None,
+        source_address: Optional[Tuple[str, int]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Modbus UDP Client."""

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -3,7 +3,7 @@ import dataclasses
 import random
 import struct
 from datetime import datetime
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 
 WORD_SIZE = 16
@@ -30,7 +30,7 @@ class Cell:
     access: bool = False
     value: int = 0
     action: int = 0
-    action_kwargs: Dict[str, Any] = None
+    action_kwargs: Optional[Dict[str, Any]] = None
     count_read: int = 0
     count_write: int = 0
 

--- a/pymodbus/logging.py
+++ b/pymodbus/logging.py
@@ -17,7 +17,7 @@ logging.getLogger("pymodbus_internal").addHandler(__null())
 
 
 def pymodbus_apply_logging_config(
-    level: Union[str, int] = logging.DEBUG, log_file_name: str = None
+    level: Union[str, int] = logging.DEBUG, log_file_name: Union[str, None] = None
 ):
     """Apply basic logging configuration used by default by Pymodbus maintainers.
 

--- a/pymodbus/repl/client/helper.py
+++ b/pymodbus/repl/client/helper.py
@@ -229,7 +229,7 @@ def get_commands(client):
 class Result:
     """Represent result command."""
 
-    function_code: int = None
+    function_code: Union[int, None] = None
     data: Union[Dict[int, Any], Any] = None
 
     def __init__(self, result):

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -5,7 +5,7 @@ import os
 import time
 import traceback
 from contextlib import suppress
-from typing import Union
+from typing import Optional, Union
 
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.device import ModbusControlBlock, ModbusDeviceIdentification
@@ -84,7 +84,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
                 traceback.format_exc(),
             )
 
-    def callback_disconnected(self, call_exc: Exception) -> None:
+    def callback_disconnected(self, call_exc: Optional[Exception]) -> None:
         """Call when connection is lost."""
         try:
             if self.handler_task:
@@ -239,7 +239,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
             result = None
         return result
 
-    def callback_data(self, data: bytes, addr: tuple = None) -> int:
+    def callback_data(self, data: bytes, addr: Union[tuple, None] = None) -> int:
         """Handle received data."""
         if addr:
             self.receive_queue.put_nowait((data, addr))
@@ -563,7 +563,9 @@ class _serverList:
     :meta private:
     """
 
-    active_server: Union[ModbusTcpServer, ModbusUdpServer, ModbusSerialServer] = None
+    active_server: Union[
+        ModbusTcpServer, ModbusUdpServer, ModbusSerialServer, None
+    ] = None
 
     def __init__(self, server):
         """Register new server."""

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -97,10 +97,10 @@ class ReactiveModbusSlaveContext(ModbusSlaveContext):
 
     def __init__(
         self,
-        discrete_inputs: BaseModbusDataBlock = None,
-        coils: BaseModbusDataBlock = None,
-        input_registers: BaseModbusDataBlock = None,
-        holding_registers: BaseModbusDataBlock = None,
+        discrete_inputs: BaseModbusDataBlock | None = None,
+        coils: BaseModbusDataBlock | None = None,
+        input_registers: BaseModbusDataBlock | None = None,
+        holding_registers: BaseModbusDataBlock | None = None,
         zero_mode: bool = False,
         randomize: int = 0,
         change_rate: int = 0,

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -5,13 +5,13 @@ import importlib
 import json
 import os
 from time import time
-from typing import List
+from typing import Any, List, Optional, cast
 
 
 try:
     from aiohttp import web
 except ImportError:
-    web = None
+    web = cast(Any, None)
 
 import contextlib
 
@@ -124,7 +124,7 @@ class ModbusSimulatorServer:
         http_port: int = 8080,
         log_file: str = "server.log",
         json_file: str = "setup.json",
-        custom_actions_module: str = None,
+        custom_actions_module: Optional[str] = None,
     ):
         """Initialize http interface."""
         if not web:
@@ -157,7 +157,7 @@ class ModbusSimulatorServer:
             del server["port"]
         device = setup["device_list"][modbus_device]
         self.datastore_context = ModbusSimulatorContext(
-            device, custom_actions_dict or None
+            device, custom_actions_dict or {}
         )
         datastore = ModbusServerContext(slaves=self.datastore_context, single=True)
         comm = comm_class[server.pop("comm")]

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -14,13 +14,13 @@ class SerialTransport(asyncio.Transport):
 
     force_poll: bool = False
 
-    def __init__(self, loop, protocol, *args, **kwargs):
+    def __init__(self, loop, protocol, *args, **kwargs) -> None:
         """Initialize."""
         super().__init__()
         self.async_loop = loop
         self._protocol: asyncio.BaseProtocol = protocol
         self.sync_serial = serial.serial_for_url(*args, **kwargs)
-        self._write_buffer = []
+        self._write_buffer: list[bytes] = []
         self.poll_task = None
         self._poll_wait_time = 0.0005
         self.sync_serial.timeout = 0
@@ -53,13 +53,13 @@ class SerialTransport(asyncio.Transport):
         with contextlib.suppress(Exception):
             self._protocol.connection_lost(exc)
 
-    def write(self, data):
+    def write(self, data) -> None:
         """Write some data to the transport."""
         self._write_buffer.append(data)
         if not self.poll_task:
             self.async_loop.add_writer(self.sync_serial.fileno(), self._write_ready)
 
-    def flush(self):
+    def flush(self) -> None:
         """Clear output buffer and stops any more data being written"""
         if not self.poll_task:
             self.async_loop.remove_writer(self.sync_serial.fileno())
@@ -159,7 +159,9 @@ class SerialTransport(asyncio.Transport):
             pass
 
 
-async def create_serial_connection(loop, protocol_factory, *args, **kwargs):
+async def create_serial_connection(
+    loop, protocol_factory, *args, **kwargs
+) -> tuple[asyncio.Transport, asyncio.BaseProtocol]:
     """Create a connection to a new serial port instance."""
     protocol = protocol_factory()
     transport = SerialTransport(loop, protocol, *args, **kwargs)

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -2,7 +2,7 @@
 import asyncio
 import contextlib
 import os
-from typing import Tuple, List
+from typing import List, Tuple
 
 
 with contextlib.suppress(ImportError):

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -2,7 +2,7 @@
 import asyncio
 import contextlib
 import os
-from typing import Tuple
+from typing import Tuple, List
 
 
 with contextlib.suppress(ImportError):
@@ -20,7 +20,7 @@ class SerialTransport(asyncio.Transport):
         self.async_loop = loop
         self._protocol: asyncio.BaseProtocol = protocol
         self.sync_serial = serial.serial_for_url(*args, **kwargs)
-        self._write_buffer: list[bytes] = []
+        self._write_buffer: List[bytes] = []
         self.poll_task = None
         self._poll_wait_time = 0.0005
         self.sync_serial.timeout = 0
@@ -161,7 +161,7 @@ class SerialTransport(asyncio.Transport):
 
 async def create_serial_connection(
     loop, protocol_factory, *args, **kwargs
-) -> tuple[asyncio.Transport, asyncio.BaseProtocol]:
+) -> Tuple[asyncio.Transport, asyncio.BaseProtocol]:
     """Create a connection to a new serial port instance."""
     protocol = protocol_factory()
     transport = SerialTransport(loop, protocol, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ version = {attr = "pymodbus.__version__"}
 [tool.pylint.main]
 init-hook='import sys; sys.path.append("examples")'
 ignore-paths = [
-    "pymodbus/transport/serial_asyncio",
     "doc"
 ]
 ignore-patterns = '^\.#'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ overgeneral-exceptions = "builtins.Exception"
 bad-functions = "map,input"
 
 [tool.mypy]
-strict_optional = false
+strict_optional = true
 exclude = "pymodbus/client/base.py"
 show_error_codes = true
 local_partial_types = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ bad-functions = "map,input"
 
 [tool.mypy]
 strict_optional = true
-exclude = "pymodbus/client/base.py"
+#exclude = "pymodbus/client/base.py"
 show_error_codes = true
 local_partial_types = true
 strict_equality = true


### PR DESCRIPTION
PEP 484 prohibits implicit Optional for good reasons. See for [Any advantages of enabled mypy `strict_optional?](https://stackoverflow.com/questions/62211237/any-advantages-of-enabled-mypy-strict-optional) some arguments.

Current mypy configuration ignores implicit Optional

```
[tool.mypy]
strict_optional = false
```

with `strict_optional` set mypy raises 87 errors in 13 files. This commit resolves all of them.

While this is mostly about adding/changing type annotations I had to apply few code changes too as well as one (minor) API change (see the marks below). Here are non-trivial issues I encountered. Maybe you find better resolutions than the ones proposed by this PR for those.


1) Subclass should follow the type declarations of its superclass


```python
base.py:ModbusBaseClient
  self.last_frame_end: float = 0

serial.py:ModbusSerialClient(ModbusBaseClient)
  self.last_frame_end = None
```

resolved by widening

```python
self.last_frame_end: float | None = 0
```


2) simple type violation

```python
base.py:ModbusBaseClient(ModbusClientMixin, ModbusProtocol)
   def callback_disconnected(self, _reason: Exception) -> None

transport.py:ModbusProtocol(asyncio.BaseProtocol):
  def callback_disconnected(self, exc: Exception) -> None
  ..
  def transport_close(self, intern: bool = False, reconnect: bool = False) -> None:
    ..
      value.callback_disconnected(None)
```

resolved by widening

```
  def callback_disconnected(self, _reason: Exception | None)
```


3) Maybe frame should not be an optional argument but mandatory? [API CHANGE]

```python
base.py:ModbusBaseClient(ModbusClientMixin, ModbusProtocol)

    def __init__(  # pylint: disable=too-many-arguments
           self, framer: type[ModbusFramer] | None = None,

        self.framer = framer(ClientDecoder(), self)
```

resolved by a cast

```python
        self.framer = cast(type[ModbusFramer], framer)(ClientDecoder(), self)
```

which make pylint to fail under Python 3.8:
```
pymodbus/client/base.py:121:27: E1136: Value 'type' is unsubscriptable (unsubscriptable-object)
```

so I removed the cast and made the framer argument mandatory

```python
    def __init__(  # pylint: disable=too-many-arguments
           self, framer: type[ModbusFramer],
```

This is an API change!


4) self.last_frame_end can be None?

base.py:ModbusBaseClient(ModbusClientMixin, ModbusProtocol)

```python
    def __init__(  # pylint: disable=too-many-arguments
       ...
       self.last_frame_end: float = 0
       ...

    def idle_time(self) -> float:
        ...
        if self.last_frame_end is None or self.silent_interval is None:
            return 0
```

resolved by extending the type declaration of `self.last_frame_end

```python
    def __init__(  # pylint: disable=too-many-arguments
       ...
       self.last_frame_end: float | None = 0
       ...
```


5) Module missing

server/simulator/http_server.py

```python
try:
    from aiohttp import web
except ImportError:
    web = None
```

mypy reports

```
pymodbus/server/simulator/http_server.py:14: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
```

resolved by using a cast

```
try:
    from aiohttp import web
except ImportError:
    web = cast(Any, None)
```

see https://github.com/python/mypy/issues/10512



6) Type violation: None is not a dict

mypy reports
```
pymodbus/server/simulator/http_server.py:159: error: Argument 2 to "ModbusSimulatorContext" has incompatible type "Any | None"; expected "dict[str, Callable[..., Any]]"  [arg-type]
```

We have

```python
        self.datastore_context = ModbusSimulatorContext(
            device, custom_actions_dict or None )
```

but

```python
ModbusSimulatorContext:
    def __init__(self, config: Dict[str, Any], custom_actions: Dict[str, Callable]
    ) -> None:


resolved by replacing the None by an empty dict

```python
        self.datastore_context = ModbusSimulatorContext(
            device, custom_actions_dict or {}
        )
```

7) ModbusProtocol.transport not a tuple [CODE CHANGE]

transport/transport.py:ModbusProtocol

```python
def __init__(
        self,
        params: CommParams,
        is_server: bool,
    ) -> None:
...
self.transport: asyncio.BaseTransport = None


async def transport_listen(self) -> bool:

            self.transport = await self.call_create()
            if isinstance(self.transport, tuple):
                self.transport = self.transport[0]
```


How can self.transport is of type asyncio.BaseTransport and thus cannot hold a tuple.


```python
            transport = await self.call_create()
            if isinstance(transport, tuple):
                self.transport = transport[0]
            else:
                self.transport = transport
```

8) baudrate in ModbusSerialClient can be None


client/serial.py

```python
class ModbusSerialClient(ModbusBaseClient):

    def __init__(
        self,
        ...
        baudrate: int = 19200,
        ...


        ModbusBaseClient.__init__(
            self,
            ...
            baudrate=baudrate,
            ...
        )


        self._t0 = float(1 + bytesize + stopbits) / self.comm_params.baudrate
```

but from `transport/transport.py` we see that `self.comm_params.baudrate` could be `None`:

```python
@dataclasses.dataclass
class CommParams:
    ...
    baudrate: int | None = None
    ...
```

resolved by adding an assertion

```python
        assert isinstance(self.comm_params.baudrate, int)
        self._t0 = float(1 + bytesize + stopbits) / self.comm_params.baudrate
```


9) Return type declaration of init_setup_serial wrong [CODE CHANGE]

transport/transport.py

```python
class ModbusProtocol(asyncio.BaseProtocol):

    def __init__(..) -> None:
        ...
        if self.comm_params.comm_type == CommType.SERIAL:
            host, port = self.init_setup_serial(host, port)
            if not host and not port:
                return
        ...
    def init_setup_serial(self, host: str, _port: int) -> tuple[str, int]:
        ...
        return None, None
```

The return type of `init_setup_serial` declaration does not match its implementation.

Resolved by extending this type declaration and taking care that in the assignment of `host` and `port` in `__init__` does not violate its declaration:

```python
    def __init__(..) -> None:
        ...
      if self.comm_params.comm_type == CommType.SERIAL:
            host_serial, port_serial = self.init_setup_serial(host, port)
            if host_serial is None or port_serial is None:
                return
            host, port = host_serial, port_serial
        ...
    def init_setup_serial(
        self, host: str, _port: int) -> tuple[str, int] | tuple[None, None]:
        ...
        return None, None
```


10) self.loop can be None

transport/transport.py:ModbusProtocol

```python
class ModbusProtocol(asyncio.BaseProtocol):
    def __init__(..) -> None:
        ..
        self.loop: asyncio.AbstractEventLoop | None = None
        ..


    def init_setup_connect_listen(self, host: str, port: int) -> None:
        """Handle connect/listen handler."""
        if self.comm_params.comm_type == CommType.UDP:
            if self.is_server:
                self.call_create = lambda: self.loop.create_datagram_endpoint(
                    self.handle_new_connection,
                    local_addr=(host, port),
                )
```

resolved by adding a cast

```python
    def init_setup_connect_listen(self, host: str, port: int) -> None:
        """Handle connect/listen handler."""
        if self.comm_params.comm_type == CommType.UDP:
            if self.is_server:
                self.call_create = lambda: cast(
                    asyncio.AbstractEventLoop, self.loop
                ).create_datagram_endpoint(
                    self.handle_new_connection,
                    local_addr=(host, port),
                )
```




11) dummy lambda does not return Coroutine as declared [CODE CHANGE]

transport/transport.py:ModbusProtocol
```python
  self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None
```

None is not a Coroutine

Resolved by using None instead of the dummy lambda

```python
  self.call_create: Callable[[], Coroutine[Any, Any, Any]] | None = None
```

and adding an assertion to

```python
    async def transport_connect(self) -> bool:
        ...
        try:
            self.transport, _protocol = await asyncio.wait_for(
                self.call_create(),
                timeout=self.comm_params.timeout_connect,
            )
        except USEEXCEPTIONS as exc:
```

here and in some related occurrences

```python
    async def transport_connect(self) -> bool:
        ...
        try:
            assert self.call_create is not None
            self.transport, _protocol = await asyncio.wait_for(
                self.call_create(),
                timeout=self.comm_params.timeout_connect,
            )
        except USEEXCEPTIONS as exc:
```