### PR TITLE
Clean client API imports.

### DIFF
--- a/examples/client_async.py
+++ b/examples/client_async.py
@@ -31,19 +31,10 @@ import logging
 
 import helper
 
-# --------------------------------------------------------------------------- #
-# import the various client implementations
-# --------------------------------------------------------------------------- #
-from pymodbus.client import (
-    AsyncModbusSerialClient,
-    AsyncModbusTcpClient,
-    AsyncModbusTlsClient,
-    AsyncModbusUdpClient,
-)
-from pymodbus.exceptions import ModbusIOException
+import pymodbus.client as modbusClient
+from pymodbus import ModbusException
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 _logger.setLevel("DEBUG")
 
@@ -55,7 +46,7 @@ def setup_async_client(description=None, cmdline=None):
     )
     _logger.info("### Create client object")
     if args.comm == "tcp":
-        client = AsyncModbusTcpClient(
+        client = modbusClient.AsyncModbusTcpClient(
             args.host,
             port=args.port,  # on which port
             # Common optional parameters:
@@ -69,7 +60,7 @@ def setup_async_client(description=None, cmdline=None):
             #    source_address=("localhost", 0),
         )
     elif args.comm == "udp":
-        client = AsyncModbusUdpClient(
+        client = modbusClient.AsyncModbusUdpClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -81,7 +72,7 @@ def setup_async_client(description=None, cmdline=None):
             #    source_address=None,
         )
     elif args.comm == "serial":
-        client = AsyncModbusSerialClient(
+        client = modbusClient.AsyncModbusSerialClient(
             args.port,
             # Common optional parameters:
             #    framer=ModbusRtuFramer,
@@ -96,7 +87,7 @@ def setup_async_client(description=None, cmdline=None):
             #    handle_local_echo=False,
         )
     elif args.comm == "tls":
-        client = AsyncModbusTlsClient(
+        client = modbusClient.AsyncModbusTlsClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -135,7 +126,7 @@ async def run_a_few_calls(client):
         rr = await client.read_holding_registers(4, 2, slave=1)
         assert rr.registers[0] == 17
         assert rr.registers[1] == 17
-    except ModbusIOException:
+    except ModbusException:
         pass
 
 

--- a/examples/client_async_calls.py
+++ b/examples/client_async_calls.py
@@ -160,7 +160,7 @@ async def async_execute_information_requests(client):
 
     rr = await client.report_slave_id(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
-    # assert rr.status
+    # assert not rr.status
 
     rr = await client.read_exception_status(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
@@ -189,7 +189,7 @@ async def async_execute_diagnostic_requests(client):
     await client.diag_read_diagnostic_register(slave=SLAVE)
     await client.diag_change_ascii_input_delimeter(slave=SLAVE)
 
-    # NOT WORKING: _await client.diag_force_listen_only(slave=SLAVE)
+    # NOT WORKING: await client.diag_force_listen_only(slave=SLAVE)
 
     await client.diag_clear_counters()
     await client.diag_read_bus_comm_error_count(slave=SLAVE)

--- a/examples/client_async_calls.py
+++ b/examples/client_async_calls.py
@@ -34,13 +34,7 @@ import logging
 
 import client_async
 
-import pymodbus.diag_message as req_diag
-import pymodbus.mei_message as req_mei
-import pymodbus.other_message as req_other
-from pymodbus.exceptions import ModbusException
 
-
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 _logger.setLevel("DEBUG")
 
@@ -56,14 +50,14 @@ async def async_template_call(client):
     """Show complete modbus call, async version."""
     try:
         rr = await client.read_coils(1, 1, slave=SLAVE)
-    except ModbusException as exc:
+    except client_async.ModbusException as exc:
         txt = f"ERROR: exception in pymodbus {exc}"
         _logger.error(txt)
         raise exc
     if rr.isError():
         txt = "ERROR: pymodbus returned an error!"
         _logger.error(txt)
-        raise ModbusException(txt)
+        raise client_async.ModbusException(txt)
 
     # Validate data
     txt = f"### Template coils response: {rr.bits!s}"
@@ -160,24 +154,24 @@ async def async_handle_input_registers(client):
 async def async_execute_information_requests(client):
     """Execute extended information requests."""
     _logger.info("### Running information requests.")
-    rr = await client.execute(req_mei.ReadDeviceInformationRequest(slave=SLAVE))
+    rr = await client.read_device_information(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     assert rr.information[0] == b"Pymodbus"
 
-    rr = await client.execute(req_other.ReportSlaveIdRequest(slave=SLAVE))
+    rr = await client.report_slave_id(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert rr.status
 
-    rr = await client.execute(req_other.ReadExceptionStatusRequest(slave=SLAVE))
+    rr = await client.read_exception_status(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert not rr.status
 
-    rr = await client.execute(req_other.GetCommEventCounterRequest(slave=SLAVE))
+    rr = await client.diag_get_comm_event_counter(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert rr.status
     # assert not rr.count
 
-    rr = await client.execute(req_other.GetCommEventLogRequest(slave=SLAVE))
+    rr = await client.diag_get_comm_event_log(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert rr.status
     # assert not (rr.event_count + rr.message_count + len(rr.events))
@@ -187,32 +181,27 @@ async def async_execute_diagnostic_requests(client):
     """Execute extended diagnostic requests."""
     _logger.info("### Running diagnostic requests.")
     message = b"OK"
-    rr = await client.execute(
-        req_diag.ReturnQueryDataRequest(message=message, slave=SLAVE)
-    )
+    rr = await client.diag_query_data(msg=message, slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     assert rr.message == message
 
-    await client.execute(req_diag.RestartCommunicationsOptionRequest(slave=SLAVE))
-    await client.execute(req_diag.ReturnDiagnosticRegisterRequest(slave=SLAVE))
-    await client.execute(req_diag.ChangeAsciiInputDelimiterRequest(slave=SLAVE))
+    await client.diag_restart_communication(True, slave=SLAVE)
+    await client.diag_read_diagnostic_register(slave=SLAVE)
+    await client.diag_change_ascii_input_delimeter(slave=SLAVE)
 
-    # NOT WORKING: _check_call(await client.execute(req_diag.ForceListenOnlyModeRequest(slave=SLAVE)))
-    # does not send a response
+    # NOT WORKING: _await client.diag_force_listen_only(slave=SLAVE)
 
-    await client.execute(req_diag.ClearCountersRequest())
-    await client.execute(req_diag.ReturnBusCommunicationErrorCountRequest(slave=SLAVE))
-    await client.execute(req_diag.ReturnBusExceptionErrorCountRequest(slave=SLAVE))
-    await client.execute(req_diag.ReturnSlaveMessageCountRequest(slave=SLAVE))
-    await client.execute(req_diag.ReturnSlaveNoResponseCountRequest(slave=SLAVE))
-    await client.execute(req_diag.ReturnSlaveNAKCountRequest(slave=SLAVE))
-    await client.execute(req_diag.ReturnSlaveBusyCountRequest(slave=SLAVE))
-    await client.execute(
-        req_diag.ReturnSlaveBusCharacterOverrunCountRequest(slave=SLAVE)
-    )
-    await client.execute(req_diag.ReturnIopOverrunCountRequest(slave=SLAVE))
-    await client.execute(req_diag.ClearOverrunCountRequest(slave=SLAVE))
-    # NOT WORKING _check_call(await client.execute(req_diag.GetClearModbusPlusRequest(slave=SLAVE)))
+    await client.diag_clear_counters()
+    await client.diag_read_bus_comm_error_count(slave=SLAVE)
+    await client.diag_read_bus_exception_error_count(slave=SLAVE)
+    await client.diag_read_slave_message_count(slave=SLAVE)
+    await client.diag_read_slave_no_response_count(slave=SLAVE)
+    await client.diag_read_slave_nak_count(slave=SLAVE)
+    await client.diag_read_slave_busy_count(slave=SLAVE)
+    await client.diag_read_bus_char_overrun_count(slave=SLAVE)
+    await client.diag_read_iop_overrun_count(slave=SLAVE)
+    await client.diag_clear_overrun_counter(slave=SLAVE)
+    # NOT WORKING await client.diag_getclear_modbus_response(slave=SLAVE)
 
 
 # ------------------------

--- a/examples/client_calls.py
+++ b/examples/client_calls.py
@@ -39,7 +39,6 @@ import pymodbus.other_message as req_other
 from pymodbus.exceptions import ModbusException
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 _logger.setLevel("DEBUG")
 

--- a/examples/client_calls.py
+++ b/examples/client_calls.py
@@ -33,11 +33,6 @@ import logging
 
 import client_sync
 
-import pymodbus.diag_message as req_diag
-import pymodbus.mei_message as req_mei
-import pymodbus.other_message as req_other
-from pymodbus.exceptions import ModbusException
-
 
 _logger = logging.getLogger(__file__)
 _logger.setLevel("DEBUG")
@@ -54,14 +49,14 @@ def template_call(client):
     """Show complete modbus call, sync version."""
     try:
         rr = client.read_coils(32, 1, slave=SLAVE)
-    except ModbusException as exc:
+    except client_sync.ModbusException as exc:
         txt = f"ERROR: exception in pymodbus {exc}"
         _logger.error(txt)
         raise exc
     if rr.isError():
         txt = "ERROR: pymodbus returned an error!"
         _logger.error(txt)
-        raise ModbusException(txt)
+        raise client_sync.ModbusException(txt)
 
     # Validate data
     txt = f"### Template coils response: {rr.bits!s}"
@@ -158,24 +153,24 @@ def handle_input_registers(client):
 def execute_information_requests(client):  # pragma no cover
     """Execute extended information requests."""
     _logger.info("### Running information requests.")
-    rr = client.execute(req_mei.ReadDeviceInformationRequest(slave=SLAVE))
+    rr = client.read_device_information(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     assert rr.information[0] == b"Pymodbus"
 
-    rr = client.execute(req_other.ReportSlaveIdRequest(slave=SLAVE))
-    assert not rr.isError()  # test that call was OK
-    # assert rr.status
-
-    rr = client.execute(req_other.ReadExceptionStatusRequest(slave=SLAVE))
+    rr = client.report_slave_id(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert not rr.status
 
-    rr = client.execute(req_other.GetCommEventCounterRequest(slave=SLAVE))
+    rr = client.read_exception_status(slave=SLAVE)
+    assert not rr.isError()  # test that call was OK
+    # assert not rr.status
+
+    rr = client.diag_get_comm_event_counter(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert rr.status
     # assert not rr.count
 
-    rr = client.execute(req_other.GetCommEventLogRequest(slave=SLAVE))
+    rr = client.diag_get_comm_event_log(slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     # assert rr.status
     # assert not (rr.event_count + rr.message_count + len(rr.events))
@@ -185,28 +180,27 @@ def execute_diagnostic_requests(client):  # pragma no cover
     """Execute extended diagnostic requests."""
     _logger.info("### Running diagnostic requests.")
     message = b"OK"
-    rr = client.execute(req_diag.ReturnQueryDataRequest(message=message, slave=SLAVE))
+    rr = client.diag_query_data(msg=message, slave=SLAVE)
     assert not rr.isError()  # test that call was OK
     assert rr.message == message
 
-    client.execute(req_diag.RestartCommunicationsOptionRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnDiagnosticRegisterRequest(slave=SLAVE))
-    client.execute(req_diag.ChangeAsciiInputDelimiterRequest(slave=SLAVE))
+    client.diag_restart_communication(True, slave=SLAVE)
+    client.diag_read_diagnostic_register(slave=SLAVE)
+    client.diag_change_ascii_input_delimeter(slave=SLAVE)
 
-    # NOT WORKING: _check_call(client.execute(req_diag.ForceListenOnlyModeRequest(slave=SLAVE)))
-    # does not send a response
+    # NOT WORKING: await client.diag_force_listen_only(slave=SLAVE)
 
-    client.execute(req_diag.ClearCountersRequest())
-    client.execute(req_diag.ReturnBusCommunicationErrorCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnBusExceptionErrorCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnSlaveMessageCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnSlaveNoResponseCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnSlaveNAKCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnSlaveBusyCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnSlaveBusCharacterOverrunCountRequest(slave=SLAVE))
-    client.execute(req_diag.ReturnIopOverrunCountRequest(slave=SLAVE))
-    client.execute(req_diag.ClearOverrunCountRequest(slave=SLAVE))
-    # NOT WORKING _check_call(client.execute(req_diag.GetClearModbusPlusRequest(slave=SLAVE)))
+    client.diag_clear_counters()
+    client.diag_read_bus_comm_error_count(slave=SLAVE)
+    client.diag_read_bus_exception_error_count(slave=SLAVE)
+    client.diag_read_slave_message_count(slave=SLAVE)
+    client.diag_read_slave_no_response_count(slave=SLAVE)
+    client.diag_read_slave_nak_count(slave=SLAVE)
+    client.diag_read_slave_busy_count(slave=SLAVE)
+    client.diag_read_bus_char_overrun_count(slave=SLAVE)
+    client.diag_read_iop_overrun_count(slave=SLAVE)
+    client.diag_clear_overrun_counter(slave=SLAVE)
+    # NOT WORKING client.diag_getclear_modbus_response(slave=SLAVE)
 
 
 # ------------------------

--- a/examples/client_custom_msg.py
+++ b/examples/client_custom_msg.py
@@ -11,7 +11,6 @@ implementation from pymodbus::
 
 """
 import asyncio
-import logging
 import struct
 
 from pymodbus import Framer
@@ -19,13 +18,6 @@ from pymodbus.bit_read_message import ReadCoilsRequest
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
 from pymodbus.pdu import ModbusExceptions, ModbusRequest, ModbusResponse
 
-
-# --------------------------------------------------------------------------- #
-# configure the client logging
-# --------------------------------------------------------------------------- #
-logging.basicConfig()
-log = logging.getLogger(__file__)
-log.setLevel(logging.DEBUG)
 
 # --------------------------------------------------------------------------- #
 # create your custom message

--- a/examples/client_custom_msg.py
+++ b/examples/client_custom_msg.py
@@ -13,7 +13,7 @@ implementation from pymodbus::
 import asyncio
 import struct
 
-from pymodbus import Framer, ModbusExceptions
+from pymodbus import Framer, ModbusException
 from pymodbus.bit_read_message import ReadCoilsRequest
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
 from pymodbus.pdu import ModbusRequest, ModbusResponse
@@ -85,9 +85,9 @@ class CustomModbusRequest(ModbusRequest):
     def execute(self, context):  # pragma no cover
         """Execute."""
         if not 1 <= self.count <= 0x7D0:
-            return self.doException(ModbusExceptions.IllegalValue)
+            return self.doException(ModbusException.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
-            return self.doException(ModbusExceptions.IllegalAddress)
+            return self.doException(ModbusException.IllegalAddress)
         values = context.getValues(self.function_code, self.address, self.count)
         return CustomModbusResponse(values)
 

--- a/examples/client_custom_msg.py
+++ b/examples/client_custom_msg.py
@@ -13,10 +13,10 @@ implementation from pymodbus::
 import asyncio
 import struct
 
-from pymodbus import Framer, ModbusException
+from pymodbus import Framer
 from pymodbus.bit_read_message import ReadCoilsRequest
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
-from pymodbus.pdu import ModbusRequest, ModbusResponse
+from pymodbus.pdu import ModbusExceptions, ModbusRequest, ModbusResponse
 
 
 # --------------------------------------------------------------------------- #
@@ -85,9 +85,9 @@ class CustomModbusRequest(ModbusRequest):
     def execute(self, context):  # pragma no cover
         """Execute."""
         if not 1 <= self.count <= 0x7D0:
-            return self.doException(ModbusException.IllegalValue)
+            return self.doException(ModbusExceptions.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
-            return self.doException(ModbusException.IllegalAddress)
+            return self.doException(ModbusExceptions.IllegalAddress)
         values = context.getValues(self.function_code, self.address, self.count)
         return CustomModbusResponse(values)
 

--- a/examples/client_custom_msg.py
+++ b/examples/client_custom_msg.py
@@ -13,10 +13,10 @@ implementation from pymodbus::
 import asyncio
 import struct
 
-from pymodbus import Framer
+from pymodbus import Framer, ModbusExceptions
 from pymodbus.bit_read_message import ReadCoilsRequest
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
-from pymodbus.pdu import ModbusExceptions, ModbusRequest, ModbusResponse
+from pymodbus.pdu import ModbusRequest, ModbusResponse
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/client_payload.py
+++ b/examples/client_payload.py
@@ -7,7 +7,6 @@ complicated memory layout using builder.
 Works out of the box together with payload_server.py
 """
 import asyncio
-import logging
 from collections import OrderedDict
 
 import client_async
@@ -16,8 +15,6 @@ from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
 
 
-logging.basicConfig()
-_logger = logging.getLogger(__file__)
 ORDER_DICT = {"<": "LITTLE", ">": "BIG"}
 
 

--- a/examples/client_sync.py
+++ b/examples/client_sync.py
@@ -34,18 +34,10 @@ import logging
 
 import helper
 
-# --------------------------------------------------------------------------- #
-# import the various client implementations
-# --------------------------------------------------------------------------- #
-from pymodbus.client import (
-    ModbusSerialClient,
-    ModbusTcpClient,
-    ModbusTlsClient,
-    ModbusUdpClient,
-)
+import pymodbus.client as modbusClient
+from pymodbus import ModbusException
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 _logger.setLevel("DEBUG")
 
@@ -59,7 +51,7 @@ def setup_sync_client(description=None, cmdline=None):
     )
     _logger.info("### Create client object")
     if args.comm == "tcp":
-        client = ModbusTcpClient(
+        client = modbusClient.ModbusTcpClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -73,7 +65,7 @@ def setup_sync_client(description=None, cmdline=None):
             #    source_address=("localhost", 0),
         )
     elif args.comm == "udp":
-        client = ModbusUdpClient(
+        client = modbusClient.ModbusUdpClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -87,7 +79,7 @@ def setup_sync_client(description=None, cmdline=None):
             #    source_address=None,
         )
     elif args.comm == "serial":
-        client = ModbusSerialClient(
+        client = modbusClient.ModbusSerialClient(
             port=args.port,  # serial port
             # Common optional parameters:
             #    framer=ModbusRtuFramer,
@@ -104,7 +96,7 @@ def setup_sync_client(description=None, cmdline=None):
             #    handle_local_echo=False,
         )
     elif args.comm == "tls":  # pragma no cover
-        client = ModbusTlsClient(
+        client = modbusClient.ModbusTlsClient(
             args.host,
             port=args.port,
             # Common optional parameters:
@@ -136,12 +128,14 @@ def run_sync_client(client, modbus_calls=None):
 
 def run_a_few_calls(client):
     """Test connection works."""
-    rr = client.read_coils(32, 1, slave=1)
-    assert len(rr.bits) == 8
-    rr = client.read_holding_registers(4, 2, slave=1)
-    assert rr.registers[0] == 17
-    assert rr.registers[1] == 17
-
+    try:
+        rr = client.read_coils(32, 1, slave=1)
+        assert len(rr.bits) == 8
+        rr = client.read_holding_registers(4, 2, slave=1)
+        assert rr.registers[0] == 17
+        assert rr.registers[1] == 17
+    except ModbusException as exc:
+        raise exc
 
 def main(cmdline=None):
     """Combine setup and run."""

--- a/examples/contrib/serial_forwarder.py
+++ b/examples/contrib/serial_forwarder.py
@@ -14,7 +14,6 @@ from pymodbus.datastore.remote import RemoteSlaveContext
 from pymodbus.server.async_io import ModbusTcpServer
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 
 

--- a/examples/contrib/solar.py
+++ b/examples/contrib/solar.py
@@ -17,7 +17,6 @@ from pymodbus.exceptions import ModbusException
 from pymodbus.transaction import ModbusSocketFramer
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 _logger.setLevel(logging.DEBUG)
 

--- a/examples/datastore_simulator.py
+++ b/examples/datastore_simulator.py
@@ -31,7 +31,6 @@ from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.server import StartAsyncTcpServer
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 
 demo_config = {

--- a/examples/message_generator.py
+++ b/examples/message_generator.py
@@ -20,7 +20,6 @@ from pymodbus.transaction import (
 )
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 
 

--- a/examples/message_parser.py
+++ b/examples/message_parser.py
@@ -20,7 +20,6 @@ from pymodbus.transaction import (
 )
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 
 

--- a/examples/modbus_forwarder.py
+++ b/examples/modbus_forwarder.py
@@ -28,7 +28,6 @@ from pymodbus.datastore.remote import RemoteSlaveContext
 from pymodbus.server import StartAsyncTcpServer
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 
 

--- a/examples/server_async.py
+++ b/examples/server_async.py
@@ -53,7 +53,6 @@ from pymodbus.server import (
 )
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 _logger.setLevel(logging.INFO)
 

--- a/examples/simple_async_client.py
+++ b/examples/simple_async_client.py
@@ -11,15 +11,13 @@ The corresponding server must be started before e.g. as:
 """
 import asyncio
 
-from pymodbus import Framer, pymodbus_apply_logging_config
-from pymodbus.client import (
-    AsyncModbusSerialClient,
-    AsyncModbusTcpClient,
-    AsyncModbusTlsClient,
-    AsyncModbusUdpClient,
+import pymodbus.client as ModbusClient
+from pymodbus import (
+    ExceptionResponse,
+    Framer,
+    ModbusException,
+    pymodbus_apply_logging_config,
 )
-from pymodbus.exceptions import ModbusException
-from pymodbus.pdu import ExceptionResponse
 
 
 async def run_async_simple_client(comm, host, port, framer=Framer.SOCKET):
@@ -29,7 +27,7 @@ async def run_async_simple_client(comm, host, port, framer=Framer.SOCKET):
 
     print("get client")
     if comm == "tcp":
-        client = AsyncModbusTcpClient(
+        client = ModbusClient.AsyncModbusTcpClient(
             host,
             port=port,
             framer=framer,
@@ -41,7 +39,7 @@ async def run_async_simple_client(comm, host, port, framer=Framer.SOCKET):
             # source_address=("localhost", 0),
         )
     elif comm == "udp":
-        client = AsyncModbusUdpClient(
+        client = ModbusClient.AsyncModbusUdpClient(
             host,
             port=port,
             framer=framer,
@@ -53,7 +51,7 @@ async def run_async_simple_client(comm, host, port, framer=Framer.SOCKET):
             # source_address=None,
         )
     elif comm == "serial":
-        client = AsyncModbusSerialClient(
+        client = ModbusClient.AsyncModbusSerialClient(
             port,
             framer=framer,
             # timeout=10,
@@ -68,7 +66,7 @@ async def run_async_simple_client(comm, host, port, framer=Framer.SOCKET):
             # handle_local_echo=False,
         )
     elif comm == "tls":
-        client = AsyncModbusTlsClient(
+        client = ModbusClient.AsyncModbusTlsClient(
             host,
             port=port,
             framer=Framer.TLS,

--- a/examples/simple_sync_client.py
+++ b/examples/simple_sync_client.py
@@ -13,15 +13,13 @@ The corresponding server must be started before e.g. as:
 # --------------------------------------------------------------------------- #
 # import the various client implementations
 # --------------------------------------------------------------------------- #
-from pymodbus import Framer, pymodbus_apply_logging_config
-from pymodbus.client import (
-    ModbusSerialClient,
-    ModbusTcpClient,
-    ModbusTlsClient,
-    ModbusUdpClient,
+import pymodbus.client as ModbusClient
+from pymodbus import (
+    ExceptionResponse,
+    Framer,
+    ModbusException,
+    pymodbus_apply_logging_config,
 )
-from pymodbus.exceptions import ModbusException
-from pymodbus.pdu import ExceptionResponse
 
 
 def run_sync_simple_client(comm, host, port, framer=Framer.SOCKET):
@@ -31,7 +29,7 @@ def run_sync_simple_client(comm, host, port, framer=Framer.SOCKET):
 
     print("get client")
     if comm == "tcp":
-        client = ModbusTcpClient(
+        client = ModbusClient.ModbusTcpClient(
             host,
             port=port,
             framer=framer,
@@ -43,7 +41,7 @@ def run_sync_simple_client(comm, host, port, framer=Framer.SOCKET):
             # source_address=("localhost", 0),
         )
     elif comm == "udp":
-        client = ModbusUdpClient(
+        client = ModbusClient.ModbusUdpClient(
             host,
             port=port,
             framer=framer,
@@ -55,7 +53,7 @@ def run_sync_simple_client(comm, host, port, framer=Framer.SOCKET):
             # source_address=None,
         )
     elif comm == "serial":
-        client = ModbusSerialClient(
+        client = ModbusClient.ModbusSerialClient(
             port,
             framer=framer,
             # timeout=10,
@@ -70,7 +68,7 @@ def run_sync_simple_client(comm, host, port, framer=Framer.SOCKET):
             # handle_local_echo=False,
         )
     elif comm == "tls":
-        client = ModbusTlsClient(
+        client = ModbusClient.ModbusTlsClient(
             host,
             port=port,
             framer=Framer.TLS,

--- a/examples/simulator.py
+++ b/examples/simulator.py
@@ -16,7 +16,6 @@ from pymodbus.datastore import ModbusSimulatorContext
 from pymodbus.server import ModbusSimulatorServer, get_simulator_commandline
 
 
-logging.basicConfig()
 _logger = logging.getLogger(__file__)
 
 

--- a/pymodbus/__init__.py
+++ b/pymodbus/__init__.py
@@ -5,11 +5,13 @@ Released under the BSD license
 
 __all__ = [
     "Framer",
+    "ModbusException",
     "pymodbus_apply_logging_config",
     "__version__",
     "__version_full__",
 ]
 
+from pymodbus.exceptions import ModbusException
 from pymodbus.framer import Framer
 from pymodbus.logging import pymodbus_apply_logging_config
 

--- a/pymodbus/__init__.py
+++ b/pymodbus/__init__.py
@@ -4,6 +4,7 @@ Released under the BSD license
 """
 
 __all__ = [
+    "ExceptionResponse",
     "Framer",
     "ModbusException",
     "pymodbus_apply_logging_config",
@@ -14,6 +15,7 @@ __all__ = [
 from pymodbus.exceptions import ModbusException
 from pymodbus.framer import Framer
 from pymodbus.logging import pymodbus_apply_logging_config
+from pymodbus.pdu import ExceptionResponse
 
 
 __version__ = "3.6.0dev"

--- a/pymodbus/client/__init__.py
+++ b/pymodbus/client/__init__.py
@@ -5,14 +5,12 @@ __all__ = [
     "AsyncModbusTcpClient",
     "AsyncModbusTlsClient",
     "AsyncModbusUdpClient",
-    "ModbusBaseClient",
     "ModbusSerialClient",
     "ModbusTcpClient",
     "ModbusTlsClient",
     "ModbusUdpClient",
 ]
 
-from pymodbus.client.base import ModbusBaseClient
 from pymodbus.client.serial import AsyncModbusSerialClient, ModbusSerialClient
 from pymodbus.client.tcp import AsyncModbusTcpClient, ModbusTcpClient
 from pymodbus.client.tls import AsyncModbusTlsClient, ModbusTlsClient

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -46,7 +46,7 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
     **Application methods, common to all clients**:
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         framer: Framer,
         timeout: float = 3,

--- a/pymodbus/exceptions.py
+++ b/pymodbus/exceptions.py
@@ -4,7 +4,6 @@ Custom exceptions to be used in the Modbus code.
 """
 
 __all__ = [
-    "ModbusException",
     "ModbusIOException",
     "ParameterException",
     "NotImplementedException",

--- a/test/test_framers.py
+++ b/test/test_framers.py
@@ -5,7 +5,7 @@ import pytest
 
 from pymodbus import Framer
 from pymodbus.bit_read_message import ReadCoilsRequest
-from pymodbus.client import ModbusBaseClient
+from pymodbus.client.base import ModbusBaseClient
 from pymodbus.exceptions import ModbusIOException
 from pymodbus.factory import ClientDecoder
 from pymodbus.framer.ascii_framer import ModbusAsciiFramer


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
An app that implement a client should only do
```
import pymodbus.client as client
```
And then have all API methods for the client, including framers exceptions etc available.

THIS MUST BE DONE WITHOUT BREAKING EXISTING APP IMPORT !
