### PR TITLE
Cleanup paths included in mypy/pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ version = {attr = "pymodbus.__version__"}
 [tool.pylint.main]
 init-hook='import sys; sys.path.append("examples")'
 ignore-paths = [
-    "pymodbus/transport/serial_asyncio",
     "doc"
 ]
 ignore-patterns = '^\.#'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,6 @@ bad-functions = "map,input"
 
 [tool.mypy]
 strict_optional = false
-exclude = "pymodbus/client/base.py"
 show_error_codes = true
 local_partial_types = true
 strict_equality = true


### PR DESCRIPTION
Clean up the paths included in linting.

Thanks to @MAKOMO.
(https://github.com/MAKOMO/pymodbus/commit/12882937a1691eeac31cea869c6092ca53e34130)
