### PR TITLE
Bump actions/stale to 8.0.0

### DIFF
--- a/.github/workflows/stale_lock.yml
+++ b/.github/workflows/stale_lock.yml
@@ -16,7 +16,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'


### PR DESCRIPTION
This avoids a pending deprecation of Node12 in `v3`.  None of the breaking changes appear to matter to this project.
