### PR TITLE
Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: pytest
         run: |
           env
-          pytest -n0  -v --full-trace --timeout=1200
+          pytest -v --full-trace --timeout=1200
 
   analyze:
     name: Analyze Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - dev
       - master
+      - dev_*
     tags:
       - v*
   pull_request:
@@ -13,8 +14,6 @@ on:
     # Sunday at 02:10 UTC.
     - cron: '10 2 * * 0'
   workflow_dispatch:
-
-# Test with new caching.
 
 jobs:
   testing:
@@ -48,11 +47,23 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Set venv path (NON Windows)
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "VIRTUAL_ENV=${{ github.workspace }}/venv" >> $GITHUB_ENV
+          echo ${{ github.workspace }}/venv/bin >> $GITHUB_PATH
+
+      - name: Set venv path (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "VIRTUAL_ENV=${{ github.workspace }}\\venv" >> $Env:GITHUB_ENV
+          echo "${{ github.workspace }}\\venv\\Scripts" >> $Env:GITHUB_PATH
+
       - name: Restore base Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.3.2
         with:
-          path: ${{ github.workspace }}/venv
+          path: ${{ env.VIRTUAL_ENV }}
           key: >-
             ${{ runner.os }}-${{ matrix.python }}-venv-${{
               hashFiles('pyproject.toml') }}-${{
@@ -61,19 +72,20 @@ jobs:
       - name: Create venv (NEW CACHE)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
-          python -m venv ${{ github.workspace }}/venv
-          echo ${{ github.workspace }}/venv/bin >> $GITHUB_PATH
+          python -m venv ${{ env.VIRTUAL_ENV }}
+          python -m pip install --upgrade pip
           pip install -e ".[all]"
 
-      - name: Activate vertial environment (EXISTING CACHE)
-        if: steps.cache-venv.outputs.cache-hit == 'true'
+      - name: CHECK pytest
         run: |
-          echo ${{ github.workspace }}/venv/bin >> $GITHUB_PATH
+          env
+          which pytest
+          which codespell
+          which mypy
 
       - name: codespell
         if: matrix.run_doc == true
         run: |
-          echo $PATH
           codespell
 
       - name: dcoumentation
@@ -98,11 +110,13 @@ jobs:
 
       - name: pytest
         run: |
+          env
           pytest -n0  -v --full-trace --timeout=1200
 
   analyze:
     name: Analyze Python
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
 
@@ -122,4 +136,4 @@ jobs:
       - testing
     timeout-minutes: 1
     steps:
-      - run: ls
+      - run: echo 'finish job'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all]"
 
-      - name: CHECK pytest
-        run: |
-          env
-          which pytest
-          which codespell
-          which mypy
-
       - name: codespell
         if: matrix.run_doc == true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     branches:
@@ -15,85 +14,112 @@ on:
     - cron: '10 2 * * 0'
   workflow_dispatch:
 
+# Test with new caching.
 
 jobs:
-  linters:
-    name: Linters - ${{ matrix.os.on }} - ${{ matrix.python.version }}
-    runs-on: ${{ matrix.os.on }}
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - on: ubuntu-latest
-          # - on: macos-latest
-          # - on: windows-latest
-        python:
-          - version: '3.8'
-          - version: '3.9'
-          - version: '3.10'
-          - version: '3.11'
-          - version: '3.12'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python.version }}
-          cache: 'pip'
-      - run: pip install -e ".[all]"
-      - run: codespell
-      - run: pylint --recursive=y examples pymodbus test
-      - run: pre-commit run --all-files
-      - run: cd doc; ./build_html
-      - run: mypy pymodbus
-
-  integreation_test:
-    name: pytest - ${{ matrix.os.on }} - ${{ matrix.python.version }}
-    runs-on: ${{ matrix.os.on }}
+  testing:
+    name: ${{ matrix.os }} - ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - on: ubuntu-latest
-          - on: macos-latest
-          - on: windows-latest
-        python:
-          - version: '3.8'
-          - version: '3.9'
-          - version: '3.10'
-          - version: '3.11'
-          - version: '3.12'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python.version }}
-          cache: 'pip'
-      - run: pip install -e ".[all]"
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        include:
+          - python: '3.8'
+            run_lint: true
+          - python: '3.12'
+            run_doc: true
+            run_lint: true
+          - os: macos-latest
+            run_doc: false
+            run_lint: false
+          - os: windows-latest
+            run_doc: false
+            run_lint: false
 
-      - run: pytest -n0  -v --full-trace --timeout=1200
+    steps:
+      - name: Checkout repo from github
+        uses: actions/checkout@v4.1.0
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Restore base Python virtual environment
+        id: cache-venv
+        uses: actions/cache@v3.3.2
+        with:
+          path: ${{ github.workspace }}/venv
+          key: >-
+            ${{ runner.os }}-${{ matrix.python }}-venv-${{
+              hashFiles('pyproject.toml') }}-${{
+              hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Create venv (NEW CACHE)
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv ${{ github.workspace }}/venv
+          echo ${{ github.workspace }}/venv/bin >> $GITHUB_PATH
+          pip install -e ".[all]"
+
+      - name: Activate vertial environment (EXISTING CACHE)
+        if: steps.cache-venv.outputs.cache-hit == 'true'
+        run: |
+          echo ${{ github.workspace }}/venv/bin >> $GITHUB_PATH
+
+      - name: codespell
+        if: matrix.run_doc == true
+        run: |
+          echo $PATH
+          codespell
+
+      - name: dcoumentation
+        if: matrix.run_doc == true
+        run: |
+          cd doc; ./build_html
+
+      - name: pylint
+        if: matrix.run_lint == true
+        run: |
+          pylint --recursive=y examples pymodbus test
+
+      - name: mypy
+        if: matrix.run_lint == true
+        run: |
+          mypy pymodbus
+
+      - name: precommit
+        if: matrix.run_lint == true
+        run: |
+          pre-commit run --all-files
+
+      - name: pytest
+        run: |
+          pytest -n0  -v --full-trace --timeout=1200
 
   analyze:
     name: Analyze Python
     runs-on: ubuntu-22.04
-
     steps:
       - uses: actions/checkout@v3
+
       - uses: github/codeql-action/init@v2
         with:
           languages: python
+
       - uses: github/codeql-action/autobuild@v2
+
       - uses: github/codeql-action/analyze@v2
 
   ci_complete:
     name: ci_complete
     runs-on: ubuntu-latest
     needs:
-      - linters
       - analyze
-      - integreation_test
+      - testing
     timeout-minutes: 1
     steps:
-      - name: Dummy
-        run: ls
+      - run: ls

--- a/.github/workflows/clean_workflow_runs.yml
+++ b/.github/workflows/clean_workflow_runs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
-          retain_days: 7
+          retain_days: 3
           keep_minimum_runs: 0
 
 


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
with python in place, we can make our own cache key, and thereby only have:

3 (Windows, Ubuntu, MacOS) x 5 (python 3.8 - 313) = 15 cache.

We need to avoid making new caches for each pull request, that currently is the cause of why some jobs are slow in starting and that the real clock time is too high.

Current timing is at 15 minutes 2 seconds.

1) Change work order since windows takes longer it should be started first.