### PR TITLE
Consistent messages if imports fail

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from contextlib import suppress
 from functools import partial
 from typing import Any
 
@@ -15,8 +14,12 @@ from pymodbus.transport import CommType
 from pymodbus.utilities import ModbusTransactionState
 
 
-with suppress(ImportError):
+try:
     import serial
+
+    PYSERIAL_MISSING = False
+except ImportError:
+    PYSERIAL_MISSING = True
 
 
 class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
@@ -74,6 +77,11 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
         **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus Serial Client."""
+        if PYSERIAL_MISSING:
+            raise RuntimeError(
+                "Serial client requires pyserial "
+                'Please install with "pip install pyserial" and try again.'
+            )
         asyncio.Protocol.__init__(self)
         ModbusBaseClient.__init__(
             self,

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -17,10 +17,6 @@ from pymodbus.pdu import ModbusExceptions as merror
 from pymodbus.transport import CommParams, CommType, ModbusProtocol
 
 
-with suppress(ImportError):
-    pass
-
-
 # --------------------------------------------------------------------------- #
 # Protocol Handlers
 # --------------------------------------------------------------------------- #

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -14,12 +14,10 @@ from enum import Enum
 
 try:
     from aiohttp import web
+
+    AIOHTTP_MISSING = False
 except ImportError:
-    print(
-        "Reactive server requires aiohttp. "
-        'Please install with "pip install aiohttp" and try again.'
-    )
-    sys.exit(1)
+    AIOHTTP_MISSING = True
 
 from pymodbus import __version__ as pymodbus_version
 from pymodbus.datastore import ModbusServerContext, ModbusSlaveContext
@@ -199,6 +197,11 @@ class ReactiveServer:
 
     def __init__(self, host, port, modbus_server):
         """Initialize."""
+        if AIOHTTP_MISSING:
+            raise RuntimeError(
+                "Reactive server requires aiohttp. "
+                'Please install with "pip install aiohttp" and try again.'
+            )
         self._web_app = web.Application()
         self._runner = web.AppRunner(self._web_app)
         self._host = host

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -9,8 +9,12 @@ from time import time
 from typing import List
 
 
-with contextlib.suppress(ImportError):
+try:
     from aiohttp import web
+
+    AIOHTTP_MISSING = False
+except ImportError:
+    AIOHTTP_MISSING = True
 
 from pymodbus.datastore import ModbusServerContext, ModbusSimulatorContext
 from pymodbus.datastore.simulator import Label
@@ -117,8 +121,11 @@ class ModbusSimulatorServer:
         custom_actions_module: str = None,
     ):
         """Initialize http interface."""
-        if not web:
-            raise RuntimeError("aiohttp not installed!")
+        if AIOHTTP_MISSING:
+            raise RuntimeError(
+                "Simulator server requires aiohttp. "
+                'Please install with "pip install aiohttp" and try again.'
+            )
         with open(json_file, encoding="utf-8") as file:
             setup = json.load(file)
 


### PR DESCRIPTION
Supercedes https://github.com/pymodbus-dev/pymodbus/pull/1827

This PR makes consistent error messages when an import (either `aiohttp` or `pyserial`) is missing, warning the user they will need to install the appropriate package.
