### PR TITLE
Cleanup author/maintainer fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "pymodbus"
 dynamic = ["version"]
 license = {text = "BSD-3-Clause"}
-authors = [{name = '"Galen Collins'}, {name = 'Jan Iversen"'}]
-maintainers = [{name = '"dhoomakethu'}, {name = 'janiversen"'}]
+authors = [{name = "Galen Collins"}, {name = "Jan Iversen"}]
+maintainers = [{name = "dhoomakethu"}, {name = "janiversen"}]
 description = "A fully featured modbus protocol stack in python"
 keywords = ["modbus", "asyncio", "scada", "client", "server", "simulator"]
 readme = "README.rst"


### PR DESCRIPTION
The TOML with overlapping is quotes apparently valid, but confusing (and it crashes the TOML parser on Python.38/windows

```toml
authors = [{name = '"Galen Collins'}, {name = 'Jan Iversen"'}]
maintainers = [{name = '"dhoomakethu'}, {name = 'janiversen"'}]
```

```
pip._vendor.toml.decoder.TomlDecodeError: Found tokens after a closed string. Invalid TOML. (line 9 column 1 char 174)
```
