### PR TITLE
Re-enable multiple cores with xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           cache: 'pip'
       - run: pip install -e ".[all]"
 
-      - run: pytest -n0  -v --full-trace --timeout=1200
+      - run: pytest -v --full-trace --timeout=1200
 
   analyze:
     name: Analyze Python


### PR DESCRIPTION
Although the GitHub hosted runners are only 2-cores, there's still an improvement with `pytest-xdist`.

See comments here: https://github.com/pymodbus-dev/pymodbus/pull/1829#issuecomment-1766988198
There are some recently flaky tests, so those should be fixed before re-enabling `xdist`

