### PR TITLE
Remove dummy complete job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,3 @@ jobs:
           languages: python
       - uses: github/codeql-action/autobuild@v2
       - uses: github/codeql-action/analyze@v2
-
-  ci_complete:
-    name: ci_complete
-    runs-on: ubuntu-latest
-    needs:
-      - linters
-      - analyze
-      - integreation_test
-    timeout-minutes: 1
-    steps:
-      - name: Dummy
-        run: ls


### PR DESCRIPTION
I do not think the dummy `ci_complete` job is necessary.  Github's branch protection rules should automatically disallow merging if any of the jobs fail, without needing this dummy.
