### PR TITLE
Switch from black to ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-added-large-files
 # run ruff with --fix before black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.0.287'
+    rev: 'v0.1.0'
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,13 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-# run ruff with --fix before black
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.0'
+    hooks:
+    -   id: ruff-format
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.1.0'
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]
--   repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-    -   id: black
-        args: [--safe, --quiet]
-        files: (examples|pymodbus|test)/

--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -220,23 +220,15 @@ class ModbusDeviceIdentification:
     # -------------------------------------------------------------------------#
     #  Properties
     # -------------------------------------------------------------------------#
-    VendorName = dict_property(
-        lambda s: s.__data, 0  # pylint: disable=protected-access
-    )
-    ProductCode = dict_property(
-        lambda s: s.__data, 1  # pylint: disable=protected-access
-    )
-    MajorMinorRevision = dict_property(
-        lambda s: s.__data, 2  # pylint: disable=protected-access
-    )
+    # fmt: off
+    VendorName = dict_property(lambda s: s.__data, 0)  # pylint: disable=protected-access
+    ProductCode = dict_property(lambda s: s.__data, 1)  # pylint: disable=protected-access
+    MajorMinorRevision = dict_property(lambda s: s.__data, 2)  # pylint: disable=protected-access
     VendorUrl = dict_property(lambda s: s.__data, 3)  # pylint: disable=protected-access
-    ProductName = dict_property(
-        lambda s: s.__data, 4  # pylint: disable=protected-access
-    )
+    ProductName = dict_property(lambda s: s.__data, 4)  # pylint: disable=protected-access
     ModelName = dict_property(lambda s: s.__data, 5)  # pylint: disable=protected-access
-    UserApplicationName = dict_property(
-        lambda s: s.__data, 6  # pylint: disable=protected-access
-    )
+    UserApplicationName = dict_property(lambda s: s.__data, 6)  # pylint: disable=protected-access
+    # fmt: on
 
 
 class DeviceInformationFactory:  # pylint: disable=too-few-public-methods
@@ -428,27 +420,17 @@ class ModbusCountersHandler:
     # -------------------------------------------------------------------------#
     #  Properties
     # -------------------------------------------------------------------------#
-    BusMessage = dict_property(
-        lambda s: s.__data, 0  # pylint: disable=protected-access
-    )
-    BusCommunicationError = dict_property(
-        lambda s: s.__data, 1  # pylint: disable=protected-access
-    )
-    BusExceptionError = dict_property(
-        lambda s: s.__data, 2  # pylint: disable=protected-access
-    )
-    SlaveMessage = dict_property(
-        lambda s: s.__data, 3  # pylint: disable=protected-access
-    )
-    SlaveNoResponse = dict_property(
-        lambda s: s.__data, 4  # pylint: disable=protected-access
-    )
+    # fmt: off
+    BusMessage = dict_property(lambda s: s.__data, 0)  # pylint: disable=protected-access
+    BusCommunicationError = dict_property(lambda s: s.__data, 1)  # pylint: disable=protected-access
+    BusExceptionError = dict_property(lambda s: s.__data, 2)  # pylint: disable=protected-access
+    SlaveMessage = dict_property(lambda s: s.__data, 3)  # pylint: disable=protected-access
+    SlaveNoResponse = dict_property(lambda s: s.__data, 4)  # pylint: disable=protected-access
     SlaveNAK = dict_property(lambda s: s.__data, 5)  # pylint: disable=protected-access
     SlaveBusy = dict_property(lambda s: s.__data, 6)  # pylint: disable=protected-access
-    BusCharacterOverrun = dict_property(
-        lambda s: s.__data, 7  # pylint: disable=protected-access
-    )
+    BusCharacterOverrun = dict_property(lambda s: s.__data, 7)  # pylint: disable=protected-access
     Event = dict_property(lambda s: s.__data, 8)  # pylint: disable=protected-access
+    # fmt: on
 
 
 # ---------------------------------------------------------------------------#

--- a/pymodbus/utilities.py
+++ b/pymodbus/utilities.py
@@ -77,26 +77,20 @@ def dict_property(store, index):
         getter = lambda self: store(  # pylint: disable=unnecessary-lambda-assignment
             self
         )[index]
-        setter = (
-            lambda self, value: store(  # pylint: disable=unnecessary-lambda-assignment
-                self
-            ).__setitem__(index, value)
-        )
+        setter = lambda self, value: store(  # pylint: disable=unnecessary-lambda-assignment
+            self
+        ).__setitem__(index, value)
     elif isinstance(store, str):
         getter = lambda self: self.__getattribute__(  # pylint: disable=unnecessary-dunder-call,unnecessary-lambda-assignment
             store
-        )[
-            index
-        ]
+        )[index]
         setter = lambda self, value: self.__getattribute__(  # pylint: disable=unnecessary-dunder-call,unnecessary-lambda-assignment
             store
-        ).__setitem__(
-            index, value
-        )
+        ).__setitem__(index, value)
     else:
-        getter = lambda self: store[  # pylint: disable=unnecessary-lambda-assignment
-            index
-        ]
+        getter = (
+            lambda self: store[index]  # pylint: disable=unnecessary-lambda-assignment
+        )
         setter = lambda self, value: store.__setitem__(  # pylint: disable=unnecessary-lambda-assignment
             index, value
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ enable = "all"
 disable = [
     "duplicate-code",     # TBD
     "file-ignored",       # ONLY to be used with extreme care.
-    "format",             # NOT wanted, handled by black
+    "format",             # NOT wanted, handled by ruff
     "locally-disabled",   # NOT wanted
     "suppressed-message"  # NOT wanted"""
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ development = [
     "pytest-cov>=4.1.0",
     "pytest-timeout>=2.2.0",
     "pytest-xdist>=3.3.1",
-    "ruff>=0.0.287",
+    "ruff>=0.1.0",
     "twine>=4.0.2",
     "types-Pygments",
     "types-pyserial"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,10 @@
 target-version="py38"
 exclude = [
-    "pymodbus/transport/serial_asyncio",
     "venv",
     ".venv",
     ".git",
     "build",
+    "doc"
 ]
 ignore = [
     "D202",  # No blank lines allowed after function docstring (to work with black)

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,7 +19,7 @@ ignore = [
     "RUF013",  # implicit Optional
     "RUF015"  # next(iter(list)) instead of list[0]
 ]
-line-length = 120
+line-length = 88
 select = [
     "B007",   # Loop control variable {name} not used within loop body
     "B014",   # Exception handler with duplicate exception

--- a/test/sub_messages/test_register_read_messages.py
+++ b/test/sub_messages/test_register_read_messages.py
@@ -58,8 +58,7 @@ class TestReadRegisterMessages:
             ReadWriteMultipleRegistersRequest(
                 write_registers=0xAB,
                 **arguments,
-            ): b"\x00\x01\x00\x05\x00\x01\x00"
-            b"\x01\x02\x00\xAB",
+            ): b"\x00\x01\x00\x05\x00\x01\x00" b"\x01\x02\x00\xAB",
         }
         self.response_read = {
             ReadRegistersResponseBase(self.values): TEST_MESSAGE,

--- a/test/sub_server/test_server_asyncio.py
+++ b/test/sub_server/test_server_asyncio.py
@@ -323,13 +323,13 @@ class TestAsyncioServer:
 
     async def test_async_udp_server_roundtrip(self):
         """Test sending and receiving data on udp socket"""
-        expected_response = b"\x01\x00\x00\x00\x00\x05\x01\x03\x02\x00\x11"  # value of 17 as per context
+        expected_response = (
+            b"\x01\x00\x00\x00\x00\x05\x01\x03\x02\x00\x11"
+        )  # value of 17 as per context
         BasicClient.dataTo = TEST_DATA  # slave 1, read register
         BasicClient.done = asyncio.Future()
         await self.start_server(do_udp=True)
-        random_port = self.server.transport._sock.getsockname()[  # pylint: disable=protected-access
-            1
-        ]
+        random_port = self.server.transport._sock.getsockname()[1]  # pylint: disable=protected-access
         transport, _ = await self.loop.create_datagram_endpoint(
             BasicClient, remote_addr=("127.0.0.1", random_port)
         )

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -65,10 +65,8 @@ class TestTransaction:  # pylint: disable=too-many-public-methods
         self._tm.client = mock.MagicMock()
         self._tm.client.framer = mock.MagicMock()
         self._tm._set_adu_size()  # pylint: disable=protected-access
-        assert (
-            not self._tm._calculate_response_length(  # pylint: disable=protected-access
-                0
-            )
+        assert not self._tm._calculate_response_length(  # pylint: disable=protected-access
+            0
         )
         self._tm.base_adu_size = 10
         assert (


### PR DESCRIPTION
Note that black has a default `line-length: 88` which differed from the `110` which was used (but ignored) for `ruff`.
