### PR TITLE
Eliminate implicit optional in simulator

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -1,4 +1,6 @@
 """Pymodbus ModbusSimulatorContext."""
+from __future__ import annotations
+
 import dataclasses
 import random
 import struct
@@ -30,7 +32,7 @@ class Cell:
     access: bool = False
     value: int = 0
     action: int = 0
-    action_kwargs: Dict[str, Any] = None
+    action_kwargs: Dict[str, Any] | None = None
     count_read: int = 0
     count_write: int = 0
 

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -5,7 +5,7 @@ import dataclasses
 import random
 import struct
 from datetime import datetime
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 
 WORD_SIZE = 16
@@ -32,7 +32,7 @@ class Cell:
     access: bool = False
     value: int = 0
     action: int = 0
-    action_kwargs: Dict[str, Any] | None = None
+    action_kwargs: dict[str, Any] | None = None
     count_read: int = 0
     count_write: int = 0
 
@@ -454,18 +454,18 @@ class ModbusSimulatorContext:
     start_time = int(datetime.now().timestamp())
 
     def __init__(
-        self, config: Dict[str, Any], custom_actions: Dict[str, Callable]
+        self, config: dict[str, Any], custom_actions: dict[str, Callable]
     ) -> None:
         """Initialize."""
-        self.registers: List[int] = []
-        self.fc_offset: Dict[int, int] = {}
+        self.registers: list[int] = []
+        self.fc_offset: dict[int, int] = {}
         self.register_count = 0
         self.type_exception = False
-        self.action_name_to_id: Dict[str, int] = {}
-        self.action_id_to_name: List[str] = []
-        self.action_methods: List[Callable] = []
-        self.registerType_name_to_id: Dict[str, int] = {}
-        self.registerType_id_to_name: List[str] = []
+        self.action_name_to_id: dict[str, int] = {}
+        self.action_id_to_name: list[str] = []
+        self.action_methods: list[Callable] = []
+        self.registerType_name_to_id: dict[str, int] = {}
+        self.registerType_id_to_name: list[str] = []
         Setup(self).setup(config, custom_actions)
 
     # --------------------------------------------

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -8,7 +8,6 @@ import importlib
 import json
 import os
 from time import time
-from typing import List
 
 
 try:
@@ -202,8 +201,8 @@ class ModbusSimulatorServer:
             with open(html_file, encoding="utf-8") as handle:
                 self.generator_html[entry][0] = handle.read()
         self.refresh_rate = 0
-        self.register_filter: List[int] = []
-        self.call_list: List[tuple] = []
+        self.register_filter: list[int] = []
+        self.call_list: list[tuple] = []
         self.request_lookup = ServerDecoder.getFCdict()
         self.call_monitor = CallTypeMonitor()
         self.call_response = CallTypeResponse()

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -1,4 +1,6 @@
 """HTTP server for modbus simulator."""
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import dataclasses
@@ -118,7 +120,7 @@ class ModbusSimulatorServer:
         http_port: int = 8080,
         log_file: str = "server.log",
         json_file: str = "setup.json",
-        custom_actions_module: str = None,
+        custom_actions_module: str | None = None,
     ):
         """Initialize http interface."""
         if AIOHTTP_MISSING:
@@ -139,7 +141,7 @@ class ModbusSimulatorServer:
             actions_module = importlib.import_module(custom_actions_module)
             custom_actions_dict = actions_module.custom_actions_dict
         else:
-            custom_actions_dict = None
+            custom_actions_dict = {}
         server = setup["server_list"][modbus_server]
         if server["comm"] != "serial":
             server["address"] = (server["host"], server["port"])
@@ -147,7 +149,7 @@ class ModbusSimulatorServer:
             del server["port"]
         device = setup["device_list"][modbus_device]
         self.datastore_context = ModbusSimulatorContext(
-            device, custom_actions_dict or None
+            device, custom_actions_dict or {}
         )
         datastore = ModbusServerContext(slaves=self.datastore_context, single=True)
         comm = comm_class[server.pop("comm")]


### PR DESCRIPTION
This eliminates another 3 implicit optional in the simulator.

Since we're already doing `from __future__ import annotations`, also eliminate

```
from typing import List
List[x]
```
in favor of just `list[x]`
