### PR TITLE
Do not attempt to close an already-closed serial connection

### DIFF
--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -51,8 +51,9 @@ class SerialTransport(asyncio.Transport):
             self.async_loop.remove_reader(self.sync_serial.fileno())
         self.sync_serial.close()
         self.sync_serial = None
-        with contextlib.suppress(Exception):
-            self._protocol.connection_lost(exc)
+        if exc:
+            with contextlib.suppress(Exception):
+                self._protocol.connection_lost(exc)
 
     def write(self, data) -> None:
         """Write some data to the transport."""


### PR DESCRIPTION
For some reason `close()` calls `connection_lost()`... which calls `close()`.

Closes #1847, but I'm not sure if this is the best approach.

