### PR TITLE
Avoid malicious user path input

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -259,8 +259,7 @@ class ModbusSimulatorServer:
         """Handle static html."""
         if not (page := request.path[1:]):
             page = "index.html"
-        unsafe_file = os.path.join(self.web_path, page)
-        file = os.path.normpath(unsafe_file)
+        file = os.path.normpath(os.path.join(self.web_path, page))
         if not file.startswith(self.web_path):
             raise ValueError(f"File access outside {self.web_path} not permitted.")
         try:

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -259,7 +259,10 @@ class ModbusSimulatorServer:
         """Handle static html."""
         if not (page := request.path[1:]):
             page = "index.html"
-        file = os.path.join(self.web_path, page)
+        unsafe_file = os.path.join(self.web_path, page)
+        file = os.path.normpath(unsafe_file)
+        if not file.startswith(self.web_path):
+            raise ValueError(f"File access outside {self.web_path} not permitted.")
         try:
             with open(file, encoding="utf-8"):
                 return web.FileResponse(file)


### PR DESCRIPTION
Closes the applicable CodeQL scanning alert
