### PR TITLE
Eliminate remaining implicit optional

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -156,10 +156,14 @@ class ModbusProtocol(asyncio.BaseProtocol):
         self.is_server = is_server
         self.is_closing = False
 
-        self.transport: asyncio.BaseTransport = None
-        self.loop: asyncio.AbstractEventLoop = None
+        self.loop: asyncio.AbstractEventLoop = None  # type: ignore[assignment]
+        self.transport: asyncio.BaseTransport | None = None
         self.recv_buffer: bytes = b""
-        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None
+
+        async def _noop():
+            ...
+
+        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = _noop
         if self.is_server:
             self.active_connections: dict[str, ModbusProtocol] = {}
         else:
@@ -398,11 +402,11 @@ class ModbusProtocol(asyncio.BaseProtocol):
             self.sent_buffer += data
         if self.comm_params.comm_type == CommType.UDP:
             if addr:
-                self.transport.sendto(data, addr=addr)  # type: ignore[attr-defined]
+                self.transport.sendto(data, addr=addr)  # type: ignore[union-attr]
             else:
-                self.transport.sendto(data)  # type: ignore[attr-defined]
+                self.transport.sendto(data)  # type: ignore[union-attr]
         else:
-            self.transport.write(data)  # type: ignore[attr-defined]
+            self.transport.write(data)  # type: ignore[union-attr]
 
     def transport_close(self, intern: bool = False, reconnect: bool = False) -> None:
         """Close connection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ overgeneral-exceptions = "builtins.Exception"
 bad-functions = "map,input"
 
 [tool.mypy]
-strict_optional = false
+strict_optional = true
 show_error_codes = true
 local_partial_types = true
 strict_equality = true


### PR DESCRIPTION
In most cases, expanding the type to include `| None` is all that was required.

In others, I needed to add a simple check: `AssertionError` or similar.

I have split the changes into 3 commits, in case some are too much for one PR.