### PR TITLE
Fix broken server examples

### DIFF
--- a/examples/client_sync.py
+++ b/examples/client_sync.py
@@ -37,6 +37,7 @@ import helper
 # --------------------------------------------------------------------------- #
 # import the various client implementations
 # --------------------------------------------------------------------------- #
+from pymodbus import Framer
 from pymodbus.client import (
     ModbusSerialClient,
     ModbusTcpClient,
@@ -63,7 +64,7 @@ def setup_sync_client(description=None, cmdline=None):
             args.host,
             port=args.port,
             # Common optional parameters:
-            framer=args.framer,
+            framer=Framer(args.framer),
             timeout=args.timeout,
             #    retries=3,
             #    retry_on_empty=False,y
@@ -77,7 +78,7 @@ def setup_sync_client(description=None, cmdline=None):
             args.host,
             port=args.port,
             # Common optional parameters:
-            framer=args.framer,
+            framer=Framer(args.framer),
             timeout=args.timeout,
             #    retries=3,
             #    retry_on_empty=False,
@@ -108,7 +109,7 @@ def setup_sync_client(description=None, cmdline=None):
             args.host,
             port=args.port,
             # Common optional parameters:
-            framer=args.framer,
+            framer=Framer(args.framer),
             timeout=args.timeout,
             #    retries=3,
             #    retry_on_empty=False,

--- a/examples/server_async.py
+++ b/examples/server_async.py
@@ -38,6 +38,7 @@ import logging
 import helper
 
 from pymodbus import __version__ as pymodbus_version
+from pymodbus import Framer
 from pymodbus.datastore import (
     ModbusSequentialDataBlock,
     ModbusServerContext,
@@ -71,7 +72,7 @@ def setup_server(description=None, context=None, cmdline=None):
         # This is because many devices exhibit this kind of behavior (but not all)
         if args.store == "sequential":
             # Continuing, use a sequential block without gaps.
-            datablock = ModbusSequentialDataBlock(0x00, [17] * 100)
+            datablock = ModbusSequentialDataBlock(0x00, [1, 0 , 0] * 100)
         elif args.store == "sparse":
             # Continuing, or use a sparse DataBlock which can have gaps
             datablock = ModbusSparseDataBlock({0x00: 0, 0x05: 1})
@@ -155,7 +156,7 @@ async def run_async_server(args):
             # TBD port=
             address=address,  # listen address
             # custom_functions=[],  # allow custom handling
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             # ignore_missing_slaves=True,  # ignore request to a missing slave
             # broadcast_enable=False,  # treat slave_id 0 as broadcast address,
             # timeout=1,  # waiting time for request to complete
@@ -171,7 +172,7 @@ async def run_async_server(args):
             identity=args.identity,  # server identify
             address=address,  # listen address
             # custom_functions=[],  # allow custom handling
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             # ignore_missing_slaves=True,  # ignore request to a missing slave
             # broadcast_enable=False,  # treat slave_id 0 as broadcast address,
             # timeout=1,  # waiting time for request to complete
@@ -186,7 +187,7 @@ async def run_async_server(args):
             # timeout=1,  # waiting time for request to complete
             port=args.port,  # serial port
             # custom_functions=[],  # allow custom handling
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             # stopbits=1,  # The number of stop bits to use
             # bytesize=8,  # The bytesize of the serial messages
             # parity="N",  # Which kind of parity to use
@@ -205,7 +206,7 @@ async def run_async_server(args):
             identity=args.identity,  # server identify
             # custom_functions=[],  # allow custom handling
             address=address,  # listen address
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             certfile=helper.get_certificate(
                 "crt"
             ),  # The cert file path for TLS (used if sslctx is None)

--- a/examples/server_async.py
+++ b/examples/server_async.py
@@ -72,7 +72,7 @@ def setup_server(description=None, context=None, cmdline=None):
         # This is because many devices exhibit this kind of behavior (but not all)
         if args.store == "sequential":
             # Continuing, use a sequential block without gaps.
-            datablock = ModbusSequentialDataBlock(0x00, [1, 0 , 0] * 100)
+            datablock = ModbusSequentialDataBlock(0x00, [17] * 100)
         elif args.store == "sparse":
             # Continuing, or use a sparse DataBlock which can have gaps
             datablock = ModbusSparseDataBlock({0x00: 0, 0x05: 1})

--- a/examples/server_sync.py
+++ b/examples/server_sync.py
@@ -39,6 +39,7 @@ import logging
 import helper
 import server_async
 
+from pymodbus import Framer
 # --------------------------------------------------------------------------- #
 # import the various client implementations
 # --------------------------------------------------------------------------- #
@@ -67,7 +68,7 @@ def run_sync_server(args):
             # TBD port=
             address=address,  # listen address
             # custom_functions=[],  # allow custom handling
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             # ignore_missing_slaves=True,  # ignore request to a missing slave
             # broadcast_enable=False,  # treat slave_id 0 as broadcast address,
             # timeout=1,  # waiting time for request to complete
@@ -80,7 +81,7 @@ def run_sync_server(args):
             identity=args.identity,  # server identify
             address=address,  # listen address
             # custom_functions=[],  # allow custom handling
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             # ignore_missing_slaves=True,  # ignore request to a missing slave
             # broadcast_enable=False,  # treat slave_id 0 as broadcast address,
             # timeout=1,  # waiting time for request to complete
@@ -95,7 +96,7 @@ def run_sync_server(args):
             # timeout=1,  # waiting time for request to complete
             port=args.port,  # serial port
             # custom_functions=[],  # allow custom handling
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             # stopbits=1,  # The number of stop bits to use
             # bytesize=7,  # The bytesize of the serial messages
             # parity="E",  # Which kind of parity to use
@@ -114,7 +115,7 @@ def run_sync_server(args):
             identity=args.identity,  # server identify
             # custom_functions=[],  # allow custom handling
             address=address,  # listen address
-            framer=args.framer,  # The framer strategy to use
+            framer=Framer(args.framer),  # The framer strategy to use
             certfile=helper.get_certificate(
                 "crt"
             ),  # The cert file path for TLS (used if sslctx is None)
@@ -134,8 +135,7 @@ def run_sync_server(args):
 def sync_helper():
     """Combine setup and run."""
     run_args = server_async.setup_server(description="Run synchronous server.")
-    server = run_sync_server(run_args)
-    server.shutdown()
+    run_sync_server(run_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current examples for server scripts are not able to communicate back due to bad framer arguments. 

The examples through the helper function that parse the argument only produce a string and is directly passed through the class arguments causing the framer attribute of the server to be a string instead of Framer object. 

This commit fix that problem.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
