### PR TITLE
Eliminate more implicit optional (client transport)

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -167,7 +167,6 @@ class ModbusSerialClient(ModbusBaseClient):
         **kwargs: Any,
     ) -> None:
         """Initialize Modbus Serial Client."""
-        self.transport = None
         kwargs["use_sync"] = True
         super().__init__(
             framer,

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -149,7 +149,6 @@ class ModbusTcpClient(ModbusBaseClient):
         if "CommType" not in kwargs:
             kwargs["CommType"] = CommType.TCP
         kwargs["use_sync"] = True
-        self.transport = None
         super().__init__(
             framer,
             host=host,
@@ -160,7 +159,7 @@ class ModbusTcpClient(ModbusBaseClient):
         self.socket = None
 
     @property
-    def connected(self):
+    def connected(self) -> bool:
         """Connect internal."""
         return self.socket is not None
 

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -156,7 +156,6 @@ class ModbusTlsClient(ModbusTcpClient):
         **kwargs: Any,
     ):
         """Initialize Modbus TLS Client."""
-        self.transport = None
         super().__init__(
             host, CommType=CommType.TLS, port=port, framer=framer, **kwargs
         )
@@ -166,7 +165,7 @@ class ModbusTlsClient(ModbusTcpClient):
         self.params.server_hostname = server_hostname
 
     @property
-    def connected(self):
+    def connected(self) -> bool:
         """Connect internal."""
         return self.transport is not None
 

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -151,7 +151,6 @@ class ModbusUdpClient(ModbusBaseClient):
     ) -> None:
         """Initialize Modbus UDP Client."""
         kwargs["use_sync"] = True
-        self.transport = None
         super().__init__(
             framer,
             port=port,
@@ -164,7 +163,7 @@ class ModbusUdpClient(ModbusBaseClient):
         self.socket = None
 
     @property
-    def connected(self):
+    def connected(self) -> bool:
         """Connect internal."""
         return self.socket is not None
 


### PR DESCRIPTION
There is no particular reason to set `self.transport = None`, so just ... remove those lines :)

This solves another 4 `mypy` errors.