### PR TITLE
Eliminate more implicit optionals in transport

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -159,7 +159,11 @@ class ModbusProtocol(asyncio.BaseProtocol):
         self.transport: asyncio.BaseTransport = None
         self.loop: asyncio.AbstractEventLoop = None
         self.recv_buffer: bytes = b""
-        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None
+
+        async def _noop():
+            ...
+
+        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = _noop
         if self.is_server:
             self.active_connections: dict[str, ModbusProtocol] = {}
         else:

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -159,7 +159,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
         self.transport: asyncio.BaseTransport = None
         self.loop: asyncio.AbstractEventLoop = None
         self.recv_buffer: bytes = b""
-        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None
+        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None  # type: ignore[assignment]
         if self.is_server:
             self.active_connections: dict[str, ModbusProtocol] = {}
         else:

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -159,11 +159,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
         self.transport: asyncio.BaseTransport = None
         self.loop: asyncio.AbstractEventLoop = None
         self.recv_buffer: bytes = b""
-
-        async def _noop():
-            ...
-
-        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = _noop
+        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None
         if self.is_server:
             self.active_connections: dict[str, ModbusProtocol] = {}
         else:

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -524,7 +524,7 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         asyncio.DatagramTransport.__init__(self)
         asyncio.Transport.__init__(self)
         self.protocol: ModbusProtocol = protocol
-        self.other_modem: NullModem = None
+        self.other_modem: NullModem
         self.listen = listen
         self.manipulator: Callable[[bytes], list[bytes]] | None = None
         self._is_closing = False
@@ -597,10 +597,10 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         if self.connections:
             with suppress(KeyError):
                 del self.connections[self]
-        if self.other_modem:
-            self.other_modem.other_modem = None
+        if hasattr(self, 'other_modem'):
+            del self.other_modem.other_modem
             self.other_modem.close()
-            self.other_modem = None
+            del self.other_modem
         if self.protocol:
             self.protocol.connection_lost(None)
 

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -38,7 +38,7 @@ class SerialTransport(asyncio.Transport):
 
     def close(self, exc: Exception | None = None) -> None:
         """Close the transport gracefully."""
-        if not self.sync_serial:
+        if not hasattr(self, 'sync_serial'):
             return
         with contextlib.suppress(Exception):
             self.sync_serial.flush()
@@ -51,7 +51,7 @@ class SerialTransport(asyncio.Transport):
         else:
             self.async_loop.remove_reader(self.sync_serial.fileno())
         self.sync_serial.close()
-        self.sync_serial = None
+        del self.sync_serial
         if exc:
             with contextlib.suppress(Exception):
                 self._protocol.connection_lost(exc)


### PR DESCRIPTION
Instead of 
```python
if foo [is not None]:
  foo = None
```

use 
```python
if hasattr(self, 'foo'):
  del foo
```

Also, revert https://github.com/pymodbus-dev/pymodbus/pull/1859

`pymodbus/transport/transport.py:255: error: "None" not callable  [misc]`