### PR TITLE
Ignore all remaining implicit optional

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -517,7 +517,7 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         asyncio.DatagramTransport.__init__(self)
         asyncio.Transport.__init__(self)
         self.protocol: ModbusProtocol = protocol
-        self.other_modem: NullModem = None
+        self.other_modem: NullModem
         self.listen = listen
         self.manipulator: Callable[[bytes], list[bytes]] | None = None
         self._is_closing = False
@@ -590,10 +590,10 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         if self.connections:
             with suppress(KeyError):
                 del self.connections[self]
-        if self.other_modem:
-            self.other_modem.other_modem = None
+        if hasattr(self, "other_modem"):
+            del self.other_modem.other_modem
             self.other_modem.close()
-            self.other_modem = None
+            del self.other_modem
         if self.protocol:
             self.protocol.connection_lost(None)
 

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -517,7 +517,7 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         asyncio.DatagramTransport.__init__(self)
         asyncio.Transport.__init__(self)
         self.protocol: ModbusProtocol = protocol
-        self.other_modem: NullModem
+        self.other_modem: NullModem = None
         self.listen = listen
         self.manipulator: Callable[[bytes], list[bytes]] | None = None
         self._is_closing = False
@@ -590,10 +590,10 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         if self.connections:
             with suppress(KeyError):
                 del self.connections[self]
-        if hasattr(self, "other_modem"):
-            del self.other_modem.other_modem
+        if self.other_modem:
+            self.other_modem.other_modem = None
             self.other_modem.close()
-            del self.other_modem
+            self.other_modem = None
         if self.protocol:
             self.protocol.connection_lost(None)
 

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -517,7 +517,7 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
         asyncio.DatagramTransport.__init__(self)
         asyncio.Transport.__init__(self)
         self.protocol: ModbusProtocol = protocol
-        self.other_modem: NullModem = None
+        self.other_modem: NullModem = None  # type: ignore[assignment]
         self.listen = listen
         self.manipulator: Callable[[bytes], list[bytes]] | None = None
         self._is_closing = False
@@ -591,9 +591,9 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
             with suppress(KeyError):
                 del self.connections[self]
         if self.other_modem:
-            self.other_modem.other_modem = None
+            self.other_modem.other_modem = None  # type: ignore[assignment]
             self.other_modem.close()
-            self.other_modem = None
+            self.other_modem = None  # type: ignore[assignment]
         if self.protocol:
             self.protocol.connection_lost(None)
 

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -156,10 +156,10 @@ class ModbusProtocol(asyncio.BaseProtocol):
         self.is_server = is_server
         self.is_closing = False
 
-        self.transport: asyncio.BaseTransport = None
-        self.loop: asyncio.AbstractEventLoop = None
+        self.transport: asyncio.BaseTransport = None  # type: ignore[assignment]
+        self.loop: asyncio.AbstractEventLoop = None  # type: ignore[assignment]
         self.recv_buffer: bytes = b""
-        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None
+        self.call_create: Callable[[], Coroutine[Any, Any, Any]] = lambda: None  # type: ignore[assignment, return-value]
         if self.is_server:
             self.active_connections: dict[str, ModbusProtocol] = {}
         else:
@@ -415,7 +415,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
             if hasattr(self.transport, "abort"):
                 self.transport.abort()
             self.transport.close()
-            self.transport = None
+            self.transport = None  # type: ignore[assignment]
         self.recv_buffer = b""
         if self.is_server:
             for _key, value in self.active_connections.items():

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -51,7 +51,7 @@ class SerialTransport(asyncio.Transport):
         else:
             self.async_loop.remove_reader(self.sync_serial.fileno())
         self.sync_serial.close()
-        self.sync_serial = None
+        self.sync_serial = None  # type: ignore[assignment]
         if exc:
             with contextlib.suppress(Exception):
                 self._protocol.connection_lost(exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ overgeneral-exceptions = "builtins.Exception"
 bad-functions = "map,input"
 
 [tool.mypy]
-strict_optional = false
+strict_optional = true
 show_error_codes = true
 local_partial_types = true
 strict_equality = true


### PR DESCRIPTION
See #1875, #1873, #1856

Since there's not an agreed way to eliminate the final implicit optionals, ignore them instead.
