### PR TITLE
Update transport.py

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -414,7 +414,8 @@ class ModbusProtocol(asyncio.BaseProtocol):
         if self.transport:
             if hasattr(self.transport, "abort"):
                 self.transport.abort()
-            self.transport.close()
+            else:
+                self.transport.close()
             self.transport = None
         self.recv_buffer = b""
         if self.is_server:


### PR DESCRIPTION
transport.abort() is already contains transport.close(), and it would cause error when transport.close() occurs after transport.abort()

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
