### PR TITLE
Remove unnecessary abort() call

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -412,8 +412,6 @@ class ModbusProtocol(asyncio.BaseProtocol):
         if not intern:
             self.is_closing = True
         if self.transport:
-            if hasattr(self.transport, "abort"):
-                self.transport.abort()
             self.transport.close()
             self.transport = None
         self.recv_buffer = b""
@@ -614,7 +612,7 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
     # Dummy methods #
     # ------------- #
     def abort(self) -> None:
-        """Abort connection."""
+        """Old alias for closing the connection."""
         self.close()
 
     def can_write_eof(self) -> bool:

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -612,7 +612,7 @@ class NullModem(asyncio.DatagramTransport, asyncio.Transport):
     # Dummy methods #
     # ------------- #
     def abort(self) -> None:
-        """Old alias for closing the connection."""
+        """Alias for closing the connection."""
         self.close()
 
     def can_write_eof(self) -> bool:

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -117,7 +117,7 @@ class SerialTransport(asyncio.Transport):
         return False
 
     def abort(self) -> None:
-        """Close the transport immediately."""
+        """Old alias for closing the connection."""
         self.close()
 
     # ------------------------------------------------

--- a/pymodbus/transport/transport_serial.py
+++ b/pymodbus/transport/transport_serial.py
@@ -117,7 +117,7 @@ class SerialTransport(asyncio.Transport):
         return False
 
     def abort(self) -> None:
-        """Old alias for closing the connection."""
+        """Alias for closing the connection."""
         self.close()
 
     # ------------------------------------------------

--- a/test/sub_transport/test_basic.py
+++ b/test/sub_transport/test_basic.py
@@ -188,13 +188,11 @@ class TestBasicModbusProtocol:
 
     async def test_transport_close(self, server, dummy_protocol):
         """Test transport_close()."""
-        dummy_protocol.abort = mock.MagicMock()
         dummy_protocol.close = mock.MagicMock()
         server.connection_made(dummy_protocol())
         server.recv_buffer = b"abc"
         server.reconnect_task = mock.MagicMock()
         server.transport_close()
-        dummy_protocol.abort.assert_called_once()
         dummy_protocol.close.assert_called_once()
         assert not server.recv_buffer
         await server.transport_listen()


### PR DESCRIPTION
Supercedes #1889


See rationale in https://github.com/pymodbus-dev/pymodbus/pull/1889#issuecomment-1813056191