### PR TITLE
Truncated duration to milliseconds

### DIFF
--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -287,7 +287,7 @@ class ModbusTcpClient(ModbusBaseSyncClient):
         readsize = f"read of {size_txt} bytes"
         msg = (
             f"{self}: Connection unexpectedly closed "
-            f"{duration} seconds into {readsize}"
+            f"{duration:.3f} seconds into {readsize}"
         )
         if data:
             result = b"".join(data)


### PR DESCRIPTION
As log messages such as `Connection unexpectedly closed 1.049041748046875e-05 seconds into read of 8 bytes without response from slave before it closed connection` is not very readable, I suggest that duration is truncated to milliseconds in `Connection unexpectedly closed`.
