### PR TITLE
Bugfix Fix: default source_address invalid for IPv6

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -66,7 +66,7 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
             CommParams(
                 comm_type=kwargs.get("CommType"),
                 comm_name="comm",
-                source_address=kwargs.get("source_address", ("0.0.0.0", 0)),
+                source_address=kwargs.get("source_address", None),
                 reconnect_delay=reconnect_delay,
                 reconnect_delay_max=reconnect_delay_max,
                 timeout_connect=timeout,
@@ -358,7 +358,7 @@ class ModbusBaseSyncClient(ModbusClientMixin, ModbusProtocol):
             CommParams(
                 comm_type=kwargs.get("CommType"),
                 comm_name="comm",
-                source_address=kwargs.get("source_address", ("0.0.0.0", 0)),
+                source_address=kwargs.get("source_address", None),
                 reconnect_delay=reconnect_delay,
                 reconnect_delay_max=reconnect_delay_max,
                 timeout_connect=timeout,

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -54,7 +54,7 @@ import ssl
 import sys
 from contextlib import suppress
 from enum import Enum
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Coroutine, Optional
 
 from pymodbus.logging import Log
 from pymodbus.transport.transport_serial import create_serial_connection
@@ -92,7 +92,7 @@ class CommParams:
     timeout_connect: float | None = None
     host: str = "127.0.0.1"
     port: int = 0
-    source_address: tuple[str, int] = ("0.0.0.0", 0)
+    source_address: tuple[str, int] | None = None
     handle_local_echo: bool = False
 
     # tls


### PR DESCRIPTION
The source_address `0.0.0.0` is only valid for IPv4. For IPv6 this would need to be `::` but neither of these is valid for both IPv4 and IPv6 at the same time.  In python, `None` indicates any source address on either ip stack.

This PR fixes #1881