### PR TITLE
Fix behavior after Exception response

### DIFF
--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -77,7 +77,7 @@ class ModbusSocketFramer(ModbusFramer):
         it or determined that it contains an error. It also has to reset the
         current frame header handle
         """
-        length = self._hsize + self._header["len"] - 1
+        length = self._hsize + self._header["len"]
         self._buffer = self._buffer[length:]
         self._header = {"tid": 0, "pid": 0, "len": 0, "uid": 0}
 


### PR DESCRIPTION
Scenario: Read supported register, read unsupported register, read same supported register.
It should behave the same on 1st and 3rd read call.

Prior to #1924 the 2nd read call would termine the connection.
While the 2nd call now returns nicely with the correct error, the 3rd is failing in 3.6.3.

## Before this PR:

```python
------------------- Reading read 5011-5012...
2024-01-12 17:07:05,172 DEBUG logging:103 send: 0x0 0x2 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x92 0x0 0x1
2024-01-12 17:07:05,172 DEBUG logging:103 Adding transaction 2
2024-01-12 17:07:05,177 DEBUG logging:103 recv: 0x0 0x2 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x8 0xbc old_data:  addr=None
2024-01-12 17:07:05,177 DEBUG logging:103 Processing: 0x0 0x2 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x8 0xbc
2024-01-12 17:07:05,177 DEBUG logging:103 Factory Response[ReadInputRegistersResponse': 4]
2024-01-12 17:07:05,177 DEBUG logging:103 Getting transaction 2
------------------- Reading read 5009-5011...
2024-01-12 17:07:05,177 DEBUG logging:103 send: 0x0 0x3 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x90 0x0 0x2
2024-01-12 17:07:05,177 DEBUG logging:103 Adding transaction 3
2024-01-12 17:07:05,182 DEBUG logging:103 recv: 0x0 0x3 0x0 0x0 0x0 0x2 0x1 0x84 0x2 old_data:  addr=None
2024-01-12 17:07:05,182 DEBUG logging:103 Processing: 0x0 0x3 0x0 0x0 0x0 0x2 0x1 0x84 0x2
2024-01-12 17:07:05,182 DEBUG logging:103 Factory Response[132]
2024-01-12 17:07:05,182 DEBUG logging:103 Getting transaction 3
Exception Response(132, 4, IllegalAddress)
------------------- Reading 5011-5012...
2024-01-12 17:07:05,182 DEBUG logging:103 send: 0x0 0x4 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x92 0x0 0x1
2024-01-12 17:07:05,182 DEBUG logging:103 Adding transaction 4
2024-01-12 17:07:05,189 DEBUG logging:103 recv: 0x0 0x4 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x8 0xbc old_data:  addr=None
2024-01-12 17:07:05,189 DEBUG logging:103 Processing: 0x0 0x4 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x8 0xbc
2024-01-12 17:07:05,189 DEBUG logging:103 Frame check failed, ignoring!!
2024-01-12 17:07:07,185 DEBUG logging:103 send: 0x0 0x4 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x92 0x0 0x1
2024-01-12 17:07:07,185 DEBUG logging:103 Adding transaction 4
2024-01-12 17:07:07,191 DEBUG logging:103 recv: 0x0 0x4 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x8 0xb4 old_data:  addr=None
2024-01-12 17:07:07,191 DEBUG logging:103 Processing: 0x0 0x4 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x8 0xb4
2024-01-12 17:07:07,191 DEBUG logging:103 Frame check failed, ignoring!!
2024-01-12 17:07:09,188 DEBUG logging:103 Connection lost comm due to Server not responding
2024-01-12 17:07:09,188 DEBUG logging:103 Getting transaction 4
```

## After this PR:

```python
Reading read 5011-5012...
2024-01-12 17:31:20,057 DEBUG logging:103 send: 0x0 0x2 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x92 0x0 0x1
2024-01-12 17:31:20,057 DEBUG logging:103 Adding transaction 2
2024-01-12 17:31:20,061 DEBUG logging:103 recv: 0x0 0x2 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x7 0x44 old_data:  addr=None
2024-01-12 17:31:20,061 DEBUG logging:103 Processing: 0x0 0x2 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x7 0x44
2024-01-12 17:31:20,061 DEBUG logging:103 Factory Response[ReadInputRegistersResponse': 4]
2024-01-12 17:31:20,061 DEBUG logging:103 Getting transaction 2
Reading read 5009-5011...
2024-01-12 17:31:20,061 DEBUG logging:103 send: 0x0 0x3 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x90 0x0 0x2
2024-01-12 17:31:20,062 DEBUG logging:103 Adding transaction 3
2024-01-12 17:31:20,067 DEBUG logging:103 recv: 0x0 0x3 0x0 0x0 0x0 0x2 0x1 0x84 0x2 old_data:  addr=None
2024-01-12 17:31:20,067 DEBUG logging:103 Processing: 0x0 0x3 0x0 0x0 0x0 0x2 0x1 0x84 0x2
2024-01-12 17:31:20,067 DEBUG logging:103 Factory Response[132]
2024-01-12 17:31:20,067 DEBUG logging:103 Getting transaction 3
Exception Response(132, 4, IllegalAddress)
Reading read 5011-5012...
2024-01-12 17:31:20,067 DEBUG logging:103 send: 0x0 0x4 0x0 0x0 0x0 0x6 0x1 0x4 0x13 0x92 0x0 0x1
2024-01-12 17:31:20,067 DEBUG logging:103 Adding transaction 4
2024-01-12 17:31:20,073 DEBUG logging:103 recv: 0x0 0x4 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x7 0x44 old_data:  addr=None
2024-01-12 17:31:20,073 DEBUG logging:103 Processing: 0x0 0x4 0x0 0x0 0x0 0x5 0x1 0x4 0x2 0x7 0x44
2024-01-12 17:31:20,073 DEBUG logging:103 Factory Response[ReadInputRegistersResponse': 4]
2024-01-12 17:31:20,073 DEBUG logging:103 Getting transaction 4
```

## Tests
Unfortunately I was not able to figure out how to add a reasonable test here.
E.g. by extending `test_recv_socket_exception_packet()`.

I only run the example above. "Works on my machine".