### PR TITLE
Always set exclusive serial port access.

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -210,6 +210,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
                 stopbits=self.comm_params.stopbits,
                 baudrate=self.comm_params.baudrate,
                 parity=self.comm_params.parity,
+                exclusive=True,
             )
             if self.params.strict:
                 self.socket.interCharTimeout = self.inter_char_timeout

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -202,6 +202,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
                 parity=self.comm_params.parity,
                 stopbits=self.comm_params.stopbits,
                 timeout=self.comm_params.timeout_connect,
+                exclusive=True,
             )
             return
         if self.comm_params.comm_type == CommType.UDP:


### PR DESCRIPTION
Should prevent two applications from trying to access the same serial port simultaneously.

Alternative to #1961.