### PR TITLE
Test and correct receiving more than one packet

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -157,13 +157,13 @@ class ModbusBaseClient(ModbusClientMixin, ModbusProtocol):
 
         count = 0
         while count <= self.retries:
+            req = self.build_response(request.transaction_id)
             if not count or not self.no_resend_on_retry:
                 self.transport_send(packet)
             if self.broadcast_enable and not request.slave_id:
                 resp = b"Broadcast write sent - no response expected"
                 break
             try:
-                req = self.build_response(request.transaction_id)
                 resp = await asyncio.wait_for(
                     req, timeout=self.comm_params.timeout_connect
                 )

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -77,7 +77,7 @@ class ModbusSocketFramer(ModbusFramer):
         it or determined that it contains an error. It also has to reset the
         current frame header handle
         """
-        length = self._hsize + self._header["len"]
+        length = self._hsize + self._header["len"] -1
         self._buffer = self._buffer[length:]
         self._header = {"tid": 0, "pid": 0, "len": 0, "uid": 0}
 
@@ -129,15 +129,16 @@ class ModbusSocketFramer(ModbusFramer):
         The processed and decoded messages are pushed to the callback
         function to process and send.
         """
-        if not self.checkFrame():
-            Log.debug("Frame check failed, ignoring!!")
-            return
-        if not self._validate_slave_id(slave, single):
-            header_txt = self._header["uid"]
-            Log.debug("Not a valid slave id - {}, ignoring!!", header_txt)
-            self.resetFrame()
-            return
-        self._process(callback, tid)
+        while True:
+            if not self.checkFrame():
+                Log.debug("Frame check failed, ignoring!!")
+                return
+            if not self._validate_slave_id(slave, single):
+                header_txt = self._header["uid"]
+                Log.debug("Not a valid slave id - {}, ignoring!!", header_txt)
+                self.resetFrame()
+                return
+            self._process(callback, tid)
 
     def _process(self, callback, tid, error=False):
         """Process incoming packets irrespective error condition."""

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -96,7 +96,7 @@ class ModbusSocketFramer(ModbusFramer):
 
         :returns: The next full frame buffer
         """
-        length = self._hsize + self._header["len"] -1
+        length = self._hsize + self._header["len"]
         return self._buffer[self._hsize : length]
 
     # ----------------------------------------------------------------------- #

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -96,7 +96,7 @@ class ModbusSocketFramer(ModbusFramer):
 
         :returns: The next full frame buffer
         """
-        length = self._hsize + self._header["len"]
+        length = self._hsize + self._header["len"] -1
         return self._buffer[self._hsize : length]
 
     # ----------------------------------------------------------------------- #

--- a/pymodbus/transport/stub.py
+++ b/pymodbus/transport/stub.py
@@ -1,6 +1,8 @@
 """ModbusProtocol network stub."""
 from __future__ import annotations
 
+from typing import Callable
+
 from pymodbus.transport.transport import CommParams, ModbusProtocol
 
 
@@ -11,7 +13,7 @@ class ModbusProtocolStub(ModbusProtocol):
         self,
         params: CommParams,
         is_server: bool,
-        handler: callable | None = None,
+        handler: Callable[[bytes], bytes] | None = None,
     ) -> None:
         """Initialize a stub instance."""
         self.stub_handle_data = handler if handler else self.dummy_handler

--- a/pymodbus/transport/stub.py
+++ b/pymodbus/transport/stub.py
@@ -10,10 +10,8 @@ class ModbusProtocolStub(ModbusProtocol):
     async def start_run(self):
         """Call need functions to start server/client."""
         if  self.is_server:
-            await self.transport_listen()
-        else:
-            await self.transport_connect()
-        self.transport = self
+            return await self.transport_listen()
+        return await self.transport_connect()
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
@@ -21,11 +19,13 @@ class ModbusProtocolStub(ModbusProtocol):
             self.transport_send(response)
         return len(data)
 
+    def callback_new_connection(self) -> ModbusProtocol:
+        """Call when listener receive new connection request."""
+        return ModbusProtocolStub(self.comm_params, False)
+
     # ---------------- #
     # external methods #
     # ---------------- #
     def stub_handle_data(self, data: bytes) -> bytes | None:
         """Handle received data."""
-        if len(data) > 5:
-            return data
-        return None
+        return data

--- a/pymodbus/transport/stub.py
+++ b/pymodbus/transport/stub.py
@@ -10,8 +10,10 @@ class ModbusProtocolStub(ModbusProtocol):
     async def start_run(self):
         """Call need functions to start server/client."""
         if  self.is_server:
-            return await self.transport_listen()
-        return await self.transport_connect()
+            await self.transport_listen()
+        else:
+            await self.transport_connect()
+        self.transport = self
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""

--- a/pymodbus/transport/stub.py
+++ b/pymodbus/transport/stub.py
@@ -1,17 +1,29 @@
 """ModbusProtocol network stub."""
 from __future__ import annotations
 
-from pymodbus.transport.transport import ModbusProtocol
+from pymodbus.transport.transport import CommParams, ModbusProtocol
 
 
 class ModbusProtocolStub(ModbusProtocol):
     """Protocol layer including transport."""
+
+    def __init__(
+        self,
+        params: CommParams,
+        is_server: bool,
+        handler: callable | None = None,
+    ) -> None:
+        """Initialize a stub instance."""
+        self.stub_handle_data = handler if handler else self.dummy_handler
+        super().__init__(params, is_server)
+
 
     async def start_run(self):
         """Call need functions to start server/client."""
         if  self.is_server:
             return await self.transport_listen()
         return await self.transport_connect()
+
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
@@ -21,11 +33,13 @@ class ModbusProtocolStub(ModbusProtocol):
 
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
-        return ModbusProtocolStub(self.comm_params, False)
+        new_stub = ModbusProtocolStub(self.comm_params, False)
+        new_stub.stub_handle_data = self.stub_handle_data
+        return new_stub
 
     # ---------------- #
     # external methods #
     # ---------------- #
-    def stub_handle_data(self, data: bytes) -> bytes | None:
+    def dummy_handler(self, data: bytes) -> bytes | None:
         """Handle received data."""
         return data

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -33,7 +33,7 @@ class TestNetwork:
     async def test_double_packet(self, use_port, use_cls):
         """Test double packet on network."""
         old_data = b''
-        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port)
+        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port, retries=0)
 
         def local_handle_data(data: bytes) -> bytes | None:
             """Handle server side for this test case."""
@@ -70,6 +70,6 @@ class TestNetwork:
         await stub.start_run()
 
         assert await client.connect()
-        await asyncio.gather(*[local_call(x) for x in range(0, 8)])
+        await asyncio.gather(*[local_call(x) for x in range(1, 4)])
         client.transport_close()
         stub.transport_close()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -42,20 +42,28 @@ class TestNetwork:
             addr = int(data[9])
             response = data[0:5] + b'\x05\x00\x03\x02\x00' + (addr*10).to_bytes()
 
-            # 1, 4, 8 return correct data
+            # 1, 4, 7 return correct data
             # 2, 5 return NO data
             # 3 return 2 + 3
-            # 6 return 5 + half 6
-            # 7 return second half 6 + 7
-            if addr in (2, 0):
+            # 6 return 6 + 6 (wrong order
+            # 8 return 7 + half 8
+            # 9 return second half 8 + 9
+            if addr in (2, 5):
                 old_data = response
                 response = None
             elif addr == 3:
                 response = old_data + response
-            #elif addr == 6:
-            #    response = old_data
-            #elif addr == 7:
-            #    response = old_data
+                old_data = b''
+            elif addr == 6:
+                response = response + old_data
+                old_data = b''
+            elif addr == 8:
+                x =  response
+                response = response[:7]
+                old_data = x[7:]
+            elif addr == 9:
+                response = old_data + response
+                old_data = b''
             return response
 
         async def local_call(addr: int) -> bool:
@@ -70,6 +78,6 @@ class TestNetwork:
         await stub.start_run()
 
         assert await client.connect()
-        await asyncio.gather(*[local_call(x) for x in range(1, 4)])
+        await asyncio.gather(*[local_call(x) for x in range(1, 10)])
         client.transport_close()
         stub.transport_close()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -23,6 +23,8 @@ class TestNetwork:
         stub = ModbusProtocolStub(use_cls, True)
         assert await stub.start_run()
         assert await client.connect()
+        test_data = b"Data got echoed."
+        client.transport.write(test_data)
         client.transport_close()
         stub.transport_close()
 
@@ -33,7 +35,7 @@ class TestNetwork:
         stub = ModbusProtocolStub(use_cls, True)
         await stub.start_run()
         assert await client.connect()
-        await client.read_holding_registers(address=1, count=2)
+        # await client.read_holding_registers(address=1, count=2)
         # await asyncio.gather(*[client.read_holding_registers(address=x, count=2) for x in range(0, 1000, 100)])
         client.transport_close()
         stub.transport_close()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -42,7 +42,7 @@ class TestNetwork:
             nonlocal old_data
 
             addr = int(data[9])
-            response = data[0:5] + b'\x05\x00\x03\x02\x00' + (addr*10).to_bytes()
+            response = data[0:5] + b'\x05\x00\x03\x02\x00' + (addr*10).to_bytes(1, 'big')
 
             # 1, 4, 7 return correct data
             # 2, 5 return NO data

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -37,21 +37,21 @@ class TestNetwork:
             nonlocal old_data
 
             addr = int(data[9])
+            response = data[0:5] + b'\x05\x00\x03\x02\x00' + (addr+10).to_bytes()
+
             # 1, 4, 8 return correct data
             # 2, 5 return NO data
             # 3 return 2 + 3
             # 6 return 5 + half 6
             # 7 return second half 6 + 7
-
-            response = data[0:5] + b'\x05\x00\x03\x02\x00' + (addr+10).to_bytes()
             if addr in (2, 5):
-                return None
+                response = None
             elif addr == 3:
-                return old_data
+                response = old_data
             elif addr == 6:
-                return old_data
+                response = old_data
             elif addr == 7:
-                return old_data
+                response = old_data
             return response
 
         stub = ModbusProtocolStub(use_cls, True, handler=local_handle_data)

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,5 +1,4 @@
 """Test transport."""
-
 import pytest
 
 from pymodbus.client import AsyncModbusTcpClient
@@ -24,5 +23,17 @@ class TestNetwork:
         stub = ModbusProtocolStub(use_cls, True)
         assert await stub.start_run()
         assert await client.connect()
+        client.transport_close()
+        stub.transport_close()
+
+    async def test_double_packet(self, use_port, use_cls):
+        """Test double packet on network."""
+        Log.debug("test_double_packet {}", use_port)
+        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port)
+        stub = ModbusProtocolStub(use_cls, True)
+        await stub.start_run()
+        assert await client.connect()
+        await client.read_holding_registers(address=1, count=2)
+        # await asyncio.gather(*[client.read_holding_registers(address=x, count=2) for x in range(0, 1000, 100)])
         client.transport_close()
         stub.transport_close()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -30,12 +30,24 @@ class TestNetwork:
 
     async def test_double_packet(self, use_port, use_cls):
         """Test double packet on network."""
-        Log.debug("test_double_packet {}", use_port)
-        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port)
-        stub = ModbusProtocolStub(use_cls, True)
+        old_data = b''
+
+        def local_handle_data(data: bytes) -> bytes | None:
+            """Handle server side for this test case."""
+            nonlocal old_data
+
+            addr = int(data[9])
+            if addr == 1:
+                return None
+            return data
+
+        stub = ModbusProtocolStub(use_cls, True, handler=local_handle_data)
+        stub.stub_handle_data = local_handle_data
         await stub.start_run()
+
+        client = AsyncModbusTcpClient(NULLMODEM_HOST, port=use_port)
         assert await client.connect()
-        # await client.read_holding_registers(address=1, count=2)
+        await client.read_holding_registers(address=10, count=2)
         # await asyncio.gather(*[client.read_holding_registers(address=x, count=2) for x in range(0, 1000, 100)])
         client.transport_close()
         stub.transport_close()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,4 +1,6 @@
 """Test transport."""
+from __future__ import annotations
+
 import asyncio
 
 import pytest
@@ -48,7 +50,7 @@ class TestNetwork:
             # 6 return 6 + 6 (wrong order
             # 8 return 7 + half 8
             # 9 return second half 8 + 9
-            if addr in (2, 5):
+            if addr in {2, 5}:
                 old_data = response
                 response = None
             elif addr == 3:


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
fixes #1949 

First a new test case is made to show the problem.

There was a problem in advanceFrame, but with this PR we actually silently support multiple parallel calls in async mode.

the suggestion for a change in getFrame, was not correct, it does not work for exception respons