### PR TITLE
Revert "Make client type annotations compatible with async client usage (#1842)"

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import struct
-from collections.abc import Awaitable
 from enum import Enum
 from typing import Any
 
@@ -47,9 +46,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
     def __init__(self):
         """Initialize."""
 
-    def execute(
-        self, _request: ModbusRequest
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def execute(self, _request: ModbusRequest) -> ModbusResponse:
         """Execute request (code ???).
 
         :raises ModbusException:
@@ -63,7 +60,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def read_coils(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Read coils (code 0x01).
 
         :param address: Start address to read from
@@ -78,7 +75,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def read_discrete_inputs(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Read discrete inputs (code 0x02).
 
         :param address: Start address to read from
@@ -93,7 +90,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def read_holding_registers(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Read holding registers (code 0x03).
 
         :param address: Start address to read from
@@ -108,7 +105,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def read_input_registers(
         self, address: int, count: int = 1, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Read input registers (code 0x04).
 
         :param address: Start address to read from
@@ -123,7 +120,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def write_coil(
         self, address: int, value: bool, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Write single coil (code 0x05).
 
         :param address: Address to write to
@@ -138,7 +135,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def write_register(
         self, address: int, value: int, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Write register (code 0x06).
 
         :param address: Address to write to
@@ -151,9 +148,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
             pdu_req_write.WriteSingleRegisterRequest(address, value, slave, **kwargs)
         )
 
-    def read_exception_status(
-        self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def read_exception_status(self, slave: int = 0, **kwargs: Any) -> ModbusResponse:
         """Read Exception Status (code 0x07).
 
         :param slave: (optional) Modbus slave ID
@@ -164,7 +159,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_query_data(
         self, msg: bytearray, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose query data (code 0x08 sub 0x00).
 
         :param msg: Message to be returned
@@ -176,7 +171,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_restart_communication(
         self, toggle: bool, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose restart communication (code 0x08 sub 0x01).
 
         :param toggle: True if toggled.
@@ -190,7 +185,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_diagnostic_register(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read diagnostic register (code 0x08 sub 0x02).
 
         :param slave: (optional) Modbus slave ID
@@ -203,7 +198,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_change_ascii_input_delimeter(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose change ASCII input delimiter (code 0x08 sub 0x03).
 
         :param slave: (optional) Modbus slave ID
@@ -214,9 +209,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
             pdu_diag.ChangeAsciiInputDelimiterRequest(slave=slave, **kwargs)
         )
 
-    def diag_force_listen_only(
-        self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def diag_force_listen_only(self, slave: int = 0, **kwargs: Any) -> ModbusResponse:
         """Diagnose force listen only (code 0x08 sub 0x04).
 
         :param slave: (optional) Modbus slave ID
@@ -225,9 +218,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_diag.ForceListenOnlyModeRequest(slave=slave, **kwargs))
 
-    def diag_clear_counters(
-        self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def diag_clear_counters(self, slave: int = 0, **kwargs: Any) -> ModbusResponse:
         """Diagnose clear counters (code 0x08 sub 0x0A).
 
         :param slave: (optional) Modbus slave ID
@@ -238,7 +229,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_bus_message_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read bus message count (code 0x08 sub 0x0B).
 
         :param slave: (optional) Modbus slave ID
@@ -251,7 +242,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_bus_comm_error_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Bus Communication Error Count (code 0x08 sub 0x0C).
 
         :param slave: (optional) Modbus slave ID
@@ -264,7 +255,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_bus_exception_error_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Bus Exception Error Count (code 0x08 sub 0x0D).
 
         :param slave: (optional) Modbus slave ID
@@ -277,7 +268,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_slave_message_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Slave Message Count (code 0x08 sub 0x0E).
 
         :param slave: (optional) Modbus slave ID
@@ -290,7 +281,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_slave_no_response_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Slave No Response Count (code 0x08 sub 0x0F).
 
         :param slave: (optional) Modbus slave ID
@@ -303,7 +294,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_slave_nak_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Slave NAK Count (code 0x08 sub 0x10).
 
         :param slave: (optional) Modbus slave ID
@@ -314,7 +305,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_slave_busy_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Slave Busy Count (code 0x08 sub 0x11).
 
         :param slave: (optional) Modbus slave ID
@@ -325,7 +316,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_bus_char_overrun_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Bus Character Overrun Count (code 0x08 sub 0x12).
 
         :param slave: (optional) Modbus slave ID
@@ -338,7 +329,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_read_iop_overrun_count(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose read Iop overrun count (code 0x08 sub 0x13).
 
         :param slave: (optional) Modbus slave ID
@@ -351,7 +342,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_clear_overrun_counter(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose Clear Overrun Counter and Flag (code 0x08 sub 0x14).
 
         :param slave: (optional) Modbus slave ID
@@ -362,7 +353,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def diag_getclear_modbus_response(
         self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Diagnose Get/Clear modbus plus (code 0x08 sub 0x15).
 
         :param slave: (optional) Modbus slave ID
@@ -371,9 +362,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_diag.GetClearModbusPlusRequest(slave=slave, **kwargs))
 
-    def diag_get_comm_event_counter(
-        self, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def diag_get_comm_event_counter(self, **kwargs: Any) -> ModbusResponse:
         """Diagnose get event counter (code 0x0B).
 
         :param kwargs: (optional) Experimental parameters.
@@ -381,9 +370,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_other_msg.GetCommEventCounterRequest(**kwargs))
 
-    def diag_get_comm_event_log(
-        self, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def diag_get_comm_event_log(self, **kwargs: Any) -> ModbusResponse:
         """Diagnose get event counter (code 0x0C).
 
         :param kwargs: (optional) Experimental parameters.
@@ -397,7 +384,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         values: list[bool] | bool,
         slave: int = 0,
         **kwargs: Any,
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Write coils (code 0x0F).
 
         :param address: Start address to write to
@@ -412,7 +399,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def write_registers(
         self, address: int, values: list[int] | int, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Write registers (code 0x10).
 
         :param address: Start address to write to
@@ -427,9 +414,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
             )
         )
 
-    def report_slave_id(
-        self, slave: int = 0, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def report_slave_id(self, slave: int = 0, **kwargs: Any) -> ModbusResponse:
         """Report slave ID (code 0x11).
 
         :param slave: (optional) Modbus slave ID
@@ -438,9 +423,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_other_msg.ReportSlaveIdRequest(slave, **kwargs))
 
-    def read_file_record(
-        self, records: list[tuple], **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def read_file_record(self, records: list[tuple], **kwargs: Any) -> ModbusResponse:
         """Read file record (code 0x14).
 
         :param records: List of (Reference type, File number, Record Number, Record Length)
@@ -449,9 +432,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_file_msg.ReadFileRecordRequest(records, **kwargs))
 
-    def write_file_record(
-        self, records: list[tuple], **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def write_file_record(self, records: list[tuple], **kwargs: Any) -> ModbusResponse:
         """Write file record (code 0x15).
 
         :param records: List of (Reference type, File number, Record Number, Record Length)
@@ -466,7 +447,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         and_mask: int = 0xFFFF,
         or_mask: int = 0x0000,
         **kwargs: Any,
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Mask write register (code 0x16).
 
         :param address: The mask pointer address (0x0000 to 0xffff)
@@ -487,7 +468,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         values: list[int] | int = 0,
         slave: int = 0,
         **kwargs,
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Read/Write registers (code 0x17).
 
         :param read_address: The address to start reading from
@@ -509,9 +490,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
             )
         )
 
-    def read_fifo_queue(
-        self, address: int = 0x0000, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    def read_fifo_queue(self, address: int = 0x0000, **kwargs: Any) -> ModbusResponse:
         """Read FIFO queue (code 0x18).
 
         :param address: The address to start reading from
@@ -524,7 +503,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
 
     def read_device_information(
         self, read_code: int | None = None, object_id: int = 0x00, **kwargs: Any
-    ) -> ModbusResponse | Awaitable[ModbusResponse]:
+    ) -> ModbusResponse:
         """Read FIFO queue (code 0x2B sub 0x0E).
 
         :param read_code: The device information read code


### PR DESCRIPTION
This reverts commit 01ad131d360cc0c01c2a28300f4a58e046058fc9 (with 2 resolved conflicts)

See discussion in #1842 and issue #1973.

This gets us no close to full type hinting, but does at least fix a bit of breakage :)

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
