### PR TITLE
Fix incorrect bytearray type hint in diagnostics query

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -163,7 +163,7 @@ class ModbusClientMixin:  # pylint: disable=too-many-public-methods
         return self.execute(pdu_other_msg.ReadExceptionStatusRequest(slave, **kwargs))
 
     def diag_query_data(
-        self, msg: bytearray, slave: int = 0, **kwargs: Any
+        self, msg: bytes, slave: int = 0, **kwargs: Any
     ) -> ModbusResponse | Awaitable[ModbusResponse]:
         """Diagnose query data (code 0x08 sub 0x00).
 

--- a/test/sub_messages/test_diag_messages.py
+++ b/test/sub_messages/test_diag_messages.py
@@ -97,8 +97,8 @@ class TestDataStore:
     ]
 
     responses = [
-        # (DiagnosticStatusResponse,                     b"\x00\x00\x00\x00"),
-        # (DiagnosticStatusSimpleResponse,               b"\x00\x00\x00\x00"),
+        (DiagnosticStatusResponse,                     b"\x00\x00\x00\x00"),
+        (DiagnosticStatusSimpleResponse,               b"\x00\x00\x00\x00"),
         (ReturnQueryDataResponse, b"\x00\x00\x00\x00"),
         (RestartCommunicationsOptionResponse, b"\x00\x01\x00\x00"),
         (ReturnDiagnosticRegisterResponse, b"\x00\x02\x00\x00"),
@@ -144,7 +144,7 @@ class TestDataStore:
         with pytest.raises(NotImplementedException):
             request.execute()
         assert request.encode() == b"\x12\x34\x12\x34"
-        DiagnosticStatusSimpleResponse(None)
+        DiagnosticStatusSimpleResponse()
 
     def test_diagnostic_response_decode(self):
         """Testing diagnostic request messages encoding."""

--- a/test/sub_messages/test_diag_messages.py
+++ b/test/sub_messages/test_diag_messages.py
@@ -178,7 +178,7 @@ class TestDataStore:
         message = ReturnQueryDataResponse(b"\x00\x00")
         assert message.encode() == b"\x00\x00\x00\x00"
 
-    def test_restart_cmmunications_option(self):
+    def test_restart_communications_option(self):
         """Testing diagnostic message execution."""
         request = RestartCommunicationsOptionRequest(True)
         assert request.encode() == b"\x00\x01\xff\x00"


### PR DESCRIPTION
(I'm trying `pyright` and it seems to be stricter than `mypy`)

Since #1638 it has not been possible to pass a `bytearray` to `diag_query_data`.

Note:
```
>>> msg = bytearray()
>>> type(msg)
<class 'bytearray'>
>>> isinstance(msg, bytes)
False
```

Also, re-enable DiagnasticStatusResponse enconding test, although it doesn't actually test much, ha.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
