### PR TITLE
Add profile option to pytest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: pytest
         run: |
           env
-          pytest -v --cov --full-trace --timeout=1200
+          pytest -v --cov
 
   analyze:
     name: Analyze Python

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ __pycache__/
 .vscode
 .vscode/
 build/
+prof/
 /dist/
 /pymodbus.egg-info/
 venv
 downloaded_files/
-htmlcov/

--- a/README.rst
+++ b/README.rst
@@ -274,7 +274,7 @@ There are 2 bigger projects ongoing:
    * Add features to and simulator, and enhance the web design
 
 
-Development Instructions
+Development instructions
 ------------------------
 The current code base is compatible with python >= 3.8.
 
@@ -295,12 +295,15 @@ Make a pull request::
 
    on github open a pull request, check that CI turns green and then wait for review comments.
 
-
 Test your changes::
 
    cd test
    pytest
 
+you can also do extended testing::
+
+   pytest --cov         <-- Coverage html report in build/html
+   pytest --profile     <-- Call profile report in prof
 
 Internals
 ^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ development = [
     "pytest>=7.3.1",
     "pytest-asyncio>=0.20.3",
     "pytest-cov>=4.1.0",
+    "pytest-profiling>=1.7.0",
     "pytest-timeout>=2.2.0",
     "pytest-xdist>=3.3.1",
     "ruff>=0.2.0",
@@ -220,9 +221,9 @@ all_files = "1"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = "-p no:warnings --dist loadscope --numprocesses auto"
+addopts = "-p no:warnings --durations=10 --dist loadscope --numprocesses auto"
 asyncio_mode = "auto"
-timeout = 40
+timeout = 120
 
 [tool.coverage.run]
 source = [


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
add pytest-profiling to the pytest plugins, to allow for easy profiling

Add “durations=10” to pytest options, to show the 10 slowest tests in every run

Now its possible to run:
    pytest —cov
        generates a coverage report in build/html
   pytest —profile
        generates prof files in prof. These can be handled by pstats

