### PR TITLE
Improve client types

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -186,7 +186,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         self.framer.processIncomingPacket(data, self._handle_response, slave=0)
         return len(data)
 
-    async def connect(self):
+    async def connect(self) -> bool:  # type: ignore[empty-body]
         """Connect to the modbus remote host."""
 
     def raise_future(self, my_future, exc):
@@ -414,7 +414,7 @@ class ModbusBaseSyncClient(ModbusClientMixin[ModbusResponse], ModbusProtocol):
             return socket.AF_INET
         return socket.AF_INET6
 
-    def connect(self):
+    def connect(self) -> bool:  # type: ignore[empty-body]
         """Connect to other end, overwritten."""
 
     def close(self):

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -241,7 +241,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         return self
 
     async def __aexit__(self, klass, value, traceback):
-        """Implement the client with exit block."""
+        """Implement the client with aexit block."""
         self.close()
 
     def __str__(self):

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -150,7 +150,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
     # ----------------------------------------------------------------------- #
     # Merged client methods
     # ----------------------------------------------------------------------- #
-    async def async_execute(self, request=None) -> ModbusResponse:
+    async def async_execute(self, request) -> ModbusResponse:
         """Execute requests asynchronously."""
         request.transaction_id = self.transaction.getNextTID()
         packet = self.framer.buildPacket(request)

--- a/test/sub_client/test_client.py
+++ b/test/sub_client/test_client.py
@@ -599,6 +599,7 @@ async def test_client_build_response():
     with pytest.raises(ConnectionException):
         await client.build_response(0)
 
+
 async def test_client_mixin_execute():
     """Test dummy execute for both sync and async."""
     client = ModbusClientMixin()


### PR DESCRIPTION
The base `connect` method is an empty body that is intended to be over-ridden.*  It implicitly has no return value.  The concrete classes have a return value of `bool`.

Also, there is no reason to call `async_execute` without `request`, so it should not be set to `None`.





<!--  Please raise your PR's against the `dev` branch instead of `master` -->
