### PR TITLE
Add more client type hints

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -206,7 +206,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
 
     def build_response(self, tid):
         """Return a deferred response for the current request."""
-        my_future = asyncio.Future()
+        my_future: asyncio.Future = asyncio.Future()
         if not self.transport:
             self.raise_future(my_future, ConnectionException("Client is not connected"))
         else:

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -53,6 +53,8 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
+    socket: socket.socket | None
+
     def __init__(
         self,
         host: str,
@@ -130,6 +132,8 @@ class ModbusTcpClient(ModbusBaseSyncClient):
 
     Remark: There are no automatic reconnect as with AsyncModbusTcpClient
     """
+
+    socket: socket.socket | None
 
     def __init__(
         self,
@@ -219,7 +223,7 @@ class ModbusTcpClient(ModbusBaseSyncClient):
         else:
             recv_size = size
 
-        data = []
+        data: list[bytes] = []
         data_length = 0
         time_ = time.time()
         end = time_ + timeout

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -137,6 +137,8 @@ class ModbusUdpClient(ModbusBaseSyncClient):
     Remark: There are no automatic reconnect as with AsyncModbusUdpClient
     """
 
+    socket: socket.socket | None
+
     def __init__(
         self,
         host: str,

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -49,7 +49,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
         self.running = False
         self.receive_queue = asyncio.Queue()
         self.handler_task = None  # coroutine to be run on asyncio loop
-        self.framer: ModbusFramer = None
+        self.framer: ModbusFramer
 
     def _log_exception(self):
         """Show log exception."""


### PR DESCRIPTION
`mypy` is sometimes a little dumb, and can't figure out types that are defined in `__init__()`.  So help it out by explicitly defining them.

126 -> 107 `mypy` problems
﻿<!--  Please raise your PR's against the `dev` branch instead of `master` -->
