### PR TITLE
Attach expect_response variable to ModbusRequest

### DIFF
--- a/pymodbus/pdu.py
+++ b/pymodbus/pdu.py
@@ -108,6 +108,7 @@ class ModbusRequest(ModbusPDU):
         :param slave: Modbus slave slave ID
         """
         super().__init__(slave, **kwargs)
+        self.expect_response = kwargs.get("expect_response", True)
 
     def doException(self, exception):
         """Build an error response based on the function.

--- a/test/sub_client/test_client.py
+++ b/test/sub_client/test_client.py
@@ -261,7 +261,7 @@ async def test_client_instanciate(
     client.connect = lambda: False
     client.transport = None
     with pytest.raises(ConnectionException):
-        client.execute()
+        await client.execute(ModbusRequest())
 
 async def test_serial_not_installed():
     """Try to instantiate clients."""


### PR DESCRIPTION
This should be a bit cleaner and allows one-shot/broadcast control on a per-request basis.