### PR TITLE
Add timeout handler callback to ModbusRequest

### DIFF
--- a/pymodbus/pdu.py
+++ b/pymodbus/pdu.py
@@ -108,6 +108,7 @@ class ModbusRequest(ModbusPDU):
         :param slave: Modbus slave slave ID
         """
         super().__init__(slave, **kwargs)
+        self.on_timeout = kwargs.get("on_timeout", None)
 
     def doException(self, exception):
         """Build an error response based on the function.


### PR DESCRIPTION
Timeout handler callback which allows for custom recovery logic when a `ModbusRequest` times out.