### PR TITLE
Allow slave=0 in serial communication.

### DIFF
--- a/examples/client_test_tool.py
+++ b/examples/client_test_tool.py
@@ -113,12 +113,17 @@ async def main(comm: CommType):
 async def client_calls(client):
     """Test client API."""
     Log.debug("--> Client calls starting.")
-    _resp = await client.read_holding_registers(address=124, count=4, slave=1)
+    _resp = await client.read_holding_registers(address=124, count=4, slave=0)
 
 def handle_stub_data(transport: ModbusProtocol, data: bytes):
     """Respond to request at transport level."""
     Log.debug("--> stub called with request {}.", data, ":hex")
     response = b'\x01\x03\x08\x00\x05\x00\x05\x00\x00\x00\x00\x0c\xd7'
+
+    # Multiple send is allowed, to test fragmentation
+    #  for data in response:
+    #    to_send = data.to_bytes()
+    #    transport.transport_send(to_send)
     transport.transport_send(response)
 
 

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -238,7 +238,8 @@ class ModbusRtuFramer(ModbusFramer):
         )
         packet += struct.pack(">H", computeCRC(packet))
         # Ensure that transaction is actually the slave id for serial comms
-        message.transaction_id = message.slave_id
+        if message.slave_id:
+            message.transaction_id = message.slave_id
         return packet
 
     def sendPacket(self, message):


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
For a longer time slave=0 have caused different problems....

thanks to the nicely prepared issue #2019, the bug was found, thanks !

The RTU_FRAMER sets transaction_id = slave_id, which is correct EXCEPT for slave=0

fixes #2019
