### PR TITLE
Add more type hints to datastore

### DIFF
--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -45,13 +45,16 @@ I have both methods implemented, and leave it up to the user to change
 based on their preference.
 """
 # pylint: disable=missing-type-doc
-from pymodbus.exceptions import NotImplementedException, ParameterException
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+from pymodbus.exceptions import ParameterException
 
 
 # ---------------------------------------------------------------------------#
 #  Datablock Storage
 # ---------------------------------------------------------------------------#
-class BaseModbusDataBlock:
+class BaseModbusDataBlock(ABC):
     """Base class for a modbus datastore.
 
     Derived classes must create the following fields:
@@ -83,32 +86,32 @@ class BaseModbusDataBlock:
             self.default_value
         ] * len(self.values)
 
+    @abstractmethod
     def validate(self, address:int, count=1) -> bool:
         """Check to see if the request is in range.
 
         :param address: The starting address
         :param count: The number of values to test for
-        :raises NotImplementedException:
+        :raises TypeError:
         """
-        raise NotImplementedException("Datastore Address Check")
 
+    @abstractmethod
     def getValues(self, address:int, count=1) -> Iterable:
         """Return the requested values from the datastore.
 
         :param address: The starting address
         :param count: The number of values to retrieve
-        :raises NotImplementedException:
+        :raises TypeError:
         """
-        raise NotImplementedException("Datastore Value Retrieve")
 
+    @abstractmethod
     def setValues(self, address:int, values) -> None:
         """Return the requested values from the datastore.
 
         :param address: The starting address
         :param values: The values to store
-        :raises NotImplementedException:
+        :raises TypeError:
         """
-        raise NotImplementedException("Datastore Value Retrieve")
 
     def __str__(self):
         """Build a representation of the datastore.

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -83,7 +83,7 @@ class BaseModbusDataBlock:
             self.default_value
         ] * len(self.values)
 
-    def validate(self, address, count=1):
+    def validate(self, address:int, count=1) -> bool:
         """Check to see if the request is in range.
 
         :param address: The starting address
@@ -92,7 +92,7 @@ class BaseModbusDataBlock:
         """
         raise NotImplementedException("Datastore Address Check")
 
-    def getValues(self, address, count=1):
+    def getValues(self, address:int, count=1) -> Iterable:
         """Return the requested values from the datastore.
 
         :param address: The starting address
@@ -101,7 +101,7 @@ class BaseModbusDataBlock:
         """
         raise NotImplementedException("Datastore Value Retrieve")
 
-    def setValues(self, address, values):
+    def setValues(self, address:int, values) -> None:
         """Return the requested values from the datastore.
 
         :param address: The starting address


### PR DESCRIPTION
Add more type hints to datastore.  `mypy` doesn't care, but it eliminates 5 `pyright` errors.

Also, use Abstract Base Class for `BaseModbusDataBlock` rather than `raise NotImplementedError`.  (This commit is not necessary for the type hints)

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
