### PR TITLE
Improve HTTP server type hints

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import os
 from time import time
+from typing import TYPE_CHECKING
 
 
 try:
@@ -16,6 +17,8 @@ try:
     AIOHTTP_MISSING = False
 except ImportError:
     AIOHTTP_MISSING = True
+if TYPE_CHECKING:  # type checkers do not understand the Raise RuntimeError in __init__()
+    from aiohttp import web
 
 from pymodbus.datastore import ModbusServerContext, ModbusSimulatorContext
 from pymodbus.datastore.simulator import Label

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -7,7 +7,7 @@ import dataclasses
 import importlib
 import json
 import os
-from time import time
+from time import sleep
 from typing import TYPE_CHECKING
 
 
@@ -620,7 +620,7 @@ class ModbusSimulatorServer:
                     "Delaying response by {}s for all incoming requests",
                     self.call_response.delay,
                 )
-                time.sleep(self.call_response.delay)  # change to async
+                sleep(self.call_response.delay)  # change to async
             else:
                 pass
                 # self.call_response.change_rate

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -17,8 +17,6 @@ try:
     AIOHTTP_MISSING = False
 except ImportError:
     AIOHTTP_MISSING = True
-if TYPE_CHECKING:  # type checkers do not understand the Raise RuntimeError in __init__()
-    from aiohttp import web
 
 from pymodbus.datastore import ModbusServerContext, ModbusSimulatorContext
 from pymodbus.datastore.simulator import Label
@@ -33,6 +31,9 @@ from pymodbus.server.async_io import (
     ModbusUdpServer,
 )
 
+
+if TYPE_CHECKING:  # type checkers do not understand the Raise RuntimeError in __init__()
+    from aiohttp import web
 
 MAX_FILTER = 1000
 


### PR DESCRIPTION
This solves another 15 errors with `mypy --checkuntyped defs pymodbus` (and a few for `pyright` that `mypy` does not find).

It also looks like it fixes a real bug with  `time.sleep()` not being called correctly.  (The existing code attempts to call `time.time()` instead.)

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
