### PR TITLE
Use "new" inter_byte_timeout and is_open for pyserial

### DIFF
--- a/doc/source/repl.rst
+++ b/doc/source/repl.rst
@@ -167,7 +167,7 @@ SERIAL
    client.get_stopbits                          Number of stop bits.
    client.get_timeout                           Serial Port Read timeout.
    client.idle_time                             Bus Idle Time to initiate next transaction
-   client.inter_char_timeout                    Read Only!
+   client.inter_byte_timeout                    Read Only!
    client.is_socket_open                        c l i e n t . i s   s o c k e t   o p e n
    client.mask_write_register                   Mask content of holding register at `address`          with `and_mask` and `or_mask`.
    client.method                                Read Only!

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -150,7 +150,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
     """
 
     state = ModbusTransactionState.IDLE
-    inter_char_timeout: float = 0
+    inter_byte_timeout: float = 0
     silent_interval: float = 0
 
     def __init__(
@@ -190,7 +190,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
         if baudrate > 19200:
             self.silent_interval = 1.75 / 1000  # ms
         else:
-            self.inter_char_timeout = 1.5 * self._t0
+            self.inter_byte_timeout = 1.5 * self._t0
             self.silent_interval = 3.5 * self._t0
         self.silent_interval = round(self.silent_interval, 6)
 
@@ -214,7 +214,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
                 exclusive=True,
             )
             if self.strict:
-                self.socket.interCharTimeout = self.inter_char_timeout
+                self.socket.inter_byte_timeout = self.inter_byte_timeout
             self.last_frame_end = None
         except serial.SerialException as msg:
             Log.error("{}", msg)

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -285,7 +285,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
     def is_socket_open(self):
         """Check if socket is open."""
         if self.socket:
-            return self.socket.is_open if hasattr(self.socket, "is_open") else self.socket.isOpen()
+            return self.socket.is_open
         return False
 
     def __repr__(self):

--- a/test/sub_client/test_client_sync.py
+++ b/test/sub_client/test_client_sync.py
@@ -354,7 +354,7 @@ class TestSynchronousClient:  # pylint: disable=too-many-public-methods
         # rtu connect/disconnect
         rtu_client = ModbusSerialClient("/dev/null", framer=Framer.RTU, strict=True)
         assert rtu_client.connect()
-        assert rtu_client.socket.interCharTimeout == rtu_client.inter_char_timeout
+        assert rtu_client.socket.inter_byte_timeout == rtu_client.inter_byte_timeout
         rtu_client.close()
         assert str(client) == "ModbusSerialClient /dev/null:0"
 


### PR DESCRIPTION
`pyserial` defines a class `Socket` which used to have a property `interCharTimeout`.  

This was renamed to `inter_byte_timeout` in [`pyserial>=3.0`](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.inter_byte_timeout).  `interCharTimeout` remains as an alias for now.

I do not believe this is an API change since it's only internal, and users set `strict: True` on `ModbusSerialClient` instead.

`is_open` has also been available [since 3.0](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.isOpen) so there is no need to keep the deprecated `isOpen()`