### PR TITLE
Simplify asyncio and server list

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -554,17 +554,12 @@ class _serverList:
 
     active_server: ModbusTcpServer | ModbusUdpServer | ModbusSerialServer
 
-    def __init__(self, server):
-        """Register new server."""
-        self.server = server
-        self.loop = asyncio.get_event_loop()
-
     @classmethod
     async def run(cls, server, custom_functions):
         """Help starting/stopping server."""
         for func in custom_functions:
             server.decoder.register(func)
-        cls.active_server = _serverList(server)
+        cls.active_server = server
         with suppress(asyncio.exceptions.CancelledError):
             await server.serve_forever()
 
@@ -573,7 +568,7 @@ class _serverList:
         """Wait for server stop."""
         if not cls.active_server:
             raise RuntimeError("ServerAsyncStop called without server task active.")
-        await cls.active_server.server.shutdown()
+        await cls.active_server.shutdown()
         if os.name == "nt":
             await asyncio.sleep(1)
         else:

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -284,10 +284,6 @@ class ModbusBaseServer(ModbusProtocol):
         return ModbusServerRequestHandler(self)
 
     async def shutdown(self):
-        """Shutdown server."""
-        await self.server_close()
-
-    async def server_close(self):
         """Close server."""
         if not self.serving.done():
             self.serving.set_result(True)

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -552,7 +552,7 @@ class _serverList:
     :meta private:
     """
 
-    active_server: ModbusTcpServer | ModbusUdpServer | ModbusSerialServer
+    active_server: ModbusTcpServer | ModbusUdpServer | ModbusSerialServer | None
 
     @classmethod
     async def run(cls, server, custom_functions):

--- a/test/sub_server/test_server_asyncio.py
+++ b/test/sub_server/test_server_asyncio.py
@@ -125,7 +125,7 @@ class TestAsyncioServer:
 
         # teardown
         if self.server is not None:
-            await self.server.server_close()
+            await self.server.shutdown()
             self.server = None
         if self.task is not None:
             await asyncio.sleep(0.1)
@@ -239,15 +239,15 @@ class TestAsyncioServer:
         BasicClient.transport.close()
         await asyncio.sleep(0.2)  # so we have to wait a bit
 
-    async def test_async_tcp_server_close_connection(self):
-        """Test server_close() while there are active TCP connections."""
+    async def test_async_tcp_server_shutdown_connection(self):
+        """Test server shutdown() while there are active TCP connections."""
         await self.start_server()
         await self.connect_server()
 
         # On Windows we seem to need to give this an extra chance to finish,
         # otherwise there ends up being an active connection at the assert.
         await asyncio.sleep(0.5)
-        await self.server.server_close()
+        await self.server.shutdown()
 
     async def test_async_tcp_server_no_slave(self):
         """Test unknown slave exception."""
@@ -258,7 +258,7 @@ class TestAsyncioServer:
         await self.start_server()
         await self.connect_server()
         assert not BasicClient.eof.done()
-        await self.server.server_close()
+        await self.server.shutdown()
         self.server = None
 
     async def test_async_tcp_server_modbus_error(self):
@@ -313,7 +313,7 @@ class TestAsyncioServer:
     async def test_async_udp_server_serve_forever_close(self):
         """Test StarAsyncUdpServer serve_forever() method."""
         await self.start_server(do_udp=True)
-        await self.server.server_close()
+        await self.server.shutdown()
         self.server = None
 
     async def test_async_udp_server_serve_forever_twice(self):


### PR DESCRIPTION
Note: this code is very confusing to me, so @janiversen please review carefully.

Solves another 5 `mypy` errors, and speeds up the Window tests.

Instancing the class `_serverList` from its own method
(1) is... strange?
(2) is unnecessary to use the methods, which are all  `@classmethod`
(3) is unnecessary to keep track of the event loop, since every server class already has `self.loop`
==> Use the class methods directly

The methods `shutdown()` and `server_close()` are essentially redundant.
==> combine

There's no use for `asyncio.wait()` directly after an `await`.
==> remove

`time.sleep()` is inefficient, as described in https://github.com/pymodbus-dev/pymodbus/issues/1992#issue-2128311471)
==> replace with waiting+timeout for the `Future`


