### PR TITLE
eliminate asyncio.sleep() and replace time.sleep() with a timeout

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import time
 import traceback
 from contextlib import suppress
 
@@ -578,10 +577,6 @@ class _serverList:
         if not cls.active_server:
             raise RuntimeError("ServerAsyncStop called without server task active.")
         await cls.active_server.server.shutdown()
-        if os.name == "nt":
-            await asyncio.sleep(1)
-        else:
-            await asyncio.sleep(0)
         cls.active_server = None
 
     @classmethod
@@ -593,11 +588,8 @@ class _serverList:
         if not cls.active_server.loop.is_running():
             Log.info("ServerStop called with loop stopped.")
             return
-        asyncio.run_coroutine_threadsafe(cls.async_stop(), cls.active_server.loop)
-        if os.name == "nt":
-            time.sleep(10)
-        else:
-            time.sleep(0.1)
+        future = asyncio.run_coroutine_threadsafe(cls.async_stop(), cls.active_server.loop)
+        future.result(timeout=10 if os.name == 'nt' else 0.1)
 
 
 async def StartAsyncTcpServer(  # pylint: disable=invalid-name,dangerous-default-value


### PR DESCRIPTION
`asyncio` sometimes behaves strangely on Windows, so longer delays were added to prevent flaky tests.  However, `time.sleep(10)` will always wait the full 10s, even though we really only need to wait until the server is stopped with `async_stop()`.

Using `future.result` with a timeout waits only as long as necessary.  This speeds up the CI on Windows significantly.

Also, having an `await asyncio.sleep()` immediately after an `await cls.active_server.server.shutdown()` is redundant.  Control flow will already yield back to the event loop with the first `await`

See https://github.com/pymodbus-dev/pymodbus/pull/2033#discussion_r1495400566

