### PR TITLE
Improve HTTP server type hints

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -7,7 +7,7 @@ import dataclasses
 import importlib
 import json
 import os
-from time import time
+from time import sleep
 from typing import TYPE_CHECKING
 
 
@@ -621,7 +621,7 @@ class ModbusSimulatorServer:
                     "Delaying response by {}s for all incoming requests",
                     self.call_response.delay,
                 )
-                time.sleep(self.call_response.delay)  # change to async
+                sleep(self.call_response.delay)  # change to async
             else:
                 pass
                 # self.call_response.change_rate

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -164,7 +164,7 @@ class ModbusSimulatorServer:
         self.modbus_server = comm(framer=framer, context=datastore, **server)
         self.serving: asyncio.Future = asyncio.Future()
         self.log_file = log_file
-        self.site = None
+        self.site: web.TCPSite | None = None
         self.runner: web.AppRunner
         self.http_host = http_host
         self.http_port = http_port
@@ -207,7 +207,7 @@ class ModbusSimulatorServer:
                 self.generator_html[entry][0] = handle.read()
         self.refresh_rate = 0
         self.register_filter: list[int] = []
-        self.call_list: list[tuple] = []
+        self.call_list: list[CallTracer] = []
         self.request_lookup = ServerDecoder.getFCdict()
         self.call_monitor = CallTypeMonitor()
         self.call_response = CallTypeResponse()
@@ -535,7 +535,7 @@ class ModbusSimulatorServer:
         self.call_monitor.range_start = range_start
         self.call_monitor.range_stop = range_stop
         self.call_monitor.function = (
-            int(params["function"]) if params["function"] else ""
+            int(params["function"]) if params["function"] else -1
         )
         self.call_monitor.hex = "show_hex" in params
         self.call_monitor.decode = "show_decode" in params
@@ -603,7 +603,7 @@ class ModbusSimulatorServer:
                 fc=response.function_code,
                 address=response.address if hasattr(response, "address") else -1,
                 count=response.count if hasattr(response, "count") else -1,
-                data="-",
+                data=b"-",
             )
             self.call_list.append(tracer)
             self.call_monitor.trace_response = False
@@ -650,7 +650,7 @@ class ModbusSimulatorServer:
         """
         if self.call_monitor.function not in {-1, request.function_code}:
             return
-        address = (request.address if hasattr(request, "address") else -1,)
+        address = request.address if hasattr(request, "address") else -1
         if self.call_monitor.range_start != -1 and address != -1:
             if (
                 self.call_monitor.range_start > address
@@ -662,7 +662,7 @@ class ModbusSimulatorServer:
             fc=request.function_code,
             address=address,
             count=request.count if hasattr(request, "count") else -1,
-            data="-",
+            data=b"-",
         )
         self.call_list.append(tracer)
         self.call_monitor.trace_response = True

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import os
 from time import time
+from typing import TYPE_CHECKING
 
 
 try:
@@ -16,6 +17,9 @@ try:
     AIOHTTP_MISSING = False
 except ImportError:
     AIOHTTP_MISSING = True
+    if TYPE_CHECKING:  # always False at runtime
+        # type checkers do not understand the Raise RuntimeError in __init__()
+        from aiohttp import web
 
 from pymodbus.datastore import ModbusServerContext, ModbusSimulatorContext
 from pymodbus.datastore.simulator import Label


### PR DESCRIPTION
Supersedes https://github.com/pymodbus-dev/pymodbus/pull/2029

This solves another 15 errors with `mypy --checkuntyped defs pymodbus` (and a few for `pyright` that `mypy` does not find).

It also looks like it fixes a real bug with  `time.sleep()` not being called correctly.  (The existing code attempts to call `time.time()` instead.)