### PR TITLE
eliminate redundant server_close()

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -283,10 +283,6 @@ class ModbusBaseServer(ModbusProtocol):
         return ModbusServerRequestHandler(self)
 
     async def shutdown(self):
-        """Shutdown server."""
-        await self.server_close()
-
-    async def server_close(self):
         """Close server."""
         if not self.serving.done():
             self.serving.set_result(True)

--- a/test/sub_server/test_server_asyncio.py
+++ b/test/sub_server/test_server_asyncio.py
@@ -125,7 +125,7 @@ class TestAsyncioServer:
 
         # teardown
         if self.server is not None:
-            await self.server.server_close()
+            await self.server.shutdown()
             self.server = None
         if self.task is not None:
             await asyncio.sleep(0.1)
@@ -239,15 +239,15 @@ class TestAsyncioServer:
         BasicClient.transport.close()
         await asyncio.sleep(0.2)  # so we have to wait a bit
 
-    async def test_async_tcp_server_close_connection(self):
-        """Test server_close() while there are active TCP connections."""
+    async def test_async_tcp_server_shutdown_connection(self):
+        """Test server shutdown() while there are active TCP connections."""
         await self.start_server()
         await self.connect_server()
 
         # On Windows we seem to need to give this an extra chance to finish,
         # otherwise there ends up being an active connection at the assert.
         await asyncio.sleep(0.5)
-        await self.server.server_close()
+        await self.server.shutdown()
 
     async def test_async_tcp_server_no_slave(self):
         """Test unknown slave exception."""
@@ -258,7 +258,7 @@ class TestAsyncioServer:
         await self.start_server()
         await self.connect_server()
         assert not BasicClient.eof.done()
-        await self.server.server_close()
+        await self.server.shutdown()
         self.server = None
 
     async def test_async_tcp_server_modbus_error(self):
@@ -313,7 +313,7 @@ class TestAsyncioServer:
     async def test_async_udp_server_serve_forever_close(self):
         """Test StarAsyncUdpServer serve_forever() method."""
         await self.start_server(do_udp=True)
-        await self.server.server_close()
+        await self.server.shutdown()
         self.server = None
 
     async def test_async_udp_server_serve_forever_twice(self):


### PR DESCRIPTION
`server.server_close()` is essentially only an alias for `server.shutdown()`.  Since it is not part of the public API, remove it.

Cherry-picked from https://github.com/pymodbus-dev/pymodbus/pull/2033 (0071ac11d0e050b2e168b86e6cde42898855e1a8)
