### PR TITLE
Use AbstractMethod in transport.

### DIFF
--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -74,7 +74,7 @@ class TransportStub(ModbusProtocol):
         """Call need functions to start server/client."""
         if  self.is_server:
             return await self.transport_listen()
-        return await self.transport_connect()
+        return await self.connect()
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""

--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -81,6 +81,13 @@ class TransportStub(ModbusProtocol):
         self.stub_handle_data(self, data)
         return len(data)
 
+    def callback_connected(self) -> None:
+        """Call when connection is succcesfull."""
+
+    def callback_disconnected(self, exc: Exception | None) -> None:
+        """Call when connection is lost."""
+        Log.debug("callback_disconnected called: {}", exc)
+
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
         new_stub = TransportStub(self.comm_params, False, self.stub_handle_data)

--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -73,7 +73,7 @@ class TransportStub(ModbusProtocol):
     async def start_run(self):
         """Call need functions to start server/client."""
         if  self.is_server:
-            return await self.transport_listen()
+            return await self.listen()
         return await self.connect()
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
@@ -166,7 +166,7 @@ class ServerTester:  # pylint: disable=too-few-public-methods
         """Execute test run."""
         pymodbus_apply_logging_config()
         Log.debug("--> Start testing.")
-        await self.server.transport_listen()
+        await self.server.listen()
         await self.stub.start_run()
         await server_calls(self.stub)
         Log.debug("--> Shutting down.")

--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -193,7 +193,7 @@ async def client_calls(client):
 async def server_calls(transport: ModbusProtocol):
     """Test client API."""
     Log.debug("--> Server calls starting.")
-    _resp = transport.transport_send(b'\x00\x02\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01' +
+    _resp = transport.send(b'\x00\x02\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01' +
         b'\x07\x00\x03\x00\x00\x06\x01\x03\x00\x00\x00\x01')
     await asyncio.sleep(1)
     print("---> all done")
@@ -206,8 +206,8 @@ def handle_client_data(transport: ModbusProtocol, data: bytes):
     # Multiple send is allowed, to test fragmentation
     #  for data in response:
     #    to_send = data.to_bytes()
-    #    transport.transport_send(to_send)
-    transport.transport_send(response)
+    #    transport.send(to_send)
+    transport.send(response)
 
 
 def handle_server_data(_transport: ModbusProtocol, data: bytes):

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -185,7 +185,13 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
 
     def callback_new_connection(self):
         """Call when listener receive new connection request."""
-        return None
+
+    def callback_connected(self) -> None:
+        """Call when connection is succcesfull."""
+
+    def callback_disconnected(self, exc: Exception | None) -> None:
+        """Call when connection is lost."""
+        Log.debug("callback_disconnected called: {}", exc)
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data.

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -183,6 +183,10 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
 
         return resp  # type: ignore[return-value]
 
+    def callback_new_connection(self):
+        """Call when listener receive new connection request."""
+        return None
+
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data.
 

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -108,6 +108,11 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         """Return state of connection."""
         return self.is_active()
 
+    async def base_connect(self) -> bool:
+        """Call transport connect."""
+        return await super().connect()
+
+
     def register(self, custom_response_class: ModbusResponse) -> None:
         """Register a custom response class with the decoder (call **sync**).
 

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -124,12 +124,12 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         """
         self.framer.decoder.register(custom_response_class)
 
-    def close(self, reconnect: bool = False) -> None:
+    def close(self, reconnect: bool = False) -> None:  # type: ignore[override] # pylint: disable=arguments-differ
         """Close connection."""
         if reconnect:
             self.connection_lost(asyncio.TimeoutError("Server not responding"))
         else:
-            self.transport_close()
+            super().close()
 
     def idle_time(self) -> float:
         """Time before initiating next transaction (call **sync**).
@@ -164,7 +164,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         while count <= self.retries:
             req = self.build_response(request.transaction_id)
             if not count or not self.no_resend_on_retry:
-                self.transport_send(packet)
+                self.send(packet)
             if self.broadcast_enable and not request.slave_id:
                 resp = None
                 break
@@ -221,12 +221,6 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
     # ----------------------------------------------------------------------- #
     # Internal methods
     # ----------------------------------------------------------------------- #
-    def send(self, request) -> int:  # type: ignore [empty-body]
-        """Send request.
-
-        :meta private:
-        """
-
     def recv(self, size):
         """Receive data.
 

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -99,7 +99,7 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
         """Connect Async client."""
         self.reset_delay()
         Log.debug("Connecting to {}.", self.comm_params.host)
-        return await self.transport_connect()
+        return await self.base_connect()
 
     def close(self, reconnect: bool = False) -> None:
         """Close connection."""

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -101,7 +101,7 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
         Log.debug("Connecting to {}.", self.comm_params.host)
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False) -> None:
+    def close(self, reconnect: bool = False) -> None:  # type: ignore[override]
         """Close connection."""
         super().close(reconnect=reconnect)
 

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -87,7 +87,7 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
         )
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False) -> None:
+    def close(self, reconnect: bool = False) -> None:  # type: ignore[override]
         """Close connection."""
         super().close(reconnect=reconnect)
 

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -85,7 +85,7 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
             self.comm_params.host,
             self.comm_params.port,
         )
-        return await self.transport_connect()
+        return await self.base_connect()
 
     def close(self, reconnect: bool = False) -> None:
         """Close connection."""

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -89,7 +89,7 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
             self.comm_params.host,
             self.comm_params.port,
         )
-        return await self.transport_connect()
+        return await self.base_connect()
 
 
 class ModbusTlsClient(ModbusTcpClient):

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -93,7 +93,7 @@ class AsyncModbusUdpClient(
             self.comm_params.host,
             self.comm_params.port,
         )
-        return await self.transport_connect()
+        return await self.base_connect()
 
 
 class ModbusUdpClient(ModbusBaseSyncClient):

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -304,6 +304,13 @@ class ModbusBaseServer(ModbusProtocol):
         await self.serving
         Log.info("Server graceful shutdown.")
 
+    def callback_connected(self) -> None:
+        """Call when connection is succcesfull."""
+
+    def callback_disconnected(self, exc: Exception | None) -> None:
+        """Call when connection is lost."""
+        Log.debug("callback_disconnected called: {}", exc)
+
 
 class ModbusTcpServer(ModbusBaseServer):
     """A modbus threaded tcp socket server.

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -56,6 +56,11 @@ class ModbusServerRequestHandler(ModbusProtocol):
             "Handler for stream [{}] has been canceled", self.comm_params.comm_name
         )
 
+    def callback_new_connection(self) -> ModbusProtocol:
+        """Call when listener receive new connection request."""
+        Log.debug("callback_new_connection called")
+        return ModbusServerRequestHandler(self)
+
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""
         try:

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -294,7 +294,7 @@ class ModbusBaseServer(ModbusProtocol):
             raise RuntimeError(
                 "Can't call serve_forever on an already running server object"
             )
-        await self.transport_listen()
+        await self.listen()
         Log.info("Server listening.")
         await self.serving
         Log.info("Server graceful shutdown.")

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -160,7 +160,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
                         exc,
                         self.comm_params.comm_name,
                     )
-                    self.transport_close()
+                    self.close()
                     self.callback_disconnected(exc)
                 else:
                     Log.error("Unknown error occurred {}", exc)
@@ -209,15 +209,15 @@ class ModbusServerRequestHandler(ModbusProtocol):
             skip_encoding = False
             if self.server.response_manipulator:
                 response, skip_encoding = self.server.response_manipulator(response)
-            self.send(response, *addr, skip_encoding=skip_encoding)
+            self.server_send(response, *addr, skip_encoding=skip_encoding)
 
-    def send(self, message, addr, **kwargs):
+    def server_send(self, message, addr, **kwargs):
         """Send message."""
         if kwargs.get("skip_encoding", False):
-            self.transport_send(message, addr=addr)
+            self.send(message, addr=addr)
         elif message.should_respond:
             pdu = self.framer.buildPacket(message)
-            self.transport_send(pdu, addr=addr)
+            self.send(pdu, addr=addr)
         else:
             Log.debug("Skipping sending response!!")
 
@@ -286,7 +286,7 @@ class ModbusBaseServer(ModbusProtocol):
         """Close server."""
         if not self.serving.done():
             self.serving.set_result(True)
-        self.transport_close()
+        self.close()
 
     async def serve_forever(self):
         """Start endless loop."""

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -311,6 +311,10 @@ class ModbusBaseServer(ModbusProtocol):
         """Call when connection is lost."""
         Log.debug("callback_disconnected called: {}", exc)
 
+    def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
+        """Handle received data."""
+        Log.debug("callback_data called: {} addr={}", data, ":hex", addr)
+        return 0
 
 class ModbusTcpServer(ModbusBaseServer):
     """A modbus threaded tcp socket server.

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -259,7 +259,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
                 self.transport = self.transport[0]
         except OSError as exc:
             Log.warning("Failed to start server {}", exc)
-            # self.transport_close(intern=True)
+            # self.close(intern=True)
             return False
         return True
 
@@ -284,7 +284,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
         if not self.transport or self.is_closing:
             return
         Log.debug("Connection lost {} due to {}", self.comm_params.comm_name, reason)
-        self.transport_close(intern=True)
+        self.close(intern=True)
         if (
             not self.is_server
             and not self.listener
@@ -374,7 +374,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
     # ----------------------------------- #
     # Helper methods for external classes #
     # ----------------------------------- #
-    def transport_send(self, data: bytes, addr: tuple | None = None) -> None:
+    def send(self, data: bytes, addr: tuple | None = None) -> None:
         """Send request.
 
         :param data: non-empty bytes object with data to send.
@@ -391,7 +391,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
         else:
             self.transport.write(data)  # type: ignore[attr-defined]
 
-    def transport_close(self, intern: bool = False, reconnect: bool = False) -> None:
+    def close(self, intern: bool = False, reconnect: bool = False) -> None:
         """Close connection.
 
         :param intern: (default false), True if called internally (temporary close)
@@ -409,7 +409,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
             for _key, value in self.active_connections.items():
                 value.listener = None
                 value.callback_disconnected(None)
-                value.transport_close()
+                value.close()
             self.active_connections = {}
             return
         if not reconnect and self.reconnect_task:
@@ -485,7 +485,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
 
     async def __aexit__(self, _class, _value, _traceback) -> None:
         """Implement the client with async exit block."""
-        self.transport_close()
+        self.close()
 
     def __str__(self) -> str:
         """Build a string representation of the connection."""

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -366,10 +366,9 @@ class ModbusProtocol(asyncio.BaseProtocol):
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""
 
+    @abstractmethod
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
-        Log.debug("callback_data called: {} addr={}", data, ":hex", addr)
-        return 0
 
     # ----------------------------------- #
     # Helper methods for external classes #

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import ssl
+from abc import abstractmethod
 from contextlib import suppress
 from enum import Enum
 from functools import partial
@@ -353,10 +354,9 @@ class ModbusProtocol(asyncio.BaseProtocol):
     # --------- #
     # callbacks #
     # --------- #
+    @abstractmethod
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
-        Log.debug("callback_new_connection called")
-        return ModbusProtocol(self.comm_params, False)
 
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -235,7 +235,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
                 ssl=self.comm_params.sslctx,
             )
 
-    async def transport_connect(self) -> bool:
+    async def connect(self) -> bool:
         """Handle generic connect and call on to specific transport connect."""
         Log.debug("Connecting {}", self.comm_params.comm_name)
         self.is_closing = False
@@ -466,7 +466,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
                 await asyncio.sleep(self.reconnect_delay_current)
                 if self.comm_params.on_reconnect_callback:
                     self.comm_params.on_reconnect_callback()
-                if await self.transport_connect():
+                if await self.connect():
                     break
                 self.reconnect_delay_current = min(
                     2 * self.reconnect_delay_current,

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -362,9 +362,9 @@ class ModbusProtocol(asyncio.BaseProtocol):
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""
 
+    @abstractmethod
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""
-        Log.debug("callback_disconnected called: {}", exc)
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -358,9 +358,9 @@ class ModbusProtocol(asyncio.BaseProtocol):
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
 
+    @abstractmethod
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""
-        Log.debug("callback_connected called")
 
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -249,7 +249,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
             return False
         return bool(self.transport)
 
-    async def transport_listen(self) -> bool:
+    async def listen(self) -> bool:
         """Handle generic listen and call on to specific transport listen."""
         Log.debug("Awaiting connections {}", self.comm_params.comm_name)
         self.is_closing = False

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -32,6 +32,13 @@ class ModbusProtocolStub(ModbusProtocol):
         return await self.connect()
 
 
+    def callback_connected(self) -> None:
+        """Call when connection is succcesfull."""
+
+    def callback_disconnected(self, exc: Exception | None) -> None:
+        """Call when connection is lost."""
+        Log.debug("callback_disconnected called: {}", exc)
+
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
         if (response := self.stub_handle_data(data)):

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -28,7 +28,7 @@ class ModbusProtocolStub(ModbusProtocol):
     async def start_run(self):
         """Call need functions to start server/client."""
         if  self.is_server:
-            return await self.transport_listen()
+            return await self.listen()
         return await self.connect()
 
 

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -35,7 +35,7 @@ class ModbusProtocolStub(ModbusProtocol):
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
         if (response := self.stub_handle_data(data)):
-            self.transport_send(response)
+            self.send(response)
         return len(data)
 
     def callback_new_connection(self) -> ModbusProtocol:
@@ -70,8 +70,8 @@ class TestNetwork:
         assert await client.connect()
         test_data = b"Data got echoed."
         client.transport.write(test_data)
-        client.transport_close()
-        stub.transport_close()
+        client.close()
+        stub.close()
 
     async def test_double_packet(self, use_port, use_cls):
         """Test double packet on network."""
@@ -122,5 +122,5 @@ class TestNetwork:
 
         assert await client.connect()
         await asyncio.gather(*[local_call(x) for x in range(1, 10)])
-        client.transport_close()
-        stub.transport_close()
+        client.close()
+        stub.close()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -29,7 +29,7 @@ class ModbusProtocolStub(ModbusProtocol):
         """Call need functions to start server/client."""
         if  self.is_server:
             return await self.transport_listen()
-        return await self.transport_connect()
+        return await self.connect()
 
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:

--- a/test/transport/conftest.py
+++ b/test/transport/conftest.py
@@ -1,11 +1,13 @@
 """Configure pytest."""
-import asyncio
+from __future__ import annotations
+
 import os
 import sys
 from unittest import mock
 
 import pytest
 
+from pymodbus.logging import Log
 from pymodbus.transport import CommParams, CommType, ModbusProtocol
 
 
@@ -15,28 +17,20 @@ sys.path.extend(["examples", "../examples", "../../examples"])
 class DummyProtocol(ModbusProtocol):
     """Use in connection_made calls."""
 
-    def __init__(self, is_server=False):
+    def __init__(self, params=CommParams(), is_server=False):
         """Initialize."""
-        self.transport = None
-        self.is_server = is_server
-        self.is_closing = False
-        self.data = b""
-        self.connection_made = mock.Mock()
-        self.connection_lost = mock.Mock()
-        self.reconnect_task: asyncio.Task = None
-        super().__init__(CommParams(), is_server)
+        #  self.connection_made = mock.Mock()
+        #  self.connection_lost = mock.Mock()
+        super().__init__(params, is_server)
 
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
         return DummyProtocol()
 
-    def close(self):  # pylint: disable=arguments-differ
-        """Simulate close."""
-        self.is_closing = True
-
-    def data_received(self, data):
-        """Call when some data is received."""
-        self.data += data
+    def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
+        """Handle received data."""
+        Log.debug("callback_data called: {} addr={}", data, ":hex", addr)
+        return 0
 
 
 @pytest.fixture(name="dummy_protocol")

--- a/test/transport/conftest.py
+++ b/test/transport/conftest.py
@@ -25,7 +25,7 @@ class DummyProtocol(ModbusProtocol):
 
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
-        return DummyProtocol()
+        return DummyProtocol(params=self.comm_params, is_server=False)
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
@@ -47,7 +47,7 @@ async def prepare_protocol(use_clc):
         use_clc.sslctx = use_clc.generate_ssl(
             False, certfile=cwd + "crt", keyfile=cwd + "key"
         )
-    transport = ModbusProtocol(use_clc, False)
+    transport = DummyProtocol(params=use_clc, is_server=False)
     transport.callback_connected = mock.Mock()
     transport.callback_disconnected = mock.Mock()
     transport.callback_data = mock.Mock(return_value=0)
@@ -64,7 +64,7 @@ async def prepare_transport_server(use_cls):
         use_cls.sslctx = use_cls.generate_ssl(
             True, certfile=cwd + "crt", keyfile=cwd + "key"
         )
-    transport = ModbusProtocol(use_cls, True)
+    transport = DummyProtocol(params=use_cls, is_server=True)
     transport.callback_connected = mock.Mock()
     transport.callback_disconnected = mock.Mock()
     transport.callback_data = mock.Mock(return_value=0)

--- a/test/transport/conftest.py
+++ b/test/transport/conftest.py
@@ -33,7 +33,7 @@ class DummyProtocol(ModbusProtocol):
             return self
         return DummyProtocol()
 
-    def close(self):
+    def close(self):  # pylint: disable=arguments-differ
         """Simulate close."""
         self.is_closing = True
 

--- a/test/transport/conftest.py
+++ b/test/transport/conftest.py
@@ -15,9 +15,8 @@ sys.path.extend(["examples", "../examples", "../../examples"])
 class DummyProtocol(ModbusProtocol):
     """Use in connection_made calls."""
 
-    def __init__(self, is_server=False):  # pylint: disable=super-init-not-called
+    def __init__(self, is_server=False):
         """Initialize."""
-        self.comm_params = CommParams()
         self.transport = None
         self.is_server = is_server
         self.is_closing = False
@@ -25,12 +24,10 @@ class DummyProtocol(ModbusProtocol):
         self.connection_made = mock.Mock()
         self.connection_lost = mock.Mock()
         self.reconnect_task: asyncio.Task = None
+        super().__init__(CommParams(), is_server)
 
-    def handle_new_connection(self):
-        """Handle incoming connect."""
-        if not self.is_server:
-            # Clients reuse the same object.
-            return self
+    def callback_new_connection(self) -> ModbusProtocol:
+        """Call when listener receive new connection request."""
         return DummyProtocol()
 
     def close(self):  # pylint: disable=arguments-differ

--- a/test/transport/conftest.py
+++ b/test/transport/conftest.py
@@ -27,6 +27,13 @@ class DummyProtocol(ModbusProtocol):
         """Call when listener receive new connection request."""
         return DummyProtocol(params=self.comm_params, is_server=False)
 
+    def callback_connected(self) -> None:
+        """Call when connection is succcesfull."""
+
+    def callback_disconnected(self, exc: Exception | None) -> None:
+        """Call when connection is lost."""
+        Log.debug("callback_disconnected called: {}", exc)
+
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
         Log.debug("callback_data called: {} addr={}", data, ":hex", addr)

--- a/test/transport/test_comm.py
+++ b/test/transport/test_comm.py
@@ -74,7 +74,7 @@ class TestTransportComm:
     async def test_listen(self, server, use_port):
         """Test listen()."""
         Log.debug("test_listen {}", use_port)
-        assert await server.transport_listen()
+        assert await server.listen()
         assert server.transport
         server.transport_close()
 
@@ -90,7 +90,7 @@ class TestTransportComm:
     async def test_listen_not_ok(self, server, use_port):
         """Test listen()."""
         Log.debug("test_listen_not_ok {}", use_port)
-        assert not await server.transport_listen()
+        assert not await server.listen()
         assert not server.transport
         server.transport_close()
 
@@ -106,7 +106,7 @@ class TestTransportComm:
     async def test_connected(self, client, server, use_comm_type, use_port):
         """Test connection and data exchange."""
         Log.debug("test_connected {}", use_port)
-        assert await server.transport_listen()
+        assert await server.listen()
         assert await client.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 1
@@ -145,7 +145,7 @@ class TestTransportComm:
     async def test_split_serial_packet(self, client, server, use_port):
         """Test connection and data exchange."""
         Log.debug("test_split_serial_packet {}", use_port)
-        assert await server.transport_listen()
+        assert await server.listen()
         assert await client.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 1
@@ -174,7 +174,7 @@ class TestTransportComm:
     async def test_serial_poll(self, client, server, use_port):
         """Test connection and data exchange."""
         Log.debug("test_serial_poll {}", use_port)
-        assert await server.transport_listen()
+        assert await server.listen()
         SerialTransport.force_poll = True
         assert await client.connect()
         await asyncio.sleep(0.5)
@@ -202,7 +202,7 @@ class TestTransportComm:
         """Test connection and data exchange."""
         Log.debug("test_connected {}", use_port)
         client.comm_params.reconnect_delay = 0.0
-        assert await server.transport_listen()
+        assert await server.listen()
         assert await client.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 1

--- a/test/transport/test_comm.py
+++ b/test/transport/test_comm.py
@@ -39,7 +39,7 @@ class TestTransportComm:
         """Test connect()."""
         Log.debug("test_connect {}", use_port)
         start = time.time()
-        assert not await client.transport_connect()
+        assert not await client.connect()
         delta = time.time() - start
         assert delta < client.comm_params.timeout_connect * FACTOR
         client.transport_close()
@@ -57,7 +57,7 @@ class TestTransportComm:
         """Test connect()."""
         Log.debug("test_connect_not_ok {}", use_port)
         start = time.time()
-        assert not await client.transport_connect()
+        assert not await client.connect()
         delta = time.time() - start
         assert delta < client.comm_params.timeout_connect * FACTOR
         client.transport_close()
@@ -107,7 +107,7 @@ class TestTransportComm:
         """Test connection and data exchange."""
         Log.debug("test_connected {}", use_port)
         assert await server.transport_listen()
-        assert await client.transport_connect()
+        assert await client.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 1
         server_connected = list(server.active_connections.values())[0]
@@ -146,7 +146,7 @@ class TestTransportComm:
         """Test connection and data exchange."""
         Log.debug("test_split_serial_packet {}", use_port)
         assert await server.transport_listen()
-        assert await client.transport_connect()
+        assert await client.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 1
         server_connected = list(server.active_connections.values())[0]
@@ -176,7 +176,7 @@ class TestTransportComm:
         Log.debug("test_serial_poll {}", use_port)
         assert await server.transport_listen()
         SerialTransport.force_poll = True
-        assert await client.transport_connect()
+        assert await client.connect()
         await asyncio.sleep(0.5)
         SerialTransport.force_poll = False
         assert len(server.active_connections) == 1
@@ -203,7 +203,7 @@ class TestTransportComm:
         Log.debug("test_connected {}", use_port)
         client.comm_params.reconnect_delay = 0.0
         assert await server.transport_listen()
-        assert await client.transport_connect()
+        assert await client.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 1
         server_connected = list(server.active_connections.values())[0]
@@ -212,7 +212,7 @@ class TestTransportComm:
         client2.callback_connected = mock.Mock()
         client2.callback_disconnected = mock.Mock()
         client2.callback_data = mock.Mock(return_value=0)
-        assert await client2.transport_connect()
+        assert await client2.connect()
         await asyncio.sleep(0.5)
         assert len(server.active_connections) == 2
         server2_connected = list(server.active_connections.values())[1]

--- a/test/transport/test_nullmodem.py
+++ b/test/transport/test_nullmodem.py
@@ -16,14 +16,14 @@ class TestTransportNullModem:
         base_ports[__class__.__name__] += 2
         return base_ports[__class__.__name__]
 
-    def test_init(self, dummy_protocol):
+    async def test_init(self, dummy_protocol):
         """Test initialize."""
         prot = dummy_protocol()
         NullModem(prot)
         prot.connection_made.assert_not_called()
         prot.connection_lost.assert_not_called()
 
-    def test_close(self, dummy_protocol):
+    async def test_close(self, dummy_protocol):
         """Test close."""
         prot = dummy_protocol()
         modem = NullModem(prot)
@@ -31,18 +31,18 @@ class TestTransportNullModem:
         prot.connection_made.assert_not_called()
         prot.connection_lost.assert_called_once()
 
-    def test_no_close(self, dummy_protocol):
+    async def test_no_close(self, dummy_protocol):
         """Test no close."""
         prot = dummy_protocol()
         NullModem(prot)
 
 
-    def test_close_no_protocol(self):
+    async def test_close_no_protocol(self):
         """Test close no protocol."""
         modem = NullModem(None)
         modem.close()
 
-    def test_close_twice(self, dummy_protocol):
+    async def test_close_twice(self, dummy_protocol):
         """Test close twice."""
         prot = dummy_protocol()
         modem = NullModem(prot)
@@ -51,7 +51,7 @@ class TestTransportNullModem:
         prot.connection_lost.assert_called_once()
         modem.close()  # test _is_closing works.
 
-    def test_listen(self, dummy_protocol, use_port):
+    async def test_listen(self, dummy_protocol, use_port):
         """Test listener (shared list)."""
         protocol = dummy_protocol(is_server=True)
         listen = NullModem.set_listener(use_port, protocol)
@@ -63,7 +63,7 @@ class TestTransportNullModem:
         protocol.connection_made.assert_not_called()
         protocol.connection_lost.assert_not_called()
 
-    def test_listen_twice(self, dummy_protocol, use_port):
+    async def test_listen_twice(self, dummy_protocol, use_port):
         """Test exception when listening twice."""
         listen1 = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         listen1.close()
@@ -72,7 +72,7 @@ class TestTransportNullModem:
         listen2.close()
         assert not NullModem.listeners
 
-    def test_listen_twice_fail(self, dummy_protocol, use_port):
+    async def test_listen_twice_fail(self, dummy_protocol, use_port):
         """Test exception when listening twice."""
         listen1 = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         with pytest.raises(AssertionError):
@@ -80,7 +80,7 @@ class TestTransportNullModem:
         listen1.close()
         assert not NullModem.listeners
 
-    def test_listen_triangle(self, dummy_protocol, use_port):
+    async def test_listen_triangle(self, dummy_protocol, use_port):
         """Test listener (shared list)."""
         listen1 = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         listen2 = NullModem.set_listener(use_port + 1, dummy_protocol(is_server=True))
@@ -90,7 +90,7 @@ class TestTransportNullModem:
         listen2.close()
         assert not NullModem.listeners
 
-    def test_is_dirty(self, dummy_protocol, use_port):
+    async def test_is_dirty(self, dummy_protocol, use_port):
         """Test is_dirty()."""
         assert not NullModem.is_dirty()
         listen1 = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
@@ -98,7 +98,7 @@ class TestTransportNullModem:
         listen1.close()
         assert not NullModem.is_dirty()
 
-    def test_connect(self, dummy_protocol, use_port):
+    async def test_connect(self, dummy_protocol, use_port):
         """Test connect."""
         prot_listen = dummy_protocol(is_server=True)
         listen = NullModem.set_listener(use_port, prot_listen)
@@ -118,12 +118,12 @@ class TestTransportNullModem:
         prot1.connection_made.assert_called_once()
         prot1.connection_lost.assert_called_once()
 
-    def test_connect_no_listen(self, dummy_protocol, use_port):
+    async def test_connect_no_listen(self, dummy_protocol, use_port):
         """Test connect without listen."""
         with pytest.raises(asyncio.TimeoutError):
             NullModem.set_connection(use_port, dummy_protocol())
 
-    def test_listen_close(self, dummy_protocol, use_port):
+    async def test_listen_close(self, dummy_protocol, use_port):
         """Test connect without listen."""
         listen = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         modem, _ = NullModem.set_connection(use_port, dummy_protocol())
@@ -132,7 +132,7 @@ class TestTransportNullModem:
         assert not NullModem.listeners
         modem.close()
 
-    def test_connect_multiple(self, dummy_protocol, use_port):
+    async def test_connect_multiple(self, dummy_protocol, use_port):
         """Test multiple connect."""
         listen1 = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         modem1, _ = NullModem.set_connection(use_port, dummy_protocol())
@@ -159,7 +159,7 @@ class TestTransportNullModem:
         assert modem2b in NullModem.connections
         modem2.close()
 
-    def test_is_dirty_with_connection(self, dummy_protocol, use_port):
+    async def test_is_dirty_with_connection(self, dummy_protocol, use_port):
         """Test connect."""
         assert not NullModem.is_dirty()
         listen = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
@@ -169,7 +169,7 @@ class TestTransportNullModem:
         listen.close()
         assert not NullModem.is_dirty()
 
-    def test_flow_write(self, dummy_protocol, use_port):
+    async def test_flow_write(self, dummy_protocol, use_port):
         """Test flow write."""
         listen = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         modem, _ = NullModem.set_connection(use_port, dummy_protocol())
@@ -184,7 +184,7 @@ class TestTransportNullModem:
         listen.close()
 
 
-    def test_flow_sendto(self, dummy_protocol, use_port):
+    async def test_flow_sendto(self, dummy_protocol, use_port):
         """Test flow sendto."""
         listen = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         modem, _ = NullModem.set_connection(use_port, dummy_protocol())
@@ -198,7 +198,7 @@ class TestTransportNullModem:
         modem.close()
         listen.close()
 
-    def test_flow_not_connected(self, dummy_protocol):
+    async def test_flow_not_connected(self, dummy_protocol):
         """Test flow not connected."""
         modem = NullModem(dummy_protocol())
         modem.sendto("no connection")
@@ -206,7 +206,7 @@ class TestTransportNullModem:
         modem.close()
 
 
-    def test_triangle_flow(self, dummy_protocol, use_port):
+    async def test_triangle_flow(self, dummy_protocol, use_port):
         """Test triangle flow."""
         listen = NullModem.set_listener(use_port, dummy_protocol(is_server=True))
         modem1, _ = NullModem.set_connection(use_port, dummy_protocol())
@@ -242,7 +242,7 @@ class TestTransportNullModem:
             [b"MANIPULATED", b"and", b"much more"],
         ],
     )
-    def test_manipulator(self, add_text, dummy_protocol, use_port):
+    async def test_manipulator(self, add_text, dummy_protocol, use_port):
         """Test manipulator."""
 
         def manipulator(data):
@@ -267,7 +267,7 @@ class TestTransportNullModem:
         modem.close()
         listen.close()
 
-    def test_abstract_methods(self, dummy_protocol):
+    async def test_abstract_methods(self, dummy_protocol):
         """Test asyncio abstract methods."""
         modem = NullModem(dummy_protocol())
         modem.abort()

--- a/test/transport/test_protocol.py
+++ b/test/transport/test_protocol.py
@@ -67,7 +67,7 @@ class TestTransportProtocol1:
         """Test properties."""
         server.call_create = mock.AsyncMock(return_value=(dummy_protocol(), None))
         server.loop = asyncio.get_running_loop()
-        assert await server.transport_listen()
+        assert await server.listen()
         assert server.loop
 
     async def test_connect_ok(self, client, dummy_protocol):
@@ -84,13 +84,13 @@ class TestTransportProtocol1:
     async def test_listen_ok(self, server, dummy_protocol):
         """Test listen_tcp()."""
         server.call_create = mock.AsyncMock(return_value=(dummy_protocol(), None))
-        assert await server.transport_listen()
+        assert await server.listen()
 
     async def test_listen_not_ok(self, server, dummy_protocol):
         """Test listen_tcp()."""
         server.call_create = mock.AsyncMock(return_value=(dummy_protocol(), None))
         server.call_create.side_effect = OSError("testing")
-        assert not await server.transport_listen()
+        assert not await server.listen()
 
     async def test_connection_made(self, client, use_clc, dummy_protocol):
         """Test connection_made()."""
@@ -246,7 +246,7 @@ class TestTransportProtocol2:
     async def test_transport_close_listen(self, server, dummy_protocol):
         """Test transport_close()."""
         dummy_protocol.close = mock.MagicMock()
-        await server.transport_listen()
+        await server.listen()
         server.active_connections = {"a": dummy_protocol()}
         server.transport_close()
         server.transport_close()
@@ -280,7 +280,7 @@ class TestTransportProtocol2:
     async def test_create_nullmodem(self, client, server):
         """Test create_nullmodem."""
         assert not await client.connect()
-        await server.transport_listen()
+        await server.listen()
         assert await client.connect()
         client.transport_close()
         server.transport_close()
@@ -349,7 +349,7 @@ class TestTransportProtocol2:
     async def test_init_create_serial(self, use_cls):
         """Test server serial with socket."""
         protocol = ModbusProtocol(use_cls, True)
-        await protocol.transport_listen()
+        await protocol.listen()
 
     @pytest.mark.parametrize("use_host", ["localhost"])
     @pytest.mark.parametrize("use_comm_type", [CommType.UDP])

--- a/test/transport/test_protocol.py
+++ b/test/transport/test_protocol.py
@@ -235,28 +235,31 @@ class TestTransportProtocol2:
 
     async def test_close_connection(self, server, dummy_protocol):
         """Test close()."""
-        dummy_protocol.close = mock.MagicMock()
-        server.connection_made(dummy_protocol())
+        prot = dummy_protocol()
+        prot.close = mock.MagicMock()
+        server.connection_made(prot)
         server.recv_buffer = b"abc"
         server.reconnect_task = mock.MagicMock()
         server.close()
-        dummy_protocol.close.assert_called_once()
+        prot.close.assert_called_once()
         assert not server.recv_buffer
 
     async def test_close_listen(self, server, dummy_protocol):
         """Test close()."""
-        dummy_protocol.close = mock.MagicMock()
+        prot = dummy_protocol()
+        prot.close = mock.MagicMock()
         await server.listen()
-        server.active_connections = {"a": dummy_protocol()}
+        server.active_connections = {"a": prot}
         server.close()
         server.close()
         assert not server.active_connections
 
     async def test_close2(self, server, client, dummy_protocol):
         """Test close()."""
-        dummy_protocol.abort = mock.Mock()
-        dummy_protocol.close = mock.Mock()
-        client.connection_made(dummy_protocol())
+        prot = dummy_protocol()
+        prot.abort = mock.Mock()
+        prot.close = mock.Mock()
+        client.connection_made(prot)
         client.recv_buffer = b"abc"
         client.reconnect_task = mock.MagicMock()
         client.listener = server
@@ -312,7 +315,7 @@ class TestTransportProtocol2:
 
     async def test_str_magic(self, use_clc, client):
         """Test magic."""
-        assert str(client) == f"ModbusProtocol({use_clc.comm_name})"
+        assert str(client) == f"DummyProtocol({use_clc.comm_name})"
 
     def test_generate_ssl_cert(self, use_clc):
         """Test ssl generation."""

--- a/test/transport/test_protocol.py
+++ b/test/transport/test_protocol.py
@@ -110,7 +110,7 @@ class TestTransportProtocol1:
         assert not client.recv_buffer
         assert client.reconnect_task
         client.callback_disconnected.assert_called_once()
-        client.transport_close()
+        client.close()
         assert not client.reconnect_task
         assert not client.reconnect_delay_current
 
@@ -152,11 +152,11 @@ class TestTransportProtocol1:
         client.callback_data(b"abcd")
 
     async def test_handle_local_echo(self, client):
-        """Test transport_send()."""
+        """Test send()."""
         client.comm_params.handle_local_echo = True
         client.transport = mock.Mock()
         test_data = b"abc"
-        client.transport_send(test_data)
+        client.send(test_data)
         client.data_received(test_data)
         assert not client.recv_buffer
         client.data_received(test_data)
@@ -164,11 +164,11 @@ class TestTransportProtocol1:
         assert not client.sent_buffer
 
     async def test_handle_local_echo_udp(self, client):
-        """Test transport_send()."""
+        """Test send()."""
         client.comm_params.handle_local_echo = True
         client.transport = mock.Mock()
         test_data = b"abc"
-        client.transport_send(test_data)
+        client.send(test_data)
         client.datagram_received(test_data, ("127.0.0.1", 502))
         assert not client.recv_buffer
         assert not client.sent_buffer
@@ -177,20 +177,20 @@ class TestTransportProtocol1:
         assert not client.sent_buffer
 
     async def test_handle_local_echo_none(self, client):
-        """Test transport_send()."""
+        """Test send()."""
         client.comm_params.handle_local_echo = True
         client.transport = mock.Mock()
         test_data = b"abc"
-        client.transport_send(b"no echo")
+        client.send(b"no echo")
         client.datagram_received(test_data, ("127.0.0.1", 502))
         assert client.recv_buffer == test_data
         assert not client.sent_buffer
 
     async def test_handle_local_echo_partial(self, client):
-        """Test transport_send()."""
+        """Test send()."""
         client.comm_params.handle_local_echo = True
         client.transport = mock.Mock()
-        client.transport_send(b"partial")
+        client.send(b"partial")
         client.datagram_received(b"par", ("127.0.0.1", 502))
         client.datagram_received(b"tialresponse", ("127.0.0.1", 502))
         assert client.recv_buffer == b"response"
@@ -216,44 +216,44 @@ class TestTransportProtocol2:
         """Test error_received."""
         client.error_received(Exception("test call"))
 
-    async def test_transport_send(self, client):
-        """Test transport_send()."""
+    async def test_send(self, client):
+        """Test send()."""
         client.transport = mock.Mock()
-        client.transport_send(b"abc")
+        client.send(b"abc")
 
-    async def test_transport_send_udp(self, client):
-        """Test transport_send()."""
-        client.transport = mock.Mock()
-        client.comm_params.comm_type = CommType.UDP
-        client.transport_send(b"abc", addr=("localhost", 502))
-
-    async def test_transport_send_udp_no_addr(self, client):
-        """Test transport_send()."""
+    async def test_send_udp(self, client):
+        """Test send()."""
         client.transport = mock.Mock()
         client.comm_params.comm_type = CommType.UDP
-        client.transport_send(b"abc")
+        client.send(b"abc", addr=("localhost", 502))
 
-    async def test_transport_close_connection(self, server, dummy_protocol):
-        """Test transport_close()."""
+    async def test_send_udp_no_addr(self, client):
+        """Test send()."""
+        client.transport = mock.Mock()
+        client.comm_params.comm_type = CommType.UDP
+        client.send(b"abc")
+
+    async def test_close_connection(self, server, dummy_protocol):
+        """Test close()."""
         dummy_protocol.close = mock.MagicMock()
         server.connection_made(dummy_protocol())
         server.recv_buffer = b"abc"
         server.reconnect_task = mock.MagicMock()
-        server.transport_close()
+        server.close()
         dummy_protocol.close.assert_called_once()
         assert not server.recv_buffer
 
-    async def test_transport_close_listen(self, server, dummy_protocol):
-        """Test transport_close()."""
+    async def test_close_listen(self, server, dummy_protocol):
+        """Test close()."""
         dummy_protocol.close = mock.MagicMock()
         await server.listen()
         server.active_connections = {"a": dummy_protocol()}
-        server.transport_close()
-        server.transport_close()
+        server.close()
+        server.close()
         assert not server.active_connections
 
-    async def test_transport_close2(self, server, client, dummy_protocol):
-        """Test transport_close()."""
+    async def test_close2(self, server, client, dummy_protocol):
+        """Test close()."""
         dummy_protocol.abort = mock.Mock()
         dummy_protocol.close = mock.Mock()
         client.connection_made(dummy_protocol())
@@ -261,7 +261,7 @@ class TestTransportProtocol2:
         client.reconnect_task = mock.MagicMock()
         client.listener = server
         server.active_connections = {client.unique_id: dummy_protocol}
-        client.transport_close()
+        client.close()
         assert not server.active_connections
 
     async def test_reset_delay(self, client, use_clc):
@@ -275,15 +275,15 @@ class TestTransportProtocol2:
         assert not client.is_active()
         client.connection_made(mock.Mock())
         assert client.is_active()
-        client.transport_close()
+        client.close()
 
     async def test_create_nullmodem(self, client, server):
         """Test create_nullmodem."""
         assert not await client.connect()
         await server.listen()
         assert await client.connect()
-        client.transport_close()
-        server.transport_close()
+        client.close()
+        server.close()
 
     async def test_handle_new_connection(self, client, server):
         """Test handle_new_connection()."""
@@ -305,10 +305,10 @@ class TestTransportProtocol2:
 
     async def test_with_magic(self, client):
         """Test magic."""
-        client.transport_close = mock.MagicMock()
+        client.close = mock.MagicMock()
         async with client:
             pass
-        client.transport_close.assert_called_once()
+        client.close.assert_called_once()
 
     async def test_str_magic(self, use_clc, client):
         """Test magic."""

--- a/test/transport/test_protocol.py
+++ b/test/transport/test_protocol.py
@@ -61,7 +61,7 @@ class TestTransportProtocol1:
     async def test_loop_connect(self, client, dummy_protocol):
         """Test properties."""
         client.call_create = mock.AsyncMock(return_value=(dummy_protocol(), None))
-        assert await client.transport_connect()
+        assert await client.connect()
 
     async def test_loop_listen(self, server, dummy_protocol):
         """Test properties."""
@@ -73,13 +73,13 @@ class TestTransportProtocol1:
     async def test_connect_ok(self, client, dummy_protocol):
         """Test properties."""
         client.call_create = mock.AsyncMock(return_value=(dummy_protocol(), None))
-        assert await client.transport_connect()
+        assert await client.connect()
 
     async def test_connect_not_ok(self, client, dummy_protocol):
         """Test properties."""
         client.call_create = mock.AsyncMock(return_value=(dummy_protocol(), None))
         client.call_create.side_effect = asyncio.TimeoutError("test")
-        assert not await client.transport_connect()
+        assert not await client.connect()
 
     async def test_listen_ok(self, server, dummy_protocol):
         """Test listen_tcp()."""
@@ -279,9 +279,9 @@ class TestTransportProtocol2:
 
     async def test_create_nullmodem(self, client, server):
         """Test create_nullmodem."""
-        assert not await client.transport_connect()
+        assert not await client.connect()
         await server.transport_listen()
-        assert await client.transport_connect()
+        assert await client.connect()
         client.transport_close()
         server.transport_close()
 
@@ -293,11 +293,11 @@ class TestTransportProtocol2:
     async def test_do_reconnect(self, client):
         """Test do_reconnect()."""
         client.comm_params.reconnect_delay = 0.01
-        client.transport_connect = mock.AsyncMock(side_effect=[False, True])
+        client.connect = mock.AsyncMock(side_effect=[False, True])
         await client.do_reconnect()
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay * 2
         assert not client.reconnect_task
-        client.transport_connect.side_effect = asyncio.CancelledError("stop loop")
+        client.connect.side_effect = asyncio.CancelledError("stop loop")
         client.comm_params.on_reconnect_callback = mock.Mock()
         await client.do_reconnect()
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay

--- a/test/transport/test_reconnect.py
+++ b/test/transport/test_reconnect.py
@@ -24,7 +24,7 @@ class TestTransportReconnect:
         assert not client.reconnect_task
         assert not client.reconnect_delay_current
         assert client.call_create.called
-        client.transport_close()
+        client.close()
 
     async def test_reconnect_call(self, client):
         """Test connection_lost()."""
@@ -40,7 +40,7 @@ class TestTransportReconnect:
         assert client.call_create.call_count == 2
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay * 2
         assert client.comm_params.on_reconnect_callback.called
-        client.transport_close()
+        client.close()
 
     async def test_multi_reconnect_call(self, client):
         """Test connection_lost()."""
@@ -58,7 +58,7 @@ class TestTransportReconnect:
         await asyncio.sleep(client.reconnect_delay_current * 1.8)
         assert client.call_create.call_count >= 4
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay_max
-        client.transport_close()
+        client.close()
 
     async def test_reconnect_call_ok(self, client):
         """Test connection_lost()."""
@@ -71,4 +71,4 @@ class TestTransportReconnect:
         assert client.call_create.call_count == 2
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay
         assert not client.reconnect_task
-        client.transport_close()
+        client.close()

--- a/test/transport/test_reconnect.py
+++ b/test/transport/test_reconnect.py
@@ -19,7 +19,7 @@ class TestTransportReconnect:
         """Test connection_lost()."""
         client.loop = asyncio.get_running_loop()
         client.call_create = mock.AsyncMock(return_value=(None, None))
-        await client.transport_connect()
+        await client.connect()
         client.connection_lost(RuntimeError("Connection lost"))
         assert not client.reconnect_task
         assert not client.reconnect_delay_current
@@ -31,7 +31,7 @@ class TestTransportReconnect:
         client.comm_params.on_reconnect_callback = mock.MagicMock()
         client.loop = asyncio.get_running_loop()
         client.call_create = mock.AsyncMock(return_value=(None, None))
-        await client.transport_connect()
+        await client.connect()
         client.connection_made(mock.Mock())
         client.connection_lost(RuntimeError("Connection lost"))
         assert client.reconnect_task
@@ -46,7 +46,7 @@ class TestTransportReconnect:
         """Test connection_lost()."""
         client.loop = asyncio.get_running_loop()
         client.call_create = mock.AsyncMock(return_value=(None, None))
-        await client.transport_connect()
+        await client.connect()
         client.connection_made(mock.Mock())
         client.connection_lost(RuntimeError("Connection lost"))
         await asyncio.sleep(client.reconnect_delay_current * 1.8)
@@ -64,7 +64,7 @@ class TestTransportReconnect:
         """Test connection_lost()."""
         client.loop = asyncio.get_running_loop()
         client.call_create = mock.AsyncMock(return_value=(mock.Mock(), mock.Mock()))
-        await client.transport_connect()
+        await client.connect()
         client.connection_made(mock.Mock())
         client.connection_lost(RuntimeError("Connection lost"))
         await asyncio.sleep(client.reconnect_delay_current * 1.8)


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Rename:
    transport_connect --> connect
    transport_listen --> listen
    transport_send --> send

Make DummyProtocol a "real" implementation of ModbusProtocol (to simulate real usage)

callback_* in transport is abstract.

