### PR TITLE
Fix field encoding of Read File Record Response

### DIFF
--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -181,7 +181,7 @@ class ReadFileRecordResponse(ModbusResponse):
         total = sum(record.response_length + 1 for record in self.records)
         packet = struct.pack("B", total)
         for record in self.records:
-            packet += struct.pack(">BB", 0x06, record.record_length)
+            packet += struct.pack(">BB", record.record_length, 0x06)
             packet += record.record_data
         return packet
 

--- a/test/test_file_message.py
+++ b/test/test_file_message.py
@@ -161,10 +161,10 @@ class TestBitMessage:
 
     def test_read_file_record_response_encode(self):
         """Test basic bit message encoding/decoding."""
-        records = [FileRecord(record_data=b"\x00\x01\x02\x03")]
+        records = [FileRecord(record_data=b"\x00\x01\x02\x03\x04\x05")]
         handle = ReadFileRecordResponse(records)
         result = handle.encode()
-        assert result == b"\x06\x06\x02\x00\x01\x02\x03"
+        assert result == b"\x08\x03\x06\x00\x01\x02\x03\x04\x05"
 
     def test_read_file_record_response_decode(self):
         """Test basic bit message encoding/decoding."""


### PR DESCRIPTION
The Modbus spec V1.1b3 states the following field order:

1. Function Code (0x14)
2. Resp. data Length (in bytes)
3. Sub-Req. x, File Resp. length (in registers)
4. Sub-Req. x, Reference Type: 0x6 (fixed)
5. Sub-Req. x, Record Data
6. Sub-Req. x+1, ...

Previously, field 4 was before field 3.
