### PR TITLE
Repair client close() (it overrides ModbusProtocol so intern= is needed, even though ugly).

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -124,12 +124,12 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         """
         self.framer.decoder.register(custom_response_class)
 
-    def close(self, reconnect: bool = False) -> None:  # type: ignore[override] # pylint: disable=arguments-differ
+    def close(self, reconnect: bool = False, intern: bool = False) -> None:  # type: ignore[override]
         """Close connection."""
         if reconnect:
             self.connection_lost(asyncio.TimeoutError("Server not responding"))
         else:
-            super().close()
+            super().close(intern)
 
     def idle_time(self) -> float:
         """Time before initiating next transaction (call **sync**).

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -101,9 +101,9 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
         Log.debug("Connecting to {}.", self.comm_params.host)
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False) -> None:  # type: ignore[override] # pylint: disable=arguments-differ
+    def close(self, reconnect: bool = False, intern: bool = False) -> None:  # type: ignore[override]
         """Close connection."""
-        super().close(reconnect=reconnect)
+        super().close(reconnect=reconnect, intern=intern)
 
 
 class ModbusSerialClient(ModbusBaseSyncClient):

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -101,7 +101,7 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
         Log.debug("Connecting to {}.", self.comm_params.host)
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False) -> None:  # type: ignore[override]
+    def close(self, reconnect: bool = False) -> None:  # type: ignore[override] # pylint: disable=arguments-differ
         """Close connection."""
         super().close(reconnect=reconnect)
 

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -87,9 +87,9 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
         )
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False) -> None:  # type: ignore[override] # pylint: disable=arguments-differ
+    def close(self, reconnect: bool = False, intern: bool = False) -> None:  # type: ignore[override]
         """Close connection."""
-        super().close(reconnect=reconnect)
+        super().close(reconnect=reconnect, intern=intern)
 
 
 class ModbusTcpClient(ModbusBaseSyncClient):

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -87,7 +87,7 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
         )
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False) -> None:  # type: ignore[override]
+    def close(self, reconnect: bool = False) -> None:  # type: ignore[override] # pylint: disable=arguments-differ
         """Close connection."""
         super().close(reconnect=reconnect)
 


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
The clients inherit directly from ModbusProtocol, which means the API close() overrides the internal (transport) close(), giving problems.

the intern= was only meant for internal usage, but is added to the client close() in order to have a disconnect work.

This is UGLY and should not be so, but it is a fast fix, a proper solution will come later.
