### PR TITLE
Cleanup dead resetFrame code

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -131,15 +131,14 @@ class ModbusServerRequestHandler(ModbusProtocol):
         )
 
     async def handle(self):
-        """Return Asyncio coroutine which represents a single conversation.
-
-        between the modbus slave and master
+        """Coroutine which represents a single master <=> slave conversation.
 
         Once the client connection is established, the data chunks will be
         fed to this coroutine via the asyncio.Queue object which is fed by
         the ModbusServerRequestHandler class's callback Future.
 
-        This callback future gets data from either
+        This callback future gets data from either asyncio.BaseProtocol.data_received
+        or asyncio.DatagramProtocol.datagram_received.
 
         This function will execute without blocking in the while-loop and
         yield to the asyncio event loop when the frame is exhausted.

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -46,7 +46,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
         super().__init__(params, False)
         self.server = owner
         self.running = False
-        self.receive_queue = asyncio.Queue()
+        self.receive_queue: asyncio.Queue = asyncio.Queue()
         self.handler_task = None  # coroutine to be run on asyncio loop
         self.framer: ModbusFramer
 
@@ -130,7 +130,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
             single=single,
         )
 
-    async def handle(self):
+    async def handle(self) -> None:
         """Coroutine which represents a single master <=> slave conversation.
 
         Once the client connection is established, the data chunks will be


### PR DESCRIPTION
`mypy` flags the `else` branch as unreachable because the `isinstance` check always passes.  I think this happened in https://github.com/pymodbus-dev/pymodbus/commit/ce67df9bf71c2a7ff8a7263fed1a602dfe49e935 but went unnoticed because the function isn't annotated.

https://github.com/pymodbus-dev/pymodbus/blob/214c7ed4ef27c686ad5d161b78477cc5aa6cb1cc/pymodbus/server/async_io.py#L162-L172

So this PR deletes the entire conditional, as well as the now-useless `reset_frame` flag.

Also, it cleans up the docstring mangled by https://github.com/pymodbus-dev/pymodbus/commit/18aa46349a0ceae65479b4b915f9657b3cb4854

