### PR TITLE
Improve simulator type hints

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -753,6 +753,7 @@ class ModbusSimulatorContext:
 
         :meta private:
         """
+        check: tuple
         if func_code in self._bits_func_code:
             # Bit access
             check = (CellType.BITS, -1)
@@ -762,7 +763,7 @@ class ModbusSimulatorContext:
             check = (CellType.UINT16, CellType.STRING)
             reg_step = 1
         else:
-            check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)  # type: ignore[assignment]
+            check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)
             reg_step = 2
 
         for i in range(real_address, real_address + count, reg_step):

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -107,7 +107,7 @@ class Setup:
         """Initialize."""
         self.runtime = runtime
         self.config = {}
-        self.config_types = {
+        self.config_types: dict[str, dict[str, Any]] = {
             Label.type_bits: {
                 Label.type: CellType.BITS,
                 Label.next: None,
@@ -748,7 +748,7 @@ class ModbusSimulatorContext:
     # Internal helper methods
     # --------------------------------------------
 
-    def validate_type(self, func_code, real_address, count):
+    def validate_type(self, func_code, real_address, count) -> bool:
         """Check if request is done against correct type.
 
         :meta private:
@@ -762,7 +762,7 @@ class ModbusSimulatorContext:
             check = (CellType.UINT16, CellType.STRING)
             reg_step = 1
         else:
-            check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)
+            check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)  # type: ignore[assignment]
             reg_step = 2
 
         for i in range(real_address, real_address + count, reg_step):


### PR DESCRIPTION
Solves another 3 `mypy` errors.

`config_types` below seemed like a good candidate for using a `TypedDict` (~equivalent to a `struct`)
﻿https://github.com/pymodbus-dev/pymodbus/blob/214c7ed4ef27c686ad5d161b78477cc5aa6cb1cc/pymodbus/datastore/simulator.py#L110-L117

However, I ran into issues:
(1) `mypy` doesn't support using variables as `TypedDict` keys: https://github.com/python/mypy/issues/7178.  This unfortunate deficiency means `TypedDict` is not suitable here until `mypy` improves.
(2) Using `type` as a key is messy, since it's a ["soft keyword"](https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords).  Maybe it would be better to use `kind`?  This should have a benefit beyond `mypy`.
