### PR TITLE
Use a TypedDict for simulator type hints

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -107,7 +107,7 @@ class Setup:
         """Initialize."""
         self.runtime = runtime
         self.config = {}
-        self.config_types = {
+        self.config_types: dict[str, dict[str, Any]] = {
             Label.type_bits: {
                 Label.type: CellType.BITS,
                 Label.next: None,
@@ -748,7 +748,7 @@ class ModbusSimulatorContext:
     # Internal helper methods
     # --------------------------------------------
 
-    def validate_type(self, func_code, real_address, count):
+    def validate_type(self, func_code, real_address, count) -> bool:
         """Check if request is done against correct type.
 
         :meta private:
@@ -762,7 +762,7 @@ class ModbusSimulatorContext:
             check = (CellType.UINT16, CellType.STRING)
             reg_step = 1
         else:
-            check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)
+            check = (CellType.UINT32, CellType.FLOAT32, CellType.STRING)  # type: ignore[assignment]
             reg_step = 2
 
         for i in range(real_address, real_address + count, reg_step):


### PR DESCRIPTION
See https://github.com/pymodbus-dev/pymodbus/pull/2084.
This is mostly a demonstration of how `TypedDict` could be used.

However, it made me question whether we should remove the `Label` abstraction.  
What is the purpose for cases where the label is identical to the key?  e.g. `Label.value == 'value'`.  

Would it not be easier to only use it when they differ e.g. `Label.co_size == 'co size'`?

Could the labels be generated programmatically?  (It looks like replacing a space with an underscore and remove `type_` prefix would work in all cases).
