### PR TITLE
Use explicit ValueError when called with incorrect function code

### DIFF
--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -50,12 +50,13 @@ class RemoteSlaveContext(ModbusBaseSlaveContext):
     def setValues(self, fc_as_hex, address, values):
         """Set the datastore with the supplied values."""
         group_fx = self.decode(fc_as_hex)
-        if fc_as_hex in self._write_fc:
-            func_fc = self.__set_callbacks[f"{group_fx}{fc_as_hex}"]
-            if fc_as_hex in {0x0F, 0x10}:
-                self.result = func_fc(address, values)
-            else:
-                self.result = func_fc(address, values[0])
+        if fc_as_hex not in self._write_fc:
+            raise ValueError(f"setValues() called with an non-write function code {fc_as_hex}")
+        func_fc = self.__set_callbacks[f"{group_fx}{fc_as_hex}"]
+        if fc_as_hex in {0x0F, 0x10}:
+            self.result = func_fc(address, values)
+        else:
+            self.result = func_fc(address, values[0])
         if self.result.isError():
             return self.result
         return None

--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -53,7 +53,7 @@ class RemoteSlaveContext(ModbusBaseSlaveContext):
         if fc_as_hex not in self._write_fc:
             raise ValueError(f"setValues() called with an non-write function code {fc_as_hex}")
         func_fc = self.__set_callbacks[f"{group_fx}{fc_as_hex}"]
-        if fc_as_hex in {0x0F, 0x10}:
+        if fc_as_hex in {0x0F, 0x10}:  # Write Multiple Coils, Write Multiple Registers
             self.result = func_fc(address, values)
         else:
             self.result = func_fc(address, values[0])


### PR DESCRIPTION
See https://github.com/pymodbus-dev/pymodbus/pull/1599 for background.

The current code has a check `if fc_as_hex in self._write_fc:`.  If this check fails, it means the function was called with a Modbus function code which isn't a write.

This will never happen normally.  If there is bad calling code, a confusing `NameError` is thrown because `self.result` is undefined.

This PR makes the check explicit (and solves another `mypy` error).  An alternative is to simply delete the check.
