### PR TITLE
Improve transport types

### DIFF
--- a/pymodbus/transport/serialtransport.py
+++ b/pymodbus/transport/serialtransport.py
@@ -154,8 +154,8 @@ class SerialTransport(asyncio.Transport):
                     self.intern_write_ready()
                 if self.sync_serial.in_waiting:
                     self.intern_read_ready()
-        except asyncio.CancelledError as exc:
-            self.close(exc)
+        except asyncio.CancelledError:
+            self.close(None)
 
 
 async def create_serial_connection(

--- a/pymodbus/transport/serialtransport.py
+++ b/pymodbus/transport/serialtransport.py
@@ -120,19 +120,19 @@ class SerialTransport(asyncio.Transport):
 
     # ------------------------------------------------
 
-    def intern_read_ready(self):
+    def intern_read_ready(self) -> None:
         """Test if there are data waiting."""
         try:
             if data := self.sync_serial.read(1024):
-                self.intern_protocol.data_received(data)
+                self.intern_protocol.data_received(data)  # type: ignore[attr-defined]
         except serial.SerialException as exc:
             self.close(exc=exc)
 
-    def intern_write_ready(self):
+    def intern_write_ready(self) -> None:
         """Asynchronously write buffered data."""
         data = b"".join(self.intern_write_buffer)
         try:
-            if (nlen := self.sync_serial.write(data)) < len(data):
+            if (nlen := self.sync_serial.write(data)) and nlen < len(data):
                 self.intern_write_buffer = [data[nlen:]]
                 if not self.poll_task:
                     self.async_loop.add_writer(


### PR DESCRIPTION
The first commit is straightforward.

For the second one, `mypy` complains that we are passing `asyncio.CancelledError` to `close` which only takes `Exception`.  As of Python 3.8 `asyncio.CancelledError` is [dervied from `BaseException` instead](https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.CancelledError).  It will therefore not be caught or suppressed by anything acting on `Exception`.

https://github.com/pymodbus-dev/pymodbus/blob/7c4a310e10abfc17b42330c3474758b67e50dda8/pymodbus/transport/serialtransport.py#L53-L55

I don't see any use in passing it, so I just used `None`.  The alternative is to just `type: ignore`
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

