### PR TITLE
Remove pointless try/except in polling_task

### DIFF
--- a/test/transport/test_serial.py
+++ b/test/transport/test_serial.py
@@ -1,5 +1,6 @@
 """Test transport."""
 import asyncio
+import contextlib
 import os
 from functools import partial
 from unittest import mock
@@ -114,7 +115,8 @@ class TestTransportSerial:
         comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy")
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.read.side_effect = asyncio.CancelledError("test")
-        await comm.polling_task()
+        with contextlib.suppress(asyncio.CancelledError):
+            await comm.polling_task()
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_poll_task(self):


### PR DESCRIPTION
See https://github.com/pymodbus-dev/pymodbus/pull/2090.  This PR goes a step further.


This code is a stack of clever hacks.
https://github.com/pymodbus-dev/pymodbus/blob/d6704a2ff9abddd0de29d6d50a1650a9d71c084c/pymodbus/transport/serialtransport.py#L45-L48

The purpose of this code is to cancel `self.poll_task()` and then set it to `None` afterwards.

Because the code is sync, `await` cannot be used to ensure the cancellation.  
Hack #1 - use `ensure_future`

Then `ruff` complains with [`RUF006`](https://docs.astral.sh/ruff/rules/asyncio-dangling-task/).  This could have been safely ignored - nobody cares if the GC cleans up, since it's immediately set to `None`.  Instead...
Hack #2 - use `self.future` to hold a reference.

Next `mypy` complains that `self.future` is untyped.
Hack #3 - add an annotation to the constructor.


Looking at `polling_task`, I see no purpose to catching `asyncio.CancelledTask`.  All it does is call `self.close()`.... which is the very code that cancelled it!
I think the whole `try/Except` and stack of hacks can be removed. :)

