### PR TITLE
Remove dead code from framer

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -13,7 +13,6 @@ __all__ = [
 # pylint: disable=missing-type-doc
 import struct
 import time
-from contextlib import suppress
 from functools import partial
 from threading import RLock
 
@@ -379,17 +378,6 @@ class ModbusTransactionManager:
                         )
                         length = struct.unpack(">H", read_min[4:6])[0] - 1
                         expected_response_length = h_size + length
-                    elif expected_response_length is None and isinstance(
-                        self.client.framer, ModbusRtuFramer
-                    ):
-                        with suppress(
-                            IndexError  # response length indeterminate with available bytes
-                        ):
-                            expected_response_length = (
-                                self.client.framer.get_expected_response_length(
-                                    read_min
-                                )
-                            )
                     if expected_response_length is not None:
                         expected_response_length -= min_size
                         total = expected_response_length + min_size


### PR DESCRIPTION
`get_expected_response_length` was totally removed in https://github.com/pymodbus-dev/pymodbus/commit/9cf07243838c12563b2ad710efbb70fb1b0c0959#diff-126482fdc00ef924006c76c322c03c809c8b598b66f0af83ab9f5aade84a6a11L314-L323 and therefore this entire branch is useless.

﻿<!--  Please raise your PR's against the `dev` branch instead of `master` -->
