### PR TITLE
Remove control encode in framers

### DIFF
--- a/pymodbus/framer/ascii_framer.py
+++ b/pymodbus/framer/ascii_framer.py
@@ -1,7 +1,6 @@
 """Ascii_framer."""
 # pylint: disable=missing-type-doc
-import struct
-from binascii import a2b_hex, b2a_hex
+from binascii import a2b_hex
 
 from pymodbus.exceptions import ModbusIOException
 from pymodbus.framer.base import BYTE_ORDER, FRAME_HEADER, ModbusFramer
@@ -96,29 +95,9 @@ class ModbusAsciiFramer(ModbusFramer):
     def buildPacket(self, message):
         """Create a ready to send modbus packet.
 
-        Built off of a  modbus request/response
-
         :param message: The request/response to send
         :return: The encoded packet
         """
-        encoded = message.encode()
-        buffer = struct.pack(
-            ASCII_FRAME_HEADER, message.slave_id, message.function_code
-        )
-        checksum = MessageAscii.compute_LRC(buffer + encoded)
-
-        packet = bytearray()
-        packet.extend(self._start)
-        packet.extend(f"{message.slave_id:02x}{message.function_code:02x}".encode())
-        packet.extend(b2a_hex(encoded))
-        packet.extend(f"{checksum:02x}".encode())
-        packet.extend(self._end)
-        packet = bytes(packet).upper()
-
-        data = message.function_code.to_bytes(1,'big') + encoded
-        packet_new = self.message_handler.encode(data, message.slave_id, message.transaction_id)
-        assert packet == packet_new, "ASCII FRAMER BuildPacket failed!"
+        data = message.function_code.to_bytes(1,'big') + message.encode()
+        packet = self.message_handler.encode(data, message.slave_id, message.transaction_id)
         return packet
-
-
-# __END__

--- a/pymodbus/framer/binary_framer.py
+++ b/pymodbus/framer/binary_framer.py
@@ -132,6 +132,3 @@ class ModbusBinaryFramer(ModbusFramer):
                 array.append(item)
             array.append(item)
         return bytes(array)
-
-
-# __END__

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -172,16 +172,8 @@ class ModbusRtuFramer(ModbusFramer):
 
         :param message: The populated request/response to send
         """
-        data = message.encode()
-        packet = (
-            struct.pack(RTU_FRAME_HEADER, message.slave_id, message.function_code)
-            + data
-        )
-        packet += struct.pack(">H", MessageRTU.compute_CRC(packet))
-
-        data_new = message.function_code.to_bytes(1, 'big') + data
-        packet_new = self.message_handler.encode(data_new, message.slave_id, message.transaction_id)
-        assert packet == packet_new, "RTU FRAMER BuildPacket failed!"
+        data = message.function_code.to_bytes(1, 'big') + message.encode()
+        packet = self.message_handler.encode(data, message.slave_id, message.transaction_id)
 
         # Ensure that transaction is actually the slave id for serial comms
         if message.slave_id:

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -118,18 +118,6 @@ class ModbusSocketFramer(ModbusFramer):
 
         :param message: The populated request/response to send
         """
-        data = message.encode()
-        packet = struct.pack(
-            SOCKET_FRAME_HEADER,
-            message.transaction_id,
-            message.protocol_id,
-            len(data) + 2,
-            message.slave_id,
-            message.function_code,
-        )
-        packet += data
-
-        data_new = message.function_code.to_bytes(1, 'big') + data
-        packet_new = self.message_handler.encode(data_new, message.slave_id, message.transaction_id)
-        assert packet == packet_new, "SOCKET FRAMER BuildPacket failed!"
+        data = message.function_code.to_bytes(1, 'big') + message.encode()
+        packet = self.message_handler.encode(data, message.slave_id, message.transaction_id)
         return packet

--- a/pymodbus/framer/tls_framer.py
+++ b/pymodbus/framer/tls_framer.py
@@ -79,14 +79,6 @@ class ModbusTlsFramer(ModbusFramer):
 
         :param message: The populated request/response to send
         """
-        data = message.encode()
-        packet = struct.pack(TLS_FRAME_HEADER, message.function_code)
-        packet += data
-
-        data_new = message.function_code.to_bytes(1,'big') + data
-        packet_new = self.message_encoder.encode(data_new, message.slave_id, message.transaction_id)
-        assert packet == packet_new, "TLS FRAMER BuildPacket failed!"
+        data = message.function_code.to_bytes(1,'big') + message.encode()
+        packet = self.message_encoder.encode(data, message.slave_id, message.transaction_id)
         return packet
-
-
-# __END__


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
The control code is enabled in v3.6.5 so it can be safely removed on dev.

This is part of the ongoing operation to activate the new message layer.
