### PR TITLE
enable `mypy --check-untyped-defs`

### DIFF
--- a/pymodbus/diag_message.py
+++ b/pymodbus/diag_message.py
@@ -382,7 +382,7 @@ class ChangeAsciiInputDelimiterRequest(DiagnosticStatusSimpleRequest):
 
         :returns: The initialized response message
         """
-        char = (self.message & 0xFF00) >> 8
+        char = (self.message & 0xFF00) >> 8  # type: ignore[operator]
         _MCB._setDelimiter(char)  # pylint: disable=protected-access
         return ChangeAsciiInputDelimiterResponse(self.message)
 

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -241,7 +241,7 @@ class ModbusTransactionManager:
                                 "/Unable to decode response"
                             )
                             response = ModbusIOException(
-                                last_exception, request.function_code
+                                last_exception, request.function_code  # type: ignore[assignment]
                             )
                         self.client.close()
                     if hasattr(self.client, "state"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ strict_concatenate = false
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
 warn_unreachable = true
+check_untyped_defs = true
 
 [tool.distutils]
 bdist_wheel = {}


### PR DESCRIPTION
![image](https://github.com/pymodbus-dev/pymodbus/assets/52292902/c515a155-bd25-4211-9987-71c19dbee339)

When I started, there were over >150 `mypy` errors in untyped definitions.  They have all been slowly solved.

Remaining ignores:
* for `diag_message`, `pyright` is smart enough to infer `int`, but `mypy` is not.  Actually, this code has a lot of type problems and needs a closer look
* `ascii_framer` is going to be deleted soon.  (See https://github.com/pymodbus-dev/pymodbus/pull/2086)
* the `transaction` code also has messy types but is being reworked
