### PR TITLE
Solve transport close() problem (regression).

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -124,12 +124,12 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         """
         self.framer.decoder.register(custom_response_class)
 
-    def close(self, reconnect: bool = False, intern: bool = False) -> None:  # type: ignore[override]
+    def close(self, reconnect: bool = False) -> None:
         """Close connection."""
         if reconnect:
             self.connection_lost(asyncio.TimeoutError("Server not responding"))
         else:
-            super().close(intern)
+            super().close()
 
     def idle_time(self) -> float:
         """Time before initiating next transaction (call **sync**).

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -101,9 +101,9 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
         Log.debug("Connecting to {}.", self.comm_params.host)
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False, intern: bool = False) -> None:  # type: ignore[override]
+    def close(self, reconnect: bool = False) -> None:
         """Close connection."""
-        super().close(reconnect=reconnect, intern=intern)
+        super().close(reconnect=reconnect)
 
 
 class ModbusSerialClient(ModbusBaseSyncClient):

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -87,9 +87,9 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
         )
         return await self.base_connect()
 
-    def close(self, reconnect: bool = False, intern: bool = False) -> None:  # type: ignore[override]
+    def close(self, reconnect: bool = False) -> None:
         """Close connection."""
-        super().close(reconnect=reconnect, intern=intern)
+        super().close(reconnect=reconnect)
 
 
 class ModbusTcpClient(ModbusBaseSyncClient):


### PR DESCRIPTION
When transport decides to close a connection it needs to call its own close() not any inherited close.

We have used intern= to secure that, but some of the type hint changes, broke that.