### PR TITLE
Add connection exception to list of exceptions catpured in retries

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -19,7 +19,7 @@ from threading import RLock
 
 from pymodbus.exceptions import (
     InvalidMessageReceivedException,
-    ModbusIOException,
+    ModbusIOException, ConnectionException,
 )
 from pymodbus.framer.ascii_framer import ModbusAsciiFramer
 from pymodbus.framer.binary_framer import ModbusBinaryFramer
@@ -325,7 +325,7 @@ class ModbusTransactionManager:
             result = self._recv(response_length, full)
             # result2 = self._recv(response_length, full)
             Log.debug("RECV: {}", result, ":hex")
-        except (OSError, ModbusIOException, InvalidMessageReceivedException) as msg:
+        except (OSError, ModbusIOException, InvalidMessageReceivedException, ConnectionException) as msg:
             self.client.close()
             Log.debug("Transaction failed. ({}) ", msg)
             last_exception = msg

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -18,8 +18,9 @@ from functools import partial
 from threading import RLock
 
 from pymodbus.exceptions import (
+    ConnectionException,
     InvalidMessageReceivedException,
-    ModbusIOException, ConnectionException,
+    ModbusIOException,
 )
 from pymodbus.framer.ascii_framer import ModbusAsciiFramer
 from pymodbus.framer.binary_framer import ModbusBinaryFramer


### PR DESCRIPTION
It's possible when using a Modbus TCP connection that the connection is unexpectedly closed while writing to a register. This raises a `ConnectionException` that is not caught in the existing `catch` statement. 

Note: The retry is done in the `retry_on_empty` catch


It's possible that this type of exception should not be caught, and should instead raise an error as the connection should not close unexpectedly. If I misunderstood, feel free to decline the pull request