### PR TITLE
on_reconnect_callback removed,  on_connect_callback added.

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -7,6 +7,8 @@ API changes 3.7.0
 -----------------
 - class method generate_ssl() added to TLS client (sync/async).
 - removed certfile, keyfile, password from TLS client, please use generate_ssl()
+- on_reconnect_callback() removed from clients (sync/async).
+- on_connect_callback(true/false) added to async clients.
 
 
 API changes 3.6.0


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
on_reconnect_callback connected the app directly with the transport layer and caused problems.
It was not implemented in the sync client.

Added new parameter: on_connect_callback()
For async clients on_connect_callback(True) is called when client is connected, and on_connect_callback(False) is called when client is disconnected.

Remark, the disconnected call, does NOT replace the reconnect mechanism, but is merely meant as an informative call.
