### PR TITLE
async datastore in modbus server

### DIFF
--- a/examples/server_callback.py
+++ b/examples/server_callback.py
@@ -31,15 +31,15 @@ class CallbackDataBlock(ModbusSequentialDataBlock):
         self.queue = queue
         super().__init__(addr, values)
 
-    def setValues(self, address, value):
+    async def async_setValues(self, address, value):
         """Set the requested values of the datastore."""
-        super().setValues(address, value)
+        await super().async_setValues(address, value)
         txt = f"Callback from setValues with address {address}, value {value}"
         _logger.debug(txt)
 
-    def getValues(self, address, count=1):
+    async def async_getValues(self, address, count=1):
         """Return the requested values from the datastore."""
-        result = super().getValues(address, count=count)
+        result = await super().async_getValues(address, count=count)
         txt = f"Callback from getValues with address {address}, count {count}, data {result}"
         _logger.debug(txt)
         return result
@@ -56,7 +56,7 @@ async def run_callback_server(cmdline=None):
     """Define datastore callback for server and do setup."""
     queue = asyncio.Queue()
     block = CallbackDataBlock(queue, 0x00, [17] * 100)
-    block.setValues(1, 15)
+    await block.async_setValues(1, 15)
     store = ModbusSlaveContext(di=block, co=block, hr=block, ir=block)
     context = ModbusServerContext(slaves=store, single=True)
     run_args = server_async.setup_server(

--- a/examples/server_updating.py
+++ b/examples/server_updating.py
@@ -61,9 +61,9 @@ async def updating_task(context):
     count = 6
 
     # set values to zero
-    values = context[slave_id].getValues(fc_as_hex, address, count=count)
+    values = await context[slave_id].async_getValues(fc_as_hex, address, count=count)
     values = [0 for v in values]
-    context[slave_id].setValues(fc_as_hex, address, values)
+    await context[slave_id].async_setValues(fc_as_hex, address, values)
 
     txt = (
         f"updating_task: started: initialised values: {values!s} at address {address!s}"
@@ -75,9 +75,11 @@ async def updating_task(context):
     while True:
         await asyncio.sleep(2)
 
-        values = context[slave_id].getValues(fc_as_hex, address, count=count)
+        values = await context[slave_id].async_getValues(
+            fc_as_hex, address, count=count
+        )
         values = [v + 1 for v in values]
-        context[slave_id].setValues(fc_as_hex, address, values)
+        await context[slave_id].async_setValues(fc_as_hex, address, values)
 
         txt = f"updating_task: incremented values: {values!s} at address {address!s}"
         print(txt)

--- a/pymodbus/bit_read_message.py
+++ b/pymodbus/bit_read_message.py
@@ -155,7 +155,7 @@ class ReadCoilsRequest(ReadBitsRequestBase):
         """
         ReadBitsRequestBase.__init__(self, address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read coils request against a datastore.
 
         Before running the request, we make sure that the request is in
@@ -223,7 +223,7 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
         """
         ReadBitsRequestBase.__init__(self, address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read discrete input request against a datastore.
 
         Before running the request, we make sure that the request is in

--- a/pymodbus/bit_read_message.py
+++ b/pymodbus/bit_read_message.py
@@ -169,7 +169,9 @@ class ReadCoilsRequest(ReadBitsRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
         return ReadCoilsResponse(values)
@@ -237,7 +239,9 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
         return ReadDiscreteInputsResponse(values)

--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -90,10 +90,12 @@ class WriteSingleCoilRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, [self.value])
+        result = await context.async_setValues(
+            self.function_code, self.address, [self.value]
+        )
         if isinstance(result, ExceptionResponse):
             return result
-        values = context.getValues(self.function_code, self.address, 1)
+        values = await context.async_getValues(self.function_code, self.address, 1)
         if isinstance(values, ExceptionResponse):
             return values
         return WriteSingleCoilResponse(self.address, values[0])
@@ -226,7 +228,9 @@ class WriteMultipleCoilsRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, count):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, self.values)
+        result = await context.async_setValues(
+            self.function_code, self.address, self.values
+        )
         if isinstance(result, ExceptionResponse):
             return result
         return WriteMultipleCoilsResponse(self.address, count)

--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -79,7 +79,7 @@ class WriteSingleCoilRequest(ModbusRequest):
         self.address, value = struct.unpack(">HH", data)
         self.value = value == ModbusStatus.ON
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write coil request against a datastore.
 
         :param context: The datastore to request from
@@ -212,7 +212,7 @@ class WriteMultipleCoilsRequest(ModbusRequest):
         values = unpack_bitstring(data[5:])
         self.values = values[:count]
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write coils request against a datastore.
 
         :param context: The datastore to request from

--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -1,18 +1,19 @@
 """Context for datastore."""
+
 # pylint: disable=missing-type-doc
 from pymodbus.datastore.store import ModbusSequentialDataBlock
 from pymodbus.exceptions import NoSuchSlaveException
 from pymodbus.logging import Log
 
 
-class ModbusBaseSlaveContext:  # pylint: disable=too-few-public-methods
+class ModbusBaseSlaveContext:
     """Interface for a modbus slave data context.
 
     Derived classes must implemented the following methods:
             reset(self)
             validate(self, fx, address, count=1)
-            getValues(self, fx, address, count=1)
-            setValues(self, fx, address, values)
+            getValues(self, fc_as_hex, address, count=1) or async_getValues(self, fc_as_hex, address, count=1)
+            setValues(self, fc_as_hex, address, values) or async_setValues(self, fc_as_hex, address, values)
     """
 
     _fx_mapper = {2: "d", 4: "i"}
@@ -26,6 +27,45 @@ class ModbusBaseSlaveContext:  # pylint: disable=too-few-public-methods
         :returns: one of [d(iscretes),i(nputs),h(olding),c(oils)
         """
         return self._fx_mapper[fx]
+
+    async def async_getValues(self, fc_as_hex, address, count=1):
+        """Get `count` values from datastore.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :returns: The requested values from a:a+c
+        """
+        return self.getValues(fc_as_hex, address, count)
+
+    async def async_setValues(self, fc_as_hex, address, values):
+        """Set the datastore with the supplied values.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param values: The new values to be set
+        """
+        return self.setValues(fc_as_hex, address, values)
+
+    def getValues(self, fc_as_hex, address, count=1):
+        """Get `count` values from datastore.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :returns: The requested values from a:a+c
+        """
+        del fc_as_hex, address, count
+        return []
+
+    def setValues(self, fc_as_hex, address, values):
+        """Set the datastore with the supplied values.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param values: The new values to be set
+        """
+        del fc_as_hex, address, values
 
 
 # ---------------------------------------------------------------------------#

--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -1,4 +1,5 @@
 """Remote datastore."""
+
 from pymodbus.datastore import ModbusBaseSlaveContext
 from pymodbus.exceptions import NotImplementedException
 from pymodbus.logging import Log
@@ -38,25 +39,37 @@ class RemoteSlaveContext(ModbusBaseSlaveContext):
         """
         return True
 
-    def getValues(self, fc_as_hex, _address, _count=1):
+    async def async_getValues(self, fc_as_hex, address, count=1):
         """Get values from real call in validate."""
         if fc_as_hex in self._write_fc:
             return [0]
         group_fx = self.decode(fc_as_hex)
         func_fc = self.__get_callbacks[group_fx]
-        self.result = func_fc(_address, _count)
+        kwargs = {}
+        if self.slave:
+            kwargs["slave"] = self.slave
+        self.result = await getattr(self._client, func_fc)(address, count, **kwargs)
         return self.__extract_result(self.decode(fc_as_hex), self.result)
 
-    def setValues(self, fc_as_hex, address, values):
+    async def async_setValues(self, fc_as_hex, address, values):
         """Set the datastore with the supplied values."""
         group_fx = self.decode(fc_as_hex)
         if fc_as_hex not in self._write_fc:
-            raise ValueError(f"setValues() called with an non-write function code {fc_as_hex}")
+            raise ValueError(
+                f"setValues() called with an non-write function code {fc_as_hex}"
+            )
         func_fc = self.__set_callbacks[f"{group_fx}{fc_as_hex}"]
+        kwargs = {}
+        if self.slave:
+            kwargs["slave"] = self.slave
         if fc_as_hex in {0x0F, 0x10}:  # Write Multiple Coils, Write Multiple Registers
-            self.result = func_fc(address, values)
+            self.result = await getattr(self._client, func_fc)(
+                address, values, **kwargs
+            )
         else:
-            self.result = func_fc(address, values[0])
+            self.result = await getattr(self._client, func_fc)(
+                address, values[0], **kwargs
+            )
         if self.result.isError():
             return self.result
         return None
@@ -74,44 +87,20 @@ class RemoteSlaveContext(ModbusBaseSlaveContext):
         if self.slave:
             kwargs["slave"] = self.slave
         self.__get_callbacks = {
-            "d": lambda a, c: self._client.read_discrete_inputs(
-                a, c, **kwargs
-            ),
-            "c": lambda a, c: self._client.read_coils(
-                a, c, **kwargs
-            ),
-            "h": lambda a, c: self._client.read_holding_registers(
-                a, c, **kwargs
-            ),
-            "i": lambda a, c: self._client.read_input_registers(
-                a, c, **kwargs
-            ),
+            "d": "read_discrete_inputs",
+            "c": "read_coils",
+            "h": "read_holding_registers",
+            "i": "read_input_registers",
         }
         self.__set_callbacks = {
-            "d5": lambda a, v: self._client.write_coil(
-                a, v, **kwargs
-            ),
-            "d15": lambda a, v: self._client.write_coils(
-                a, v, **kwargs
-            ),
-            "c5": lambda a, v: self._client.write_coil(
-                a, v, **kwargs
-            ),
-            "c15": lambda a, v: self._client.write_coils(
-                a, v, **kwargs
-            ),
-            "h6": lambda a, v: self._client.write_register(
-                a, v, **kwargs
-            ),
-            "h16": lambda a, v: self._client.write_registers(
-                a, v, **kwargs
-            ),
-            "i6": lambda a, v: self._client.write_register(
-                a, v, **kwargs
-            ),
-            "i16": lambda a, v: self._client.write_registers(
-                a, v, **kwargs
-            ),
+            "d5": "write_coil",
+            "d15": "write_coils",
+            "c5": "write_coil",
+            "c15": "write_coils",
+            "h6": "write_register",
+            "h16": "write_registers",
+            "i6": "write_register",
+            "i16": "write_registers",
         }
         self._write_fc = (0x05, 0x06, 0x0F, 0x10)
 

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -577,6 +577,13 @@ class ModbusSimulatorContext:
         fx_write = func_code in self._write_func_code
         return self.loop_validate(real_address, real_address + count, fx_write)
 
+    async def async_getValues(self, func_code, address, count=1):
+        """Return the requested values of the datastore.
+
+        :meta private:
+        """
+        return self.getValues(func_code, address, count)
+
     def getValues(self, func_code, address, count=1):
         """Return the requested values of the datastore.
 
@@ -610,6 +617,13 @@ class ModbusSimulatorContext:
                     bit_index += 1
                 bit_index = 0
         return result
+
+    async def async_setValues(self, func_code, address, values):
+        """Set the requested values of the datastore.
+
+        :meta private:
+        """
+        return self.setValues(func_code, address, values)
 
     def setValues(self, func_code, address, values):
         """Set the requested values of the datastore.

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -72,6 +72,10 @@ class BaseModbusDataBlock(ABC, Generic[V]):
             getValues(self, address, count=1)
             setValues(self, address, values)
             reset(self)
+
+    Derived classes can implemented the following async methods:
+            async_getValues(self, address, count=1)
+            async_setValues(self, address, values)
     """
 
     values: V
@@ -87,6 +91,15 @@ class BaseModbusDataBlock(ABC, Generic[V]):
         :raises TypeError:
         """
 
+    async def async_getValues(self, address: int, count=1) -> Iterable:
+        """Return the requested values from the datastore.
+
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :raises TypeError:
+        """
+        return self.getValues(address, count)
+
     @abstractmethod
     def getValues(self, address:int, count=1) -> Iterable:
         """Return the requested values from the datastore.
@@ -95,6 +108,15 @@ class BaseModbusDataBlock(ABC, Generic[V]):
         :param count: The number of values to retrieve
         :raises TypeError:
         """
+
+    async def async_setValues(self, address: int, values):
+        """Return the requested values from the datastore.
+
+        :param address: The starting address
+        :param values: The values to store
+        :raises TypeError:
+        """
+        return self.setValues(address, values)
 
     @abstractmethod
     def setValues(self, address:int, values) -> None:

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -139,7 +139,7 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
         """
         super().__init__(address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read holding request against a datastore.
 
         :param context: The datastore to request from
@@ -200,7 +200,7 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
         """
         super().__init__(address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read input request against a datastore.
 
         :param context: The datastore to request from
@@ -310,7 +310,7 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
             register = struct.unpack(">H", data[i : i + 2])[0]
             self.write_registers.append(register)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -149,7 +149,9 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
 
@@ -210,7 +212,9 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
         return ReadInputRegistersResponse(values)
@@ -328,12 +332,12 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
             return self.doException(merror.IllegalAddress)
         if not context.validate(self.function_code, self.read_address, self.read_count):
             return self.doException(merror.IllegalAddress)
-        result = context.setValues(
+        result = await context.async_setValues(
             self.function_code, self.write_address, self.write_registers
         )
         if isinstance(result, ExceptionResponse):
             return result
-        registers = context.getValues(
+        registers = await context.async_getValues(
             self.function_code, self.read_address, self.read_count
         )
         return ReadWriteMultipleRegistersResponse(registers)

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -57,7 +57,7 @@ class WriteSingleRegisterRequest(ModbusRequest):
         """
         self.address, self.value = struct.unpack(">HH", data)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from
@@ -200,7 +200,7 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         for idx in range(5, (self.count * 2) + 5, 2):
             self.values.append(struct.unpack(">H", data[idx : idx + 2])[0])
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from
@@ -321,7 +321,7 @@ class MaskWriteRegisterRequest(ModbusRequest):
         """
         self.address, self.and_mask, self.or_mask = struct.unpack(">HHH", data)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a mask write register request against the store.
 
         :param context: The datastore to request from

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -68,10 +68,12 @@ class WriteSingleRegisterRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, [self.value])
+        result = await context.async_setValues(
+            self.function_code, self.address, [self.value]
+        )
         if isinstance(result, ExceptionResponse):
             return result
-        values = context.getValues(self.function_code, self.address, 1)
+        values = await context.async_getValues(self.function_code, self.address, 1)
         return WriteSingleRegisterResponse(self.address, values[0])
 
     def get_response_pdu_size(self):
@@ -213,7 +215,9 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, self.values)
+        result = await context.async_setValues(
+            self.function_code, self.address, self.values
+        )
         if isinstance(result, ExceptionResponse):
             return result
         return WriteMultipleRegistersResponse(self.address, self.count)
@@ -333,11 +337,13 @@ class MaskWriteRegisterRequest(ModbusRequest):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, 1)[0]
+        values = (await context.async_getValues(self.function_code, self.address, 1))[0]
         if isinstance(values, ExceptionResponse):
             return values
         values = (values & self.and_mask) | (self.or_mask & ~self.and_mask)
-        result = context.setValues(self.function_code, self.address, [values])
+        result = await context.async_setValues(
+            self.function_code, self.address, [values]
+        )
         if isinstance(result, ExceptionResponse):
             return result
         return MaskWriteRegisterResponse(self.address, self.and_mask, self.or_mask)

--- a/test/sub_client/test_client.py
+++ b/test/sub_client/test_client.py
@@ -392,7 +392,7 @@ class MockTransport:
     async def delayed_resp(self):
         """Send a response to a received packet."""
         await asyncio.sleep(0.05)
-        resp = self.req.execute(self.ctx)
+        resp = await self.req.execute(self.ctx)
         pkt = self.base.ctx.framer.buildPacket(resp)
         self.base.ctx.data_received(pkt)
 

--- a/test/sub_function_codes/test_bit_read_messages.py
+++ b/test/sub_function_codes/test_bit_read_messages.py
@@ -85,7 +85,7 @@ class TestModbusBitMessage:
         for request, expected in iter(messages.items()):
             assert request.encode() == expected
 
-    def test_bit_read_message_execute_value_errors(self):
+    async def test_bit_read_message_execute_value_errors(self):
         """Test bit read request encoding."""
         context = MockContext()
         requests = [
@@ -93,10 +93,10 @@ class TestModbusBitMessage:
             ReadDiscreteInputsRequest(1, 0x800),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert ModbusExceptions.IllegalValue == result.exception_code
 
-    def test_bit_read_message_execute_address_errors(self):
+    async def test_bit_read_message_execute_address_errors(self):
         """Test bit read request encoding."""
         context = MockContext()
         requests = [
@@ -104,10 +104,10 @@ class TestModbusBitMessage:
             ReadDiscreteInputsRequest(1, 5),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert ModbusExceptions.IllegalAddress == result.exception_code
 
-    def test_bit_read_message_execute_success(self):
+    async def test_bit_read_message_execute_success(self):
         """Test bit read request encoding."""
         context = MockContext()
         context.validate = lambda a, b, c: True
@@ -116,7 +116,7 @@ class TestModbusBitMessage:
             ReadDiscreteInputsRequest(1, 5),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert result.bits == [True] * 5
 
     def test_bit_read_message_get_response_pdu(self):

--- a/test/sub_function_codes/test_bit_write_messages.py
+++ b/test/sub_function_codes/test_bit_write_messages.py
@@ -81,45 +81,45 @@ class TestModbusBitMessage:
         request = WriteSingleCoilRequest(1, False)
         assert request.encode() == b"\x00\x01\x00\x00"
 
-    def test_write_single_coil_execute(self):
+    async def test_write_single_coil_execute(self):
         """Test write single coil."""
         context = MockContext(False, default=True)
         request = WriteSingleCoilRequest(2, True)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         context.valid = True
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.encode() == b"\x00\x02\xff\x00"
 
         context = MockContext(True, default=False)
         request = WriteSingleCoilRequest(2, False)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.encode() == b"\x00\x02\x00\x00"
 
-    def test_write_multiple_coils_execute(self):
+    async def test_write_multiple_coils_execute(self):
         """Test write multiple coils."""
         context = MockContext(False)
         # too many values
         request = WriteMultipleCoilsRequest(2, FakeList(0x123456))
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         # bad byte count
         request = WriteMultipleCoilsRequest(2, [0x00] * 4)
         request.byte_count = 0x00
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         # does not validate
         context.valid = False
         request = WriteMultipleCoilsRequest(2, [0x00] * 4)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         # validated request
         context.valid = True
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.encode() == b"\x00\x02\x00\x04"
 
     def test_write_multiple_coils_response(self):

--- a/test/sub_function_codes/test_register_read_messages.py
+++ b/test/sub_function_codes/test_register_read_messages.py
@@ -100,7 +100,7 @@ class TestReadRegisterMessages:
             request.decode(response)
             assert request.registers == register
 
-    def test_register_read_requests_count_errors(self):
+    async def test_register_read_requests_count_errors(self):
         """This tests that the register request messages.
 
         will break on counts that are out of range
@@ -117,10 +117,10 @@ class TestReadRegisterMessages:
             ),
         ]
         for request in requests:
-            result = request.execute(None)
+            result = await request.execute(None)
             assert ModbusExceptions.IllegalValue == result.exception_code
 
-    def test_register_read_requests_validate_errors(self):
+    async def test_register_read_requests_validate_errors(self):
         """This tests that the register request messages.
 
         will break on counts that are out of range
@@ -133,10 +133,10 @@ class TestReadRegisterMessages:
             # ReadWriteMultipleRegistersRequest(1,5,-1,5),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert ModbusExceptions.IllegalAddress == result.exception_code
 
-    def test_register_read_requests_execute(self):
+    async def test_register_read_requests_execute(self):
         """This tests that the register request messages.
 
         will break on counts that are out of range
@@ -147,34 +147,34 @@ class TestReadRegisterMessages:
             ReadInputRegistersRequest(-1, 5),
         ]
         for request in requests:
-            response = request.execute(context)
+            response = await request.execute(context)
             assert request.function_code == response.function_code
 
-    def test_read_write_multiple_registers_request(self):
+    async def test_read_write_multiple_registers_request(self):
         """Test read/write multiple registers."""
         context = MockContext(True)
         request = ReadWriteMultipleRegistersRequest(
             read_address=1, read_count=10, write_address=1, write_registers=[0x00]
         )
-        response = request.execute(context)
+        response = await request.execute(context)
         assert request.function_code == response.function_code
 
-    def test_read_write_multiple_registers_validate(self):
+    async def test_read_write_multiple_registers_validate(self):
         """Test read/write multiple registers."""
         context = MockContext()
         context.validate = lambda f, a, c: a == 1
         request = ReadWriteMultipleRegistersRequest(
             read_address=1, read_count=10, write_address=2, write_registers=[0x00]
         )
-        response = request.execute(context)
+        response = await request.execute(context)
         assert response.exception_code == ModbusExceptions.IllegalAddress
 
         context.validate = lambda f, a, c: a == 2
-        response = request.execute(context)
+        response = await request.execute(context)
         assert response.exception_code == ModbusExceptions.IllegalAddress
 
         request.write_byte_count = 0x100
-        response = request.execute(context)
+        response = await request.execute(context)
         assert response.exception_code == ModbusExceptions.IllegalValue
 
     def test_read_write_multiple_registers_request_decode(self):

--- a/test/sub_function_codes/test_register_write_messages.py
+++ b/test/sub_function_codes/test_register_write_messages.py
@@ -84,43 +84,43 @@ class TestWriteRegisterMessages:
         for request in iter(self.write.keys()):
             assert str(request)
 
-    def test_write_single_register_request(self):
+    async def test_write_single_register_request(self):
         """Test write single register request."""
         context = MockContext()
         request = WriteSingleRegisterRequest(0x00, 0xF0000)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         request.value = 0x00FF
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         context.valid = True
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.function_code == request.function_code
 
-    def test_write_multiple_register_request(self):
+    async def test_write_multiple_register_request(self):
         """Test write multiple register request."""
         context = MockContext()
         request = WriteMultipleRegistersRequest(0x00, [0x00] * 10)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         request.count = 0x05  # bytecode != code * 2
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         request.count = 0x800  # outside of range
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         context.valid = True
         request = WriteMultipleRegistersRequest(0x00, [0x00] * 10)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.function_code == request.function_code
 
         request = WriteMultipleRegistersRequest(0x00, 0x00)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.function_code == request.function_code
 
         # -----------------------------------------------------------------------#
@@ -142,7 +142,7 @@ class TestWriteRegisterMessages:
         assert handle.and_mask == 0x00F2
         assert handle.or_mask == 0x0025
 
-    def test_mask_write_register_request_execute(self):
+    async def test_mask_write_register_request_execute(self):
         """Test write register request valid execution."""
         # The test uses the 4 nibbles of the 16-bit values to test
         # the combinations:
@@ -152,23 +152,23 @@ class TestWriteRegisterMessages:
         #     and_mask=F, or_mask=F
         context = MockLastValuesContext(valid=True, default=0xAA55)
         handle = MaskWriteRegisterRequest(0x0000, 0x0F0F, 0x00FF)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert isinstance(result, MaskWriteRegisterResponse)
         assert context.last_values == [0x0AF5]
 
-    def test_mask_write_register_request_invalid_execute(self):
+    async def test_mask_write_register_request_invalid_execute(self):
         """Test write register request execute with invalid data."""
         context = MockContext(valid=False, default=0x0000)
         handle = MaskWriteRegisterRequest(0x0000, -1, 0x1010)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert ModbusExceptions.IllegalValue == result.exception_code
 
         handle = MaskWriteRegisterRequest(0x0000, 0x0101, -1)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert ModbusExceptions.IllegalValue == result.exception_code
 
         handle = MaskWriteRegisterRequest(0x0000, 0x0101, 0x1010)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert ModbusExceptions.IllegalAddress == result.exception_code
 
         # -----------------------------------------------------------------------#

--- a/test/sub_server/test_simulator.py
+++ b/test/sub_server/test_simulator.py
@@ -1,4 +1,5 @@
 """Test datastore."""
+
 import asyncio
 import copy
 import json
@@ -582,9 +583,9 @@ class TestSimulator:
             )
         ),
     )
-    async def test_simulator_server_tcp(self):
+    async def test_simulator_server_tcp(self, unused_tcp_port):
         """Test init simulator server."""
-        task = ModbusSimulatorServer()
+        task = ModbusSimulatorServer(http_port=unused_tcp_port)
         await task.run_forever(only_start=True)
         await asyncio.sleep(0.5)
         await task.stop()

--- a/test/test_remote_datastore.py
+++ b/test/test_remote_datastore.py
@@ -1,4 +1,5 @@
 """Test remote datastore."""
+
 from unittest import mock
 
 import pytest
@@ -21,44 +22,64 @@ class TestRemoteDataStore:
         with pytest.raises(NotImplementedException):
             context.reset()
 
-    def test_remote_slave_set_values(self):
+    async def test_remote_slave_set_values(self):
         """Test setting values against a remote slave context."""
         client = mock.MagicMock()
-        client.write_coils = lambda a, b: WriteMultipleCoilsResponse()
-        client.write_registers = lambda a, b: ExceptionResponse(0x10, 0x02)
+        client.write_coils = mock.MagicMock(return_value=WriteMultipleCoilsResponse())
+        client.write_registers = mock.MagicMock(
+            return_value=ExceptionResponse(0x10, 0x02)
+        )
 
         context = RemoteSlaveContext(client)
+        await context.async_setValues(0x0F, 0, [1])
         context.setValues(0x0F, 0, [1])
+        result = await context.async_setValues(0x10, 1, [1])
+        assert result.exception_code == 0x02
+        assert result.function_code == 0x90
         result = context.setValues(0x10, 1, [1])
         assert result.exception_code == 0x02
         assert result.function_code == 0x90
 
-    def test_remote_slave_get_values(self):
+    async def test_remote_slave_get_values(self):
         """Test getting values from a remote slave context."""
         client = mock.MagicMock()
-        client.read_coils = lambda a, b: ReadCoilsResponse([1] * 10)
-        client.read_input_registers = lambda a, b: ReadInputRegistersResponse([10] * 10)
-        client.read_holding_registers = lambda a, b: ExceptionResponse(0x15)
+        client.read_coils = mock.MagicMock(return_value=ReadCoilsResponse([1] * 10))
+        client.read_input_registers = mock.MagicMock(
+            return_value=ReadInputRegistersResponse([10] * 10)
+        )
+        client.read_holding_registers = mock.MagicMock(
+            return_value=ExceptionResponse(0x15)
+        )
 
         context = RemoteSlaveContext(client)
         context.validate(1, 0, 10)
+        result = await context.async_getValues(1, 0, 10)
+        assert result == [1] * 10
         result = context.getValues(1, 0, 10)
         assert result == [1] * 10
 
         context.validate(4, 0, 10)
+        result = await context.async_getValues(4, 0, 10)
+        assert result == [10] * 10
         result = context.getValues(4, 0, 10)
         assert result == [10] * 10
 
         context.validate(3, 0, 10)
+        result = await context.async_getValues(3, 0, 10)
+        assert result != [10] * 10
         result = context.getValues(3, 0, 10)
         assert result != [10] * 10
 
     def test_remote_slave_validate_values(self):
         """Test validating against a remote slave context."""
         client = mock.MagicMock()
-        client.read_coils = lambda a, b: ReadCoilsResponse([1] * 10)
-        client.read_input_registers = lambda a, b: ReadInputRegistersResponse([10] * 10)
-        client.read_holding_registers = lambda a, b: ExceptionResponse(0x15)
+        client.read_coils = mock.AsyncMock(return_value=ReadCoilsResponse([1] * 10))
+        client.read_input_registers = mock.AsyncMock(
+            return_value=ReadInputRegistersResponse([10] * 10)
+        )
+        client.read_holding_registers = mock.AsyncMock(
+            return_value=ExceptionResponse(0x15)
+        )
 
         context = RemoteSlaveContext(client)
         result = context.validate(1, 0, 10)

--- a/test/test_remote_datastore.py
+++ b/test/test_remote_datastore.py
@@ -24,9 +24,9 @@ class TestRemoteDataStore:
 
     async def test_remote_slave_set_values(self):
         """Test setting values against a remote slave context."""
-        client = mock.MagicMock()
-        client.write_coils = mock.MagicMock(return_value=WriteMultipleCoilsResponse())
-        client.write_registers = mock.MagicMock(
+        client = mock.AsyncMock()
+        client.write_coils = mock.AsyncMock(return_value=WriteMultipleCoilsResponse())
+        client.write_registers = mock.AsyncMock(
             return_value=ExceptionResponse(0x10, 0x02)
         )
 
@@ -36,18 +36,15 @@ class TestRemoteDataStore:
         result = await context.async_setValues(0x10, 1, [1])
         assert result.exception_code == 0x02
         assert result.function_code == 0x90
-        result = context.setValues(0x10, 1, [1])
-        assert result.exception_code == 0x02
-        assert result.function_code == 0x90
 
     async def test_remote_slave_get_values(self):
         """Test getting values from a remote slave context."""
-        client = mock.MagicMock()
-        client.read_coils = mock.MagicMock(return_value=ReadCoilsResponse([1] * 10))
-        client.read_input_registers = mock.MagicMock(
+        client = mock.AsyncMock()
+        client.read_coils = mock.AsyncMock(return_value=ReadCoilsResponse([1] * 10))
+        client.read_input_registers = mock.AsyncMock(
             return_value=ReadInputRegistersResponse([10] * 10)
         )
-        client.read_holding_registers = mock.MagicMock(
+        client.read_holding_registers = mock.AsyncMock(
             return_value=ExceptionResponse(0x15)
         )
 
@@ -55,19 +52,13 @@ class TestRemoteDataStore:
         context.validate(1, 0, 10)
         result = await context.async_getValues(1, 0, 10)
         assert result == [1] * 10
-        result = context.getValues(1, 0, 10)
-        assert result == [1] * 10
 
         context.validate(4, 0, 10)
         result = await context.async_getValues(4, 0, 10)
         assert result == [10] * 10
-        result = context.getValues(4, 0, 10)
-        assert result == [10] * 10
 
         context.validate(3, 0, 10)
         result = await context.async_getValues(3, 0, 10)
-        assert result != [10] * 10
-        result = context.getValues(3, 0, 10)
         assert result != [10] * 10
 
     def test_remote_slave_validate_values(self):

--- a/test/test_sparse_datastore.py
+++ b/test/test_sparse_datastore.py
@@ -1,10 +1,12 @@
 """Test framers."""
 
+import pytest
 
 from pymodbus.datastore import ModbusSparseDataBlock
 
 
-def test_check_sparsedatastore():
+@pytest.mark.asyncio()
+async def test_check_sparsedatastore():
     """Test check frame."""
     data_in_block = {
         1: 6720,
@@ -22,4 +24,5 @@ def test_check_sparsedatastore():
         for value in entry:
             assert datablock.validate(key, 1)
             assert datablock.getValues(key, 1) == [value]
+            assert await datablock.async_getValues(key, 1) == [value]
             key += 1


### PR DESCRIPTION
Changed datastore to be used by async-flow by modbus server, allowing datastores to be async related to getValues/setValues use.