### PR TITLE
Fix link to github in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ and all API changes are `documented <https://pymodbus.readthedocs.io/en/latest/s
 
 A big thanks to all the `volunteers <https://pymodbus.readthedocs.io/en/latest/source/authors.html>`_ that helps make pymodbus a great project.
 
-Source code on `github <https://pymodbus.readthedocs.io/en/latest/source/authors.html>`_
+Source code on `github <https://github.com/pymodbus-dev/pymodbus>`_
 
 Pymodbus in a nutshell
 ----------------------


### PR DESCRIPTION
The link to github on the online documentation[1] incorrectly links to the authors page instead of the github repo.

Link: https://pymodbus.readthedocs.io/en/latest/source/readme.html [1]