### PR TITLE
Dislodge client classes from modbusProtocol.

### DIFF
--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -122,7 +122,7 @@ class ClientTester:  # pylint: disable=too-few-public-methods
             )
         else:
             raise RuntimeError("ERROR: CommType not implemented")
-        server_params = self.client.comm_params.copy()
+        server_params = self.client.ctx.comm_params.copy()
         server_params.source_address = (host, test_port)
         self.stub = TransportStub(server_params, True, simulate_server)
         test_port += 1

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -103,8 +103,14 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
         """Return state of connection."""
         return self.ctx.is_active()
 
-    async def base_connect(self) -> bool:
+    async def connect(self) -> bool:
         """Call transport connect."""
+        self.ctx.reset_delay()
+        Log.debug(
+            "Connecting to {}:{}.",
+            self.ctx.comm_params.host,
+            self.ctx.comm_params.port,
+        )
         return await self.ctx.connect()
 
 
@@ -177,9 +183,6 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
             )
 
         return resp  # type: ignore[return-value]
-
-    async def connect(self) -> bool:  # type: ignore[empty-body]
-        """Connect to the modbus remote host."""
 
     def build_response(self, tid):
         """Return a deferred response for the current request."""

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -8,17 +8,18 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from pymodbus.client.mixin import ModbusClientMixin
+from pymodbus.client.modbusclientprotocol import ModbusClientProtocol
 from pymodbus.exceptions import ConnectionException, ModbusIOException
 from pymodbus.factory import ClientDecoder
 from pymodbus.framer import FRAMER_NAME_TO_CLASS, FramerType, ModbusFramer
 from pymodbus.logging import Log
 from pymodbus.pdu import ModbusRequest, ModbusResponse
 from pymodbus.transaction import ModbusTransactionManager
-from pymodbus.transport import CommParams, ModbusProtocol
+from pymodbus.transport import CommParams
 from pymodbus.utilities import ModbusTransactionState
 
 
-class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProtocol):
+class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
     """**ModbusBaseClient**.
 
     Fixed parameters:
@@ -62,8 +63,8 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
     ) -> None:
         """Initialize a client instance."""
         ModbusClientMixin.__init__(self)  # type: ignore[arg-type]
-        ModbusProtocol.__init__(
-            self,
+        self.ctx = ModbusClientProtocol(
+            framer,
             CommParams(
                 comm_type=kwargs.get("CommType"),
                 comm_name="comm",
@@ -80,22 +81,15 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
                 stopbits=kwargs.get("stopbits", None),
                 handle_local_echo=kwargs.get("handle_local_echo", False),
             ),
-            False,
+            retries,
+            retry_on_empty,
+            on_connect_callback,
         )
-        self.on_connect_callback = on_connect_callback
-        self.retry_on_empty: int = 0
         self.no_resend_on_retry = no_resend_on_retry
-        self.slaves: list[int] = []
-        self.retries: int = retries
         self.broadcast_enable = broadcast_enable
+        self.retries = retries
 
         # Common variables.
-        self.framer = FRAMER_NAME_TO_CLASS.get(
-            framer, cast(type[ModbusFramer], framer)
-        )(ClientDecoder(), self)
-        self.transaction = ModbusTransactionManager(
-            self, retries=retries, retry_on_empty=retry_on_empty, **kwargs
-        )
         self.use_udp = False
         self.state = ModbusTransactionState.IDLE
         self.last_frame_end: float | None = 0
@@ -107,11 +101,11 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
     @property
     def connected(self) -> bool:
         """Return state of connection."""
-        return self.is_active()
+        return self.ctx.is_active()
 
     async def base_connect(self) -> bool:
         """Call transport connect."""
-        return await super().connect()
+        return await self.ctx.connect()
 
 
     def register(self, custom_response_class: ModbusResponse) -> None:
@@ -123,14 +117,14 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         Use register() to add non-standard responses (like e.g. a login prompt) and
         have them interpreted automatically.
         """
-        self.framer.decoder.register(custom_response_class)
+        self.ctx.framer.decoder.register(custom_response_class)
 
     def close(self, reconnect: bool = False) -> None:
         """Close connection."""
         if reconnect:
-            self.connection_lost(asyncio.TimeoutError("Server not responding"))
+            self.ctx.connection_lost(asyncio.TimeoutError("Server not responding"))
         else:
-            super().close()
+            self.ctx.close()
 
     def idle_time(self) -> float:
         """Time before initiating next transaction (call **sync**).
@@ -149,7 +143,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         :returns: The result of the request execution
         :raises ConnectionException: Check exception text.
         """
-        if not self.transport:
+        if not self.ctx.transport:
             raise ConnectionException(f"Not connected[{self!s}]")
         return self.async_execute(request)
 
@@ -158,20 +152,20 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
     # ----------------------------------------------------------------------- #
     async def async_execute(self, request) -> ModbusResponse:
         """Execute requests asynchronously."""
-        request.transaction_id = self.transaction.getNextTID()
-        packet = self.framer.buildPacket(request)
+        request.transaction_id = self.ctx.transaction.getNextTID()
+        packet = self.ctx.framer.buildPacket(request)
 
         count = 0
         while count <= self.retries:
             req = self.build_response(request.transaction_id)
             if not count or not self.no_resend_on_retry:
-                self.send(packet)
+                self.ctx.send(packet)
             if self.broadcast_enable and not request.slave_id:
                 resp = None
                 break
             try:
                 resp = await asyncio.wait_for(
-                    req, timeout=self.comm_params.timeout_connect
+                    req, timeout=self.ctx.comm_params.timeout_connect
                 )
                 break
             except asyncio.exceptions.TimeoutError:
@@ -184,49 +178,17 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
 
         return resp  # type: ignore[return-value]
 
-    def callback_new_connection(self):
-        """Call when listener receive new connection request."""
-
-    def callback_connected(self) -> None:
-        """Call when connection is succcesfull."""
-        if self.on_connect_callback:
-            self.loop.call_soon(self.on_connect_callback, True)
-
-    def callback_disconnected(self, exc: Exception | None) -> None:
-        """Call when connection is lost."""
-        Log.debug("callback_disconnected called: {}", exc)
-        if self.on_connect_callback:
-            self.loop.call_soon(self.on_connect_callback, False)
-
-    def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
-        """Handle received data.
-
-        returns number of bytes consumed
-        """
-        self.framer.processIncomingPacket(data, self._handle_response, slave=0)
-        return len(data)
-
     async def connect(self) -> bool:  # type: ignore[empty-body]
         """Connect to the modbus remote host."""
-
-    def _handle_response(self, reply, **_kwargs):
-        """Handle the processed response and link to correct deferred."""
-        if reply is not None:
-            tid = reply.transaction_id
-            if handler := self.transaction.getTransaction(tid):
-                if not handler.done():
-                    handler.set_result(reply)
-            else:
-                Log.debug("Unrequested message: {}", reply, ":str")
 
     def build_response(self, tid):
         """Return a deferred response for the current request."""
         my_future: asyncio.Future = asyncio.Future()
-        if not self.transport:
+        if not self.ctx.transport:
             if not my_future.done():
                 my_future.set_exception(ConnectionException("Client is not connected"))
         else:
-            self.transaction.addTransaction(my_future, tid)
+            self.ctx.transaction.addTransaction(my_future, tid)
         return my_future
 
     # ----------------------------------------------------------------------- #
@@ -260,7 +222,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         :returns: The string representation
         """
         return (
-            f"{self.__class__.__name__} {self.comm_params.host}:{self.comm_params.port}"
+            f"{self.__class__.__name__} {self.ctx.comm_params.host}:{self.ctx.comm_params.port}"
         )
 
 

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -209,11 +209,6 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
     async def connect(self) -> bool:  # type: ignore[empty-body]
         """Connect to the modbus remote host."""
 
-    def raise_future(self, my_future, exc):
-        """Set exception of a future if not done."""
-        if not my_future.done():
-            my_future.set_exception(exc)
-
     def _handle_response(self, reply, **_kwargs):
         """Handle the processed response and link to correct deferred."""
         if reply is not None:
@@ -228,7 +223,8 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]], ModbusProto
         """Return a deferred response for the current request."""
         my_future: asyncio.Future = asyncio.Future()
         if not self.transport:
-            self.raise_future(my_future, ConnectionException("Client is not connected"))
+            if not my_future.done():
+                my_future.set_exception(ConnectionException("Client is not connected"))
         else:
             self.transaction.addTransaction(my_future, tid)
         return my_future

--- a/pymodbus/client/modbusclientprotocol.py
+++ b/pymodbus/client/modbusclientprotocol.py
@@ -1,0 +1,136 @@
+"""ModbusProtocol implementation for all clients."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+from pymodbus.factory import ClientDecoder
+from pymodbus.framer import FRAMER_NAME_TO_CLASS, FramerType, ModbusFramer
+from pymodbus.logging import Log
+from pymodbus.transaction import ModbusTransactionManager
+from pymodbus.transport import CommParams, ModbusProtocol
+from pymodbus.utilities import ModbusTransactionState
+
+
+class ModbusClientProtocol(ModbusProtocol):
+    """**ModbusClientProtocol**.
+
+    Fixed parameters:
+
+    :param framer: Framer enum name
+
+    Optional parameters:
+
+    :param timeout: Timeout for a request, in seconds.
+    :param retries: Max number of retries per request.
+    :param retry_on_empty: Retry on empty response.
+    :param broadcast_enable: True to treat id 0 as broadcast address.
+    :param reconnect_delay: Minimum delay in seconds.milliseconds before reconnecting.
+    :param reconnect_delay_max: Maximum delay in seconds.milliseconds before reconnecting.
+    :param on_connect_callback: Will be called when connected/disconnected (bool parameter)
+    :param no_resend_on_retry: Do not resend request when retrying due to missing response.
+    :param kwargs: Experimental parameters.
+
+    .. tip::
+        **reconnect_delay** doubles automatically with each unsuccessful connect, from
+        **reconnect_delay** to **reconnect_delay_max**.
+        Set `reconnect_delay=0` to avoid automatic reconnection.
+
+    :mod:`ModbusClientProtocol` is normally not referenced outside :mod:`pymodbus`.
+
+    **Application methods, common to all clients**:
+    """
+
+    def __init__(
+        self,
+        framer: FramerType,
+        timeout: float = 3,
+        retries: int = 3,
+        retry_on_empty: bool = False,
+        broadcast_enable: bool = False,
+        reconnect_delay: float = 0.1,
+        reconnect_delay_max: float = 300,
+        on_connect_callback: Callable[[bool], None] | None = None,
+        no_resend_on_retry: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a client instance."""
+        ModbusProtocol.__init__(
+            self,
+            CommParams(
+                comm_type=kwargs.get("CommType"),
+                comm_name="comm",
+                source_address=kwargs.get("source_address", None),
+                reconnect_delay=reconnect_delay,
+                reconnect_delay_max=reconnect_delay_max,
+                timeout_connect=timeout,
+                host=kwargs.get("host", None),
+                port=kwargs.get("port", 0),
+                sslctx=kwargs.get("sslctx", None),
+                baudrate=kwargs.get("baudrate", None),
+                bytesize=kwargs.get("bytesize", None),
+                parity=kwargs.get("parity", None),
+                stopbits=kwargs.get("stopbits", None),
+                handle_local_echo=kwargs.get("handle_local_echo", False),
+            ),
+            False,
+        )
+        self.on_connect_callback = on_connect_callback
+        self.retry_on_empty: int = 0
+        self.no_resend_on_retry = no_resend_on_retry
+        self.slaves: list[int] = []
+        self.retries: int = retries
+        self.broadcast_enable = broadcast_enable
+
+        # Common variables.
+        self.framer = FRAMER_NAME_TO_CLASS.get(
+            framer, cast(type[ModbusFramer], framer)
+        )(ClientDecoder(), self)
+        self.transaction = ModbusTransactionManager(
+            self, retries=retries, retry_on_empty=retry_on_empty, **kwargs
+        )
+        self.use_udp = False
+        self.state = ModbusTransactionState.IDLE
+        self.last_frame_end: float | None = 0
+        self.silent_interval: float = 0
+
+    def _handle_response(self, reply, **_kwargs):
+        """Handle the processed response and link to correct deferred."""
+        if reply is not None:
+            tid = reply.transaction_id
+            if handler := self.transaction.getTransaction(tid):
+                if not handler.done():
+                    handler.set_result(reply)
+            else:
+                Log.debug("Unrequested message: {}", reply, ":str")
+
+    def callback_new_connection(self):
+        """Call when listener receive new connection request."""
+
+    def callback_connected(self) -> None:
+        """Call when connection is succcesfull."""
+        if self.on_connect_callback:
+            self.loop.call_soon(self.on_connect_callback, True)
+
+    def callback_disconnected(self, exc: Exception | None) -> None:
+        """Call when connection is lost."""
+        Log.debug("callback_disconnected called: {}", exc)
+        if self.on_connect_callback:
+            self.loop.call_soon(self.on_connect_callback, False)
+
+    def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
+        """Handle received data.
+
+        returns number of bytes consumed
+        """
+        self.framer.processIncomingPacket(data, self._handle_response, slave=0)
+        return len(data)
+
+    def __str__(self):
+        """Build a string representation of the connection.
+
+        :returns: The string representation
+        """
+        return (
+            f"{self.__class__.__name__} {self.comm_params.host}:{self.comm_params.port}"
+        )

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -95,8 +95,8 @@ class AsyncModbusSerialClient(ModbusBaseClient):
 
     async def connect(self) -> bool:
         """Connect Async client."""
-        self.reset_delay()
-        Log.debug("Connecting to {}.", self.comm_params.host)
+        self.ctx.reset_delay()
+        Log.debug("Connecting to {}.", self.ctx.comm_params.host)
         return await self.base_connect()
 
     def close(self, reconnect: bool = False) -> None:

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -1,7 +1,6 @@
 """Modbus client async serial communication."""
 from __future__ import annotations
 
-import asyncio
 import time
 from functools import partial
 from typing import TYPE_CHECKING, Any
@@ -24,7 +23,7 @@ except ImportError:
         # type checkers do not understand the Raise RuntimeError in __init__()
         import serial
 
-class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
+class AsyncModbusSerialClient(ModbusBaseClient):
     """**AsyncModbusSerialClient**.
 
     Fixed parameters:
@@ -82,7 +81,6 @@ class AsyncModbusSerialClient(ModbusBaseClient, asyncio.Protocol):
                 "Serial client requires pyserial "
                 'Please install with "pip install pyserial" and try again.'
             )
-        asyncio.Protocol.__init__(self)
         ModbusBaseClient.__init__(
             self,
             framer,

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -93,12 +93,6 @@ class AsyncModbusSerialClient(ModbusBaseClient):
             **kwargs,
         )
 
-    async def connect(self) -> bool:
-        """Connect Async client."""
-        self.ctx.reset_delay()
-        Log.debug("Connecting to {}.", self.ctx.comm_params.host)
-        return await self.base_connect()
-
     def close(self, reconnect: bool = False) -> None:
         """Close connection."""
         super().close(reconnect=reconnect)

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -75,16 +75,6 @@ class AsyncModbusTcpClient(ModbusBaseClient):
             **kwargs,
         )
 
-    async def connect(self) -> bool:
-        """Initiate connection to start client."""
-        self.ctx.reset_delay()
-        Log.debug(
-            "Connecting to {}:{}.",
-            self.ctx.comm_params.host,
-            self.ctx.comm_params.port,
-        )
-        return await self.base_connect()
-
     def close(self, reconnect: bool = False) -> None:
         """Close connection."""
         super().close(reconnect=reconnect)

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -1,7 +1,6 @@
 """Modbus client async TCP communication."""
 from __future__ import annotations
 
-import asyncio
 import select
 import socket
 import time
@@ -14,7 +13,7 @@ from pymodbus.logging import Log
 from pymodbus.transport import CommType
 
 
-class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
+class AsyncModbusTcpClient(ModbusBaseClient):
     """**AsyncModbusTcpClient**.
 
     Fixed parameters:
@@ -64,7 +63,6 @@ class AsyncModbusTcpClient(ModbusBaseClient, asyncio.Protocol):
         **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus TCP Client."""
-        asyncio.Protocol.__init__(self)
         if "CommType" not in kwargs:
             kwargs["CommType"] = CommType.TCP
         if source_address:

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -77,11 +77,11 @@ class AsyncModbusTcpClient(ModbusBaseClient):
 
     async def connect(self) -> bool:
         """Initiate connection to start client."""
-        self.reset_delay()
+        self.ctx.reset_delay()
         Log.debug(
             "Connecting to {}:{}.",
-            self.comm_params.host,
-            self.comm_params.port,
+            self.ctx.comm_params.host,
+            self.ctx.comm_params.port,
         )
         return await self.base_connect()
 

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -73,16 +73,6 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
         )
         self.server_hostname = server_hostname
 
-    async def connect(self) -> bool:
-        """Initiate connection to start client."""
-        self.ctx.reset_delay()
-        Log.debug(
-            "Connecting to {}:{}.",
-            self.ctx.comm_params.host,
-            self.ctx.comm_params.port,
-        )
-        return await self.base_connect()
-
     @classmethod
     def generate_ssl(
         cls,

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -75,11 +75,11 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
 
     async def connect(self) -> bool:
         """Initiate connection to start client."""
-        self.reset_delay()
+        self.ctx.reset_delay()
         Log.debug(
             "Connecting to {}:{}.",
-            self.comm_params.host,
-            self.comm_params.port,
+            self.ctx.comm_params.host,
+            self.ctx.comm_params.port,
         )
         return await self.base_connect()
 

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -77,19 +77,6 @@ class AsyncModbusUdpClient(ModbusBaseClient):
         """Return true if connected."""
         return self.ctx.is_active()
 
-    async def connect(self) -> bool:
-        """Start reconnecting asynchronous udp client.
-
-        :meta private:
-        """
-        self.ctx.reset_delay()
-        Log.debug(
-            "Connecting to {}:{}.",
-            self.ctx.comm_params.host,
-            self.ctx.comm_params.port,
-        )
-        return await self.base_connect()
-
 
 class ModbusUdpClient(ModbusBaseSyncClient):
     """**ModbusUdpClient**.

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -75,18 +75,18 @@ class AsyncModbusUdpClient(ModbusBaseClient):
     @property
     def connected(self):
         """Return true if connected."""
-        return self.is_active()
+        return self.ctx.is_active()
 
     async def connect(self) -> bool:
         """Start reconnecting asynchronous udp client.
 
         :meta private:
         """
-        self.reset_delay()
+        self.ctx.reset_delay()
         Log.debug(
             "Connecting to {}:{}.",
-            self.comm_params.host,
-            self.comm_params.port,
+            self.ctx.comm_params.host,
+            self.ctx.comm_params.port,
         )
         return await self.base_connect()
 

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -1,7 +1,6 @@
 """Modbus client async UDP communication."""
 from __future__ import annotations
 
-import asyncio
 import socket
 from typing import Any
 
@@ -15,9 +14,7 @@ from pymodbus.transport import CommType
 DGRAM_TYPE = socket.SOCK_DGRAM
 
 
-class AsyncModbusUdpClient(
-    ModbusBaseClient, asyncio.Protocol, asyncio.DatagramProtocol
-):
+class AsyncModbusUdpClient(ModbusBaseClient):
     """**AsyncModbusUdpClient**.
 
     Fixed parameters:
@@ -65,8 +62,6 @@ class AsyncModbusUdpClient(
         **kwargs: Any,
     ) -> None:
         """Initialize Asyncio Modbus UDP Client."""
-        asyncio.DatagramProtocol.__init__(self)
-        asyncio.Protocol.__init__(self)
         ModbusBaseClient.__init__(
             self,
             framer,

--- a/pymodbus/framer/old_framer_rtu.py
+++ b/pymodbus/framer/old_framer_rtu.py
@@ -186,7 +186,10 @@ class ModbusRtuFramer(ModbusFramer):
         """
         super().resetFrame()
         start = time.time()
-        timeout = start + self.client.comm_params.timeout_connect
+        if hasattr(self.client,"ctx"):
+            timeout = start + self.client.ctx.comm_params.timeout_connect
+        else:
+            timeout = start + self.client.comm_params.timeout_connect
         while self.client.state != ModbusTransactionState.IDLE:
             if self.client.state == ModbusTransactionState.TRANSACTION_COMPLETE:
                 timestamp = round(time.time(), 6)

--- a/test/framers/test_old_framers.py
+++ b/test/framers/test_old_framers.py
@@ -336,7 +336,7 @@ class TestFramers:
         client.state = ModbusTransactionState.TRANSACTION_COMPLETE
         client.silent_interval = 1
         client.last_frame_end = 1
-        client.comm_params.timeout_connect = 0.25
+        client.ctx.comm_params.timeout_connect = 0.25
         client.idle_time = mock.Mock(return_value=1)
         client.send = mock.Mock(return_value=len(message))
         rtu_framer.client = client

--- a/test/sub_client/test_client.py
+++ b/test/sub_client/test_client.py
@@ -337,7 +337,7 @@ async def test_client_protocol_receiver():
     # setup existing request
     assert not list(base.transaction)
     response = base.build_response(0x00)  # pylint: disable=protected-access
-    base.data_received(data)
+    base.ctx.data_received(data)
     result = response.result()
     assert isinstance(result, pdu_bit_read.ReadCoilsResponse)
 
@@ -369,10 +369,10 @@ async def test_client_protocol_handler():
     base.ctx.connection_made(transport=transport)
     reply = pdu_bit_read.ReadCoilsRequest(1, 1)
     reply.transaction_id = 0x00
-    base._handle_response(None)  # pylint: disable=protected-access
-    base._handle_response(reply)  # pylint: disable=protected-access
+    base.ctx._handle_response(None)  # pylint: disable=protected-access
+    base.ctx._handle_response(reply)  # pylint: disable=protected-access
     response = base.build_response(0x00)  # pylint: disable=protected-access
-    base._handle_response(reply)  # pylint: disable=protected-access
+    base.ctx._handle_response(reply)  # pylint: disable=protected-access
     result = response.result()
     assert result == reply
 
@@ -393,8 +393,8 @@ class MockTransport:
         """Send a response to a received packet."""
         await asyncio.sleep(0.05)
         resp = self.req.execute(self.ctx)
-        pkt = self.base.framer.buildPacket(resp)
-        self.base.data_received(pkt)
+        pkt = self.base.ctx.framer.buildPacket(resp)
+        self.base.ctx.data_received(pkt)
 
     def write(self, data, addr=None):
         """Write data to the transport, start a task to send the response."""

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -74,7 +74,7 @@ class TestNetwork:
         assert await stub.start_run()
         assert await client.connect()
         test_data = b"Data got echoed."
-        client.transport.write(test_data)
+        client.ctx.transport.write(test_data)
         client.close()
         stub.close()
 


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
this PR makes the client classes independent (relative) of ModbusProtocol, which instead is kept a variable in the base class.
