### PR TITLE
test_simulator: use unused_tcp_port fixture

### DIFF
--- a/test/sub_server/test_simulator.py
+++ b/test/sub_server/test_simulator.py
@@ -1,4 +1,5 @@
 """Test datastore."""
+
 import asyncio
 import copy
 import json
@@ -582,9 +583,9 @@ class TestSimulator:
             )
         ),
     )
-    async def test_simulator_server_tcp(self):
+    async def test_simulator_server_tcp(self, unused_tcp_port):
         """Test init simulator server."""
-        task = ModbusSimulatorServer()
+        task = ModbusSimulatorServer(http_port=unused_tcp_port)
         await task.run_forever(only_start=True)
         await asyncio.sleep(0.5)
         await task.stop()


### PR DESCRIPTION
default port 8080 can be in use when running test in developer machine, so better to use port that is available