### PR TITLE
Request/Response: change execute to be async method

### DIFF
--- a/pymodbus/pdu/bit_read_message.py
+++ b/pymodbus/pdu/bit_read_message.py
@@ -155,7 +155,7 @@ class ReadCoilsRequest(ReadBitsRequestBase):
         """
         ReadBitsRequestBase.__init__(self, address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read coils request against a datastore.
 
         Before running the request, we make sure that the request is in
@@ -223,7 +223,7 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
         """
         ReadBitsRequestBase.__init__(self, address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read discrete input request against a datastore.
 
         Before running the request, we make sure that the request is in

--- a/pymodbus/pdu/bit_write_message.py
+++ b/pymodbus/pdu/bit_write_message.py
@@ -79,7 +79,7 @@ class WriteSingleCoilRequest(ModbusRequest):
         self.address, value = struct.unpack(">HH", data)
         self.value = value == ModbusStatus.ON
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write coil request against a datastore.
 
         :param context: The datastore to request from
@@ -213,7 +213,7 @@ class WriteMultipleCoilsRequest(ModbusRequest):
         values = unpack_bitstring(data[5:])
         self.values = values[:count]
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write coils request against a datastore.
 
         :param context: The datastore to request from

--- a/pymodbus/pdu/diag_message.py
+++ b/pymodbus/pdu/diag_message.py
@@ -199,7 +199,7 @@ class DiagnosticStatusSimpleRequest(DiagnosticStatusRequest):
         DiagnosticStatusRequest.__init__(self, **kwargs)
         self.message = data
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Raise if not implemented."""
         raise NotImplementedException("Diagnostic Message Has No Execute Method")
 
@@ -245,7 +245,7 @@ class ReturnQueryDataRequest(DiagnosticStatusRequest):
             raise ModbusException(f"message({type(message)}) must be bytes")
         self.message = message
 
-    def execute(self, *_args):
+    async def execute(self, *_args):
         """Execute the loopback request (builds the response).
 
         :returns: The populated loopback response message
@@ -301,7 +301,7 @@ class RestartCommunicationsOptionRequest(DiagnosticStatusRequest):
         else:
             self.message = [ModbusStatus.OFF]
 
-    def execute(self, *_args):
+    async def execute(self, *_args):
         """Clear event log and restart.
 
         :returns: The initialized response message
@@ -343,7 +343,7 @@ class ReturnDiagnosticRegisterRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0002
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -377,7 +377,7 @@ class ChangeAsciiInputDelimiterRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0003
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -412,7 +412,7 @@ class ForceListenOnlyModeRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0004
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -451,7 +451,7 @@ class ClearCountersRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x000A
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -482,7 +482,7 @@ class ReturnBusMessageCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x000B
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -515,7 +515,7 @@ class ReturnBusCommunicationErrorCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x000C
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -548,7 +548,7 @@ class ReturnBusExceptionErrorCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x000D
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -581,7 +581,7 @@ class ReturnSlaveMessageCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x000E
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -614,7 +614,7 @@ class ReturnSlaveNoResponseCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x000F
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -648,7 +648,7 @@ class ReturnSlaveNAKCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0010
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -682,7 +682,7 @@ class ReturnSlaveBusyCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0011
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -717,7 +717,7 @@ class ReturnSlaveBusCharacterOverrunCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0012
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -750,7 +750,7 @@ class ReturnIopOverrunCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0013
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -783,7 +783,7 @@ class ClearOverrunCountRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0014
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message
@@ -834,7 +834,7 @@ class GetClearModbusPlusRequest(DiagnosticStatusSimpleRequest):
             data = 0
         return 1 + 2 + 2 + 2 + data
 
-    def execute(self, *args):
+    async def execute(self, *args):
         """Execute the diagnostic request on the given device.
 
         :returns: The initialized response message

--- a/pymodbus/pdu/mei_message.py
+++ b/pymodbus/pdu/mei_message.py
@@ -84,7 +84,7 @@ class ReadDeviceInformationRequest(ModbusRequest):
         params = struct.unpack(">BBB", data)
         self.sub_function_code, self.read_code, self.object_id = params
 
-    def execute(self, _context):
+    async def execute(self, _context):
         """Run a read exception status request against the store.
 
         :returns: The populated response

--- a/pymodbus/pdu/other_message.py
+++ b/pymodbus/pdu/other_message.py
@@ -54,7 +54,7 @@ class ReadExceptionStatusRequest(ModbusRequest):
         :param data: The incoming data
         """
 
-    def execute(self, _context=None):
+    async def execute(self, _context=None):
         """Run a read exception status request against the store.
 
         :returns: The populated response
@@ -159,7 +159,7 @@ class GetCommEventCounterRequest(ModbusRequest):
         :param data: The incoming data
         """
 
-    def execute(self, _context=None):
+    async def execute(self, _context=None):
         """Run a read exception status request against the store.
 
         :returns: The populated response
@@ -270,7 +270,7 @@ class GetCommEventLogRequest(ModbusRequest):
         :param data: The incoming data
         """
 
-    def execute(self, _context=None):
+    async def execute(self, _context=None):
         """Run a read exception status request against the store.
 
         :returns: The populated response
@@ -395,7 +395,7 @@ class ReportSlaveIdRequest(ModbusRequest):
         :param data: The incoming data
         """
 
-    def execute(self, context=None):
+    async def execute(self, context=None):
         """Run a report slave id request against the store.
 
         :returns: The populated response

--- a/pymodbus/pdu/pdu.py
+++ b/pymodbus/pdu/pdu.py
@@ -252,7 +252,7 @@ class IllegalFunctionRequest(ModbusRequest):
     def encode(self):
         """Decode so this failure will run correctly."""
 
-    def execute(self, _context):
+    async def execute(self, _context):
         """Build an illegal function request error response.
 
         :returns: The error response packet

--- a/pymodbus/pdu/register_read_message.py
+++ b/pymodbus/pdu/register_read_message.py
@@ -139,7 +139,7 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
         """
         super().__init__(address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read holding request against a datastore.
 
         :param context: The datastore to request from
@@ -200,7 +200,7 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
         """
         super().__init__(address, count, slave, **kwargs)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a read input request against a datastore.
 
         :param context: The datastore to request from
@@ -310,7 +310,7 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
             register = struct.unpack(">H", data[i : i + 2])[0]
             self.write_registers.append(register)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from

--- a/pymodbus/pdu/register_write_message.py
+++ b/pymodbus/pdu/register_write_message.py
@@ -57,7 +57,7 @@ class WriteSingleRegisterRequest(ModbusRequest):
         """
         self.address, self.value = struct.unpack(">HH", data)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from
@@ -200,7 +200,7 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         for idx in range(5, (self.count * 2) + 5, 2):
             self.values.append(struct.unpack(">H", data[idx : idx + 2])[0])
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from
@@ -321,7 +321,7 @@ class MaskWriteRegisterRequest(ModbusRequest):
         """
         self.address, self.and_mask, self.or_mask = struct.unpack(">HHH", data)
 
-    def execute(self, context):
+    async def execute(self, context):
         """Run a mask write register request against the store.
 
         :param context: The datastore to request from

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -184,17 +184,10 @@ class ModbusServerRequestHandler(ModbusProtocol):
                 # if broadcasting then execute on all slave contexts,
                 # note response will be ignored
                 for slave_id in self.server.context.slaves():
-                    response = request.execute(self.server.context[slave_id])
-                    # Temporary check while we move execute to async method
-                    if asyncio.iscoroutine(response):
-                        response = await response
+                    response = await request.execute(self.server.context[slave_id])
             else:
                 context = self.server.context[request.slave_id]
-                response = request.execute(context)
-
-                # Temporary check while we move execute to async method
-                if asyncio.iscoroutine(response):
-                    response = await response
+                response = await request.execute(context)
 
         except NoSuchSlaveException:
             Log.error("requested slave does not exist: {}", request.slave_id)

--- a/test/sub_client/test_client.py
+++ b/test/sub_client/test_client.py
@@ -392,7 +392,7 @@ class MockTransport:
     async def delayed_resp(self):
         """Send a response to a received packet."""
         await asyncio.sleep(0.05)
-        resp = self.req.execute(self.ctx)
+        resp = await self.req.execute(self.ctx)
         pkt = self.base.ctx.framer.buildPacket(resp)
         self.base.ctx.data_received(pkt)
 

--- a/test/sub_function_codes/test_bit_read_messages.py
+++ b/test/sub_function_codes/test_bit_read_messages.py
@@ -85,7 +85,7 @@ class TestModbusBitMessage:
         for request, expected in iter(messages.items()):
             assert request.encode() == expected
 
-    def test_bit_read_message_execute_value_errors(self):
+    async def test_bit_read_message_execute_value_errors(self):
         """Test bit read request encoding."""
         context = MockContext()
         requests = [
@@ -93,10 +93,10 @@ class TestModbusBitMessage:
             ReadDiscreteInputsRequest(1, 0x800),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert ModbusExceptions.IllegalValue == result.exception_code
 
-    def test_bit_read_message_execute_address_errors(self):
+    async def test_bit_read_message_execute_address_errors(self):
         """Test bit read request encoding."""
         context = MockContext()
         requests = [
@@ -104,10 +104,10 @@ class TestModbusBitMessage:
             ReadDiscreteInputsRequest(1, 5),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert ModbusExceptions.IllegalAddress == result.exception_code
 
-    def test_bit_read_message_execute_success(self):
+    async def test_bit_read_message_execute_success(self):
         """Test bit read request encoding."""
         context = MockContext()
         context.validate = lambda a, b, c: True
@@ -116,7 +116,7 @@ class TestModbusBitMessage:
             ReadDiscreteInputsRequest(1, 5),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert result.bits == [True] * 5
 
     def test_bit_read_message_get_response_pdu(self):

--- a/test/sub_function_codes/test_bit_write_messages.py
+++ b/test/sub_function_codes/test_bit_write_messages.py
@@ -81,45 +81,45 @@ class TestModbusBitMessage:
         request = WriteSingleCoilRequest(1, False)
         assert request.encode() == b"\x00\x01\x00\x00"
 
-    def test_write_single_coil_execute(self):
+    async def test_write_single_coil_execute(self):
         """Test write single coil."""
         context = MockContext(False, default=True)
         request = WriteSingleCoilRequest(2, True)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         context.valid = True
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.encode() == b"\x00\x02\xff\x00"
 
         context = MockContext(True, default=False)
         request = WriteSingleCoilRequest(2, False)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.encode() == b"\x00\x02\x00\x00"
 
-    def test_write_multiple_coils_execute(self):
+    async def test_write_multiple_coils_execute(self):
         """Test write multiple coils."""
         context = MockContext(False)
         # too many values
         request = WriteMultipleCoilsRequest(2, FakeList(0x123456))
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         # bad byte count
         request = WriteMultipleCoilsRequest(2, [0x00] * 4)
         request.byte_count = 0x00
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         # does not validate
         context.valid = False
         request = WriteMultipleCoilsRequest(2, [0x00] * 4)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         # validated request
         context.valid = True
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.encode() == b"\x00\x02\x00\x04"
 
     def test_write_multiple_coils_response(self):

--- a/test/sub_function_codes/test_diag_messages.py
+++ b/test/sub_function_codes/test_diag_messages.py
@@ -137,12 +137,12 @@ class TestDataStore:
             encoded = handle.encode()
             assert enc == encoded
 
-    def test_diagnostic_simple_requests(self):
+    async def test_diagnostic_simple_requests(self):
         """Testing diagnostic request messages encoding."""
         request = DiagnosticStatusSimpleRequest(b"\x12\x34")
         request.sub_function_code = 0x1234
         with pytest.raises(NotImplementedException):
-            request.execute()
+            await request.execute()
         assert request.encode() == b"\x12\x34\x12\x34"
         DiagnosticStatusSimpleResponse()
 
@@ -158,10 +158,10 @@ class TestDataStore:
         for msg, enc, _ in self.requests:
             assert msg().encode() == enc
 
-    def test_diagnostic_execute(self):
+    async def test_diagnostic_execute(self):
         """Testing diagnostic message execution."""
         for message, encoded, executed in self.requests:
-            encoded = message().execute().encode()
+            encoded = (await message().execute()).encode()
             assert encoded == executed
 
     def test_return_query_data_request(self):
@@ -190,13 +190,13 @@ class TestDataStore:
         response = RestartCommunicationsOptionResponse(False)
         assert response.encode() == b"\x00\x01\x00\x00"
 
-    def test_get_clear_modbus_plus_request_execute(self):
+    async def test_get_clear_modbus_plus_request_execute(self):
         """Testing diagnostic message execution."""
         request = GetClearModbusPlusRequest(data=ModbusPlusOperation.CLEAR_STATISTICS)
-        response = request.execute()
+        response = await request.execute()
         assert response.message == ModbusPlusOperation.CLEAR_STATISTICS
 
         request = GetClearModbusPlusRequest(data=ModbusPlusOperation.GET_STATISTICS)
-        response = request.execute()
+        response = await request.execute()
         resp = [ModbusPlusOperation.GET_STATISTICS]
         assert response.message == resp + [0x00] * 55

--- a/test/sub_function_codes/test_mei_messages.py
+++ b/test/sub_function_codes/test_mei_messages.py
@@ -43,7 +43,7 @@ class TestMeiMessage:
         assert handle.read_code == DeviceInformation.BASIC
         assert not handle.object_id
 
-    def test_read_device_information_request(self):
+    async def test_read_device_information_request(self):
         """Test basic bit message encoding/decoding."""
         context = None
         control = ModbusControlBlock()
@@ -53,7 +53,7 @@ class TestMeiMessage:
         control.Identity.update({0x81: ["Test", "Repeated"]})
 
         handle = ReadDeviceInformationRequest()
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert isinstance(result, ReadDeviceInformationResponse)
         assert result.information[0x00] == "Company"
         assert result.information[0x01] == "Product"
@@ -64,20 +64,20 @@ class TestMeiMessage:
         handle = ReadDeviceInformationRequest(
             read_code=DeviceInformation.EXTENDED, object_id=0x80
         )
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert result.information[0x81] == ["Test", "Repeated"]
 
-    def test_read_device_information_request_error(self):
+    async def test_read_device_information_request_error(self):
         """Test basic bit message encoding/decoding."""
         handle = ReadDeviceInformationRequest()
         handle.read_code = -1
-        assert handle.execute(None).function_code == 0xAB
+        assert (await handle.execute(None)).function_code == 0xAB
         handle.read_code = 0x05
-        assert handle.execute(None).function_code == 0xAB
+        assert (await handle.execute(None)).function_code == 0xAB
         handle.object_id = -1
-        assert handle.execute(None).function_code == 0xAB
+        assert (await handle.execute(None)).function_code == 0xAB
         handle.object_id = 0x100
-        assert handle.execute(None).function_code == 0xAB
+        assert (await handle.execute(None)).function_code == 0xAB
 
     def test_read_device_information_encode(self):
         """Test that the read fifo queue response can encode."""

--- a/test/sub_function_codes/test_other_messages.py
+++ b/test/sub_function_codes/test_other_messages.py
@@ -28,24 +28,24 @@ class TestOtherMessage:
         for message in self.responses:
             assert str(message)
 
-    def test_read_exception_status(self):
+    async def test_read_exception_status(self):
         """Test read exception status."""
         request = pymodbus_message.ReadExceptionStatusRequest()
         request.decode(b"\x12")
         assert not request.encode()
-        assert request.execute().function_code == 0x07
+        assert (await request.execute()).function_code == 0x07
 
         response = pymodbus_message.ReadExceptionStatusResponse(0x12)
         assert response.encode() == b"\x12"
         response.decode(b"\x12")
         assert response.status == 0x12
 
-    def test_get_comm_event_counter(self):
+    async def test_get_comm_event_counter(self):
         """Test get comm event counter."""
         request = pymodbus_message.GetCommEventCounterRequest()
         request.decode(b"\x12")
         assert not request.encode()
-        assert request.execute().function_code == 0x0B
+        assert (await request.execute()).function_code == 0x0B
 
         response = pymodbus_message.GetCommEventCounterResponse(0x12)
         assert response.encode() == b"\x00\x00\x00\x12"
@@ -56,12 +56,12 @@ class TestOtherMessage:
         response.status = False
         assert response.encode() == b"\xFF\xFF\x00\x12"
 
-    def test_get_comm_event_log(self):
+    async def test_get_comm_event_log(self):
         """Test get comm event log."""
         request = pymodbus_message.GetCommEventLogRequest()
         request.decode(b"\x12")
         assert not request.encode()
-        assert request.execute().function_code == 0x0C
+        assert (await request.execute()).function_code == 0x0C
 
         response = pymodbus_message.GetCommEventLogResponse()
         assert response.encode() == b"\x06\x00\x00\x00\x00\x00\x00"
@@ -84,7 +84,7 @@ class TestOtherMessage:
         assert response.event_count == 0x12
         assert response.events == [0x12, 0x34, 0x56]
 
-    def test_report_slave_id_request(self):
+    async def test_report_slave_id_request(self):
         """Test report slave id request."""
         with mock.patch("pymodbus.pdu.other_message.DeviceInformationFactory") as dif:
             # First test regular identity strings
@@ -103,7 +103,7 @@ class TestOtherMessage:
             expected_identity = "-".join(identity.values()).encode()
 
             request = pymodbus_message.ReportSlaveIdRequest()
-            response = request.execute()
+            response = await request.execute()
             assert response.identifier == expected_identity
 
             # Change to byte strings and test again (final result should be the same)
@@ -121,20 +121,20 @@ class TestOtherMessage:
             dif.get.return_value = identity
 
             request = pymodbus_message.ReportSlaveIdRequest()
-            response = request.execute()
+            response = await request.execute()
             assert response.identifier == expected_identity
 
-    def test_report_slave_id(self):
+    async def test_report_slave_id(self):
         """Test report slave id."""
         with mock.patch("pymodbus.pdu.other_message.DeviceInformationFactory") as dif:
             dif.get.return_value = {}
             request = pymodbus_message.ReportSlaveIdRequest()
             request.decode(b"\x12")
             assert not request.encode()
-            assert request.execute().function_code == 0x11
+            assert (await request.execute()).function_code == 0x11
 
             response = pymodbus_message.ReportSlaveIdResponse(
-                request.execute().identifier, True
+                (await request.execute()).identifier, True
             )
 
             assert response.encode() == b"\tPymodbus\xff"

--- a/test/sub_function_codes/test_register_read_messages.py
+++ b/test/sub_function_codes/test_register_read_messages.py
@@ -100,7 +100,7 @@ class TestReadRegisterMessages:
             request.decode(response)
             assert request.registers == register
 
-    def test_register_read_requests_count_errors(self):
+    async def test_register_read_requests_count_errors(self):
         """This tests that the register request messages.
 
         will break on counts that are out of range
@@ -117,10 +117,10 @@ class TestReadRegisterMessages:
             ),
         ]
         for request in requests:
-            result = request.execute(None)
+            result = await request.execute(None)
             assert ModbusExceptions.IllegalValue == result.exception_code
 
-    def test_register_read_requests_validate_errors(self):
+    async def test_register_read_requests_validate_errors(self):
         """This tests that the register request messages.
 
         will break on counts that are out of range
@@ -133,10 +133,10 @@ class TestReadRegisterMessages:
             # ReadWriteMultipleRegistersRequest(1,5,-1,5),
         ]
         for request in requests:
-            result = request.execute(context)
+            result = await request.execute(context)
             assert ModbusExceptions.IllegalAddress == result.exception_code
 
-    def test_register_read_requests_execute(self):
+    async def test_register_read_requests_execute(self):
         """This tests that the register request messages.
 
         will break on counts that are out of range
@@ -147,34 +147,34 @@ class TestReadRegisterMessages:
             ReadInputRegistersRequest(-1, 5),
         ]
         for request in requests:
-            response = request.execute(context)
+            response = await request.execute(context)
             assert request.function_code == response.function_code
 
-    def test_read_write_multiple_registers_request(self):
+    async def test_read_write_multiple_registers_request(self):
         """Test read/write multiple registers."""
         context = MockContext(True)
         request = ReadWriteMultipleRegistersRequest(
             read_address=1, read_count=10, write_address=1, write_registers=[0x00]
         )
-        response = request.execute(context)
+        response = await request.execute(context)
         assert request.function_code == response.function_code
 
-    def test_read_write_multiple_registers_validate(self):
+    async def test_read_write_multiple_registers_validate(self):
         """Test read/write multiple registers."""
         context = MockContext()
         context.validate = lambda f, a, c: a == 1
         request = ReadWriteMultipleRegistersRequest(
             read_address=1, read_count=10, write_address=2, write_registers=[0x00]
         )
-        response = request.execute(context)
+        response = await request.execute(context)
         assert response.exception_code == ModbusExceptions.IllegalAddress
 
         context.validate = lambda f, a, c: a == 2
-        response = request.execute(context)
+        response = await request.execute(context)
         assert response.exception_code == ModbusExceptions.IllegalAddress
 
         request.write_byte_count = 0x100
-        response = request.execute(context)
+        response = await request.execute(context)
         assert response.exception_code == ModbusExceptions.IllegalValue
 
     def test_read_write_multiple_registers_request_decode(self):

--- a/test/sub_function_codes/test_register_write_messages.py
+++ b/test/sub_function_codes/test_register_write_messages.py
@@ -84,43 +84,43 @@ class TestWriteRegisterMessages:
         for request in iter(self.write.keys()):
             assert str(request)
 
-    def test_write_single_register_request(self):
+    async def test_write_single_register_request(self):
         """Test write single register request."""
         context = MockContext()
         request = WriteSingleRegisterRequest(0x00, 0xF0000)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         request.value = 0x00FF
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         context.valid = True
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.function_code == request.function_code
 
-    def test_write_multiple_register_request(self):
+    async def test_write_multiple_register_request(self):
         """Test write multiple register request."""
         context = MockContext()
         request = WriteMultipleRegistersRequest(0x00, [0x00] * 10)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalAddress
 
         request.count = 0x05  # bytecode != code * 2
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         request.count = 0x800  # outside of range
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.exception_code == ModbusExceptions.IllegalValue
 
         context.valid = True
         request = WriteMultipleRegistersRequest(0x00, [0x00] * 10)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.function_code == request.function_code
 
         request = WriteMultipleRegistersRequest(0x00, 0x00)
-        result = request.execute(context)
+        result = await request.execute(context)
         assert result.function_code == request.function_code
 
         # -----------------------------------------------------------------------#
@@ -142,7 +142,7 @@ class TestWriteRegisterMessages:
         assert handle.and_mask == 0x00F2
         assert handle.or_mask == 0x0025
 
-    def test_mask_write_register_request_execute(self):
+    async def test_mask_write_register_request_execute(self):
         """Test write register request valid execution."""
         # The test uses the 4 nibbles of the 16-bit values to test
         # the combinations:
@@ -152,23 +152,23 @@ class TestWriteRegisterMessages:
         #     and_mask=F, or_mask=F
         context = MockLastValuesContext(valid=True, default=0xAA55)
         handle = MaskWriteRegisterRequest(0x0000, 0x0F0F, 0x00FF)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert isinstance(result, MaskWriteRegisterResponse)
         assert context.last_values == [0x0AF5]
 
-    def test_mask_write_register_request_invalid_execute(self):
+    async def test_mask_write_register_request_invalid_execute(self):
         """Test write register request execute with invalid data."""
         context = MockContext(valid=False, default=0x0000)
         handle = MaskWriteRegisterRequest(0x0000, -1, 0x1010)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert ModbusExceptions.IllegalValue == result.exception_code
 
         handle = MaskWriteRegisterRequest(0x0000, 0x0101, -1)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert ModbusExceptions.IllegalValue == result.exception_code
 
         handle = MaskWriteRegisterRequest(0x0000, 0x0101, 0x1010)
-        result = handle.execute(context)
+        result = await handle.execute(context)
         assert ModbusExceptions.IllegalAddress == result.exception_code
 
         # -----------------------------------------------------------------------#

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -204,11 +204,11 @@ class TestFactory:
     #  since the high bit is set, it will simply echo the resulting message
     # ---------------------------------------------------------------------------#
 
-    def test_request_errors(self):
+    async def test_request_errors(self):
         """Test a request factory decoder exceptions."""
         for func, msg in self.bad:
             result = self.server.decode(msg)
             assert result.ErrorCode == 1, "Failed to decode invalid requests"
             assert (
-                result.execute(None).function_code == func
-            ), "Failed to create correct response message"
+                await result.execute(None)
+            ).function_code == func, "Failed to create correct response message"

--- a/test/test_pdu.py
+++ b/test/test_pdu.py
@@ -31,10 +31,10 @@ class TestPdu:
             with pytest.raises(NotImplementedException):
                 request.decode(None)
 
-    def test_error_methods(self):
+    async def test_error_methods(self):
         """Test all error methods."""
         self.illegal.decode("12345")
-        self.illegal.execute(None)
+        await self.illegal.execute(None)
 
         result = self.exception.encode()
         self.exception.decode(result)


### PR DESCRIPTION
contains only async/await edits, no functional changes otherwise. This combined with https://github.com/pymodbus-dev/pymodbus/pull/2144 allows to utilize async datastore calls in modbus server

Split from https://github.com/pymodbus-dev/pymodbus/pull/2127 and depends on https://github.com/pymodbus-dev/pymodbus/pull/2139