### PR TITLE
datastore: add async_setValues/getValues methods

### DIFF
--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -1,9 +1,12 @@
 """Context for datastore."""
 
+from __future__ import annotations
+
 # pylint: disable=missing-type-doc
 from pymodbus.datastore.store import ModbusSequentialDataBlock
 from pymodbus.exceptions import NoSuchSlaveException
 from pymodbus.logging import Log
+from pymodbus.pdu import ExceptionResponse
 
 
 class ModbusBaseSlaveContext:
@@ -28,7 +31,7 @@ class ModbusBaseSlaveContext:
         """
         return self._fx_mapper[fx]
 
-    async def async_getValues(self, fc_as_hex, address, count=1):
+    async def async_getValues(self, fc_as_hex: int, address: int, count: int = 1) -> list[int | bool | None] | ExceptionResponse:
         """Get `count` values from datastore.
 
         :param fc_as_hex: The function we are working with
@@ -38,7 +41,7 @@ class ModbusBaseSlaveContext:
         """
         return self.getValues(fc_as_hex, address, count)
 
-    async def async_setValues(self, fc_as_hex, address, values):
+    async def async_setValues(self, fc_as_hex: int, address: int, values: list[int | bool]) -> None:
         """Set the datastore with the supplied values.
 
         :param fc_as_hex: The function we are working with
@@ -47,7 +50,7 @@ class ModbusBaseSlaveContext:
         """
         self.setValues(fc_as_hex, address, values)
 
-    def getValues( self, fc_as_hex, address, count=1):  # pylint: disable=unused-argument
+    def getValues(self, fc_as_hex: int, address: int, count: int = 1) -> list[int | bool | None] | ExceptionResponse:  # pylint: disable=unused-argument
         """Get `count` values from datastore.
 
         :param fc_as_hex: The function we are working with
@@ -57,7 +60,7 @@ class ModbusBaseSlaveContext:
         """
         return []
 
-    def setValues(self, fc_as_hex, address, values):
+    def setValues(self, fc_as_hex: int, address: int, values: list[int | bool]) -> None | ExceptionResponse:
         """Set the datastore with the supplied values.
 
         :param fc_as_hex: The function we are working with

--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -1,18 +1,19 @@
 """Context for datastore."""
+
 # pylint: disable=missing-type-doc
 from pymodbus.datastore.store import ModbusSequentialDataBlock
 from pymodbus.exceptions import NoSuchSlaveException
 from pymodbus.logging import Log
 
 
-class ModbusBaseSlaveContext:  # pylint: disable=too-few-public-methods
+class ModbusBaseSlaveContext:
     """Interface for a modbus slave data context.
 
     Derived classes must implemented the following methods:
             reset(self)
             validate(self, fx, address, count=1)
-            getValues(self, fx, address, count=1)
-            setValues(self, fx, address, values)
+            getValues(self, fc_as_hex, address, count=1) or async_getValues(self, fc_as_hex, address, count=1)
+            setValues(self, fc_as_hex, address, values) or async_setValues(self, fc_as_hex, address, values)
     """
 
     _fx_mapper = {2: "d", 4: "i"}
@@ -26,6 +27,43 @@ class ModbusBaseSlaveContext:  # pylint: disable=too-few-public-methods
         :returns: one of [d(iscretes),i(nputs),h(olding),c(oils)
         """
         return self._fx_mapper[fx]
+
+    async def async_getValues(self, fc_as_hex, address, count=1):
+        """Get `count` values from datastore.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :returns: The requested values from a:a+c
+        """
+        return self.getValues(fc_as_hex, address, count)
+
+    async def async_setValues(self, fc_as_hex, address, values):
+        """Set the datastore with the supplied values.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param values: The new values to be set
+        """
+        self.setValues(fc_as_hex, address, values)
+
+    def getValues( self, fc_as_hex, address, count=1):  # pylint: disable=unused-argument
+        """Get `count` values from datastore.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :returns: The requested values from a:a+c
+        """
+        return []
+
+    def setValues(self, fc_as_hex, address, values):
+        """Set the datastore with the supplied values.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param values: The new values to be set
+        """
 
 
 # ---------------------------------------------------------------------------#

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -72,6 +72,10 @@ class BaseModbusDataBlock(ABC, Generic[V]):
             getValues(self, address, count=1)
             setValues(self, address, values)
             reset(self)
+
+    Derived classes can implemented the following async methods:
+            async_getValues(self, address, count=1)
+            async_setValues(self, address, values)
     """
 
     values: V
@@ -87,6 +91,15 @@ class BaseModbusDataBlock(ABC, Generic[V]):
         :raises TypeError:
         """
 
+    async def async_getValues(self, address: int, count=1) -> Iterable:
+        """Return the requested values from the datastore.
+
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :raises TypeError:
+        """
+        return self.getValues(address, count)
+
     @abstractmethod
     def getValues(self, address:int, count=1) -> Iterable:
         """Return the requested values from the datastore.
@@ -95,6 +108,15 @@ class BaseModbusDataBlock(ABC, Generic[V]):
         :param count: The number of values to retrieve
         :raises TypeError:
         """
+
+    async def async_setValues(self, address: int, values):
+        """Return the requested values from the datastore.
+
+        :param address: The starting address
+        :param values: The values to store
+        :raises TypeError:
+        """
+        return self.setValues(address, values)
 
     @abstractmethod
     def setValues(self, address:int, values) -> None:

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -109,7 +109,7 @@ class BaseModbusDataBlock(ABC, Generic[V]):
         :raises TypeError:
         """
 
-    async def async_setValues(self, address: int, values):
+    async def async_setValues(self, address: int, values: list[int|bool]) -> None:
         """Return the requested values from the datastore.
 
         :param address: The starting address

--- a/test/test_remote_datastore.py
+++ b/test/test_remote_datastore.py
@@ -1,4 +1,5 @@
 """Test remote datastore."""
+
 from unittest import mock
 
 import pytest
@@ -34,6 +35,18 @@ class TestRemoteDataStore:
         # assert result.exception_code == 0x02
         # assert result.function_code == 0x90
 
+    async def test_remote_slave_async_set_values(self):
+        """Test setting values against a remote slave context."""
+        client = mock.MagicMock()
+        client.write_coils = mock.MagicMock(return_value=WriteMultipleCoilsResponse())
+        client.write_registers = mock.MagicMock(
+            return_value=ExceptionResponse(0x10, 0x02)
+        )
+
+        context = RemoteSlaveContext(client)
+        await context.async_setValues(0x0F, 0, [1])
+        await context.async_setValues(0x10, 1, [1])
+
     def test_remote_slave_get_values(self):
         """Test getting values from a remote slave context."""
         client = mock.MagicMock()
@@ -52,6 +65,30 @@ class TestRemoteDataStore:
 
         context.validate(3, 0, 10)
         result = context.getValues(3, 0, 10)
+        assert result != [10] * 10
+
+    async def test_remote_slave_asyn_get_values(self):
+        """Test getting values from a remote slave context."""
+        client = mock.MagicMock()
+        client.read_coils = mock.MagicMock(return_value=ReadCoilsResponse([1] * 10))
+        client.read_input_registers = mock.MagicMock(
+            return_value=ReadInputRegistersResponse([10] * 10)
+        )
+        client.read_holding_registers = mock.MagicMock(
+            return_value=ExceptionResponse(0x15)
+        )
+
+        context = RemoteSlaveContext(client)
+        context.validate(1, 0, 10)
+        result = await context.async_getValues(1, 0, 10)
+        assert result == [1] * 10
+
+        context.validate(4, 0, 10)
+        result = await context.async_getValues(4, 0, 10)
+        assert result == [10] * 10
+
+        context.validate(3, 0, 10)
+        result = await context.async_getValues(3, 0, 10)
         assert result != [10] * 10
 
     def test_remote_slave_validate_values(self):

--- a/test/test_sparse_datastore.py
+++ b/test/test_sparse_datastore.py
@@ -1,7 +1,30 @@
 """Test framers."""
 
+import pytest
 
 from pymodbus.datastore import ModbusSparseDataBlock
+
+
+@pytest.mark.asyncio()
+async def test_check_async_sparsedatastore():
+    """Test check frame."""
+    data_in_block = {
+        1: 6720,
+        2: 130,
+        30: [0x0D, 0xFE],
+        105: [1, 2, 3, 4],
+        20000: [45, 241, 48],
+        20008: 38,
+        48140: [0x4208, 0xCCCD],
+    }
+    datablock = ModbusSparseDataBlock(data_in_block)
+    for key, entry in data_in_block.items():
+        if isinstance(entry, int):
+            entry = [entry]
+        for value in entry:
+            assert datablock.validate(key, 1)
+            assert await datablock.async_getValues(key, 1) == [value]
+            key += 1
 
 
 def test_check_sparsedatastore():


### PR DESCRIPTION
By default those just call self.set/getValues but can be used to implement more async datastore access in modbus server.

Split from https://github.com/pymodbus-dev/pymodbus/pull/2127


