### PR TITLE
call async datastore from modbus server execute flow

### DIFF
--- a/pymodbus/pdu/bit_read_message.py
+++ b/pymodbus/pdu/bit_read_message.py
@@ -169,7 +169,9 @@ class ReadCoilsRequest(ReadBitsRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
         return ReadCoilsResponse(values)
@@ -237,7 +239,9 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
         return ReadDiscreteInputsResponse(values)

--- a/pymodbus/pdu/bit_write_message.py
+++ b/pymodbus/pdu/bit_write_message.py
@@ -90,11 +90,8 @@ class WriteSingleCoilRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
 
-        context.setValues(self.function_code, self.address, [self.value])
-        # result = context.setValues(self.function_code, self.address, [self.value])
-        # if isinstance(result, ExceptionResponse):
-        #    return result
-        values = context.getValues(self.function_code, self.address, 1)
+        await context.async_setValues(self.function_code, self.address, [self.value])
+        values = await context.async_getValues(self.function_code, self.address, 1)
         # if isinstance(values, ExceptionResponse):
         #    return values
         return WriteSingleCoilResponse(self.address, values[0])
@@ -227,7 +224,9 @@ class WriteMultipleCoilsRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, count):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, self.values)
+        result = await context.async_setValues(
+            self.function_code, self.address, self.values
+        )
         if isinstance(result, ExceptionResponse):
             return result
         return WriteMultipleCoilsResponse(self.address, count)

--- a/pymodbus/pdu/bit_write_message.py
+++ b/pymodbus/pdu/bit_write_message.py
@@ -14,8 +14,8 @@ __all__ = [
 import struct
 
 from pymodbus.constants import ModbusStatus
-from pymodbus.pdu import ExceptionResponse, ModbusRequest, ModbusResponse
 from pymodbus.pdu import ModbusExceptions as merror
+from pymodbus.pdu import ModbusRequest, ModbusResponse
 from pymodbus.utilities import pack_bitstring, unpack_bitstring
 
 
@@ -224,11 +224,9 @@ class WriteMultipleCoilsRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, count):
             return self.doException(merror.IllegalAddress)
 
-        result = await context.async_setValues(
+        await context.async_setValues(
             self.function_code, self.address, self.values
         )
-        if isinstance(result, ExceptionResponse):
-            return result
         return WriteMultipleCoilsResponse(self.address, count)
 
     def __str__(self):

--- a/pymodbus/pdu/register_read_message.py
+++ b/pymodbus/pdu/register_read_message.py
@@ -149,7 +149,9 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
 
@@ -210,7 +212,9 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, self.count)
+        values = await context.async_getValues(
+            self.function_code, self.address, self.count
+        )
         if isinstance(values, ExceptionResponse):
             return values
         return ReadInputRegistersResponse(values)
@@ -328,12 +332,12 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
             return self.doException(merror.IllegalAddress)
         if not context.validate(self.function_code, self.read_address, self.read_count):
             return self.doException(merror.IllegalAddress)
-        result = context.setValues(
+        result = await context.async_setValues(
             self.function_code, self.write_address, self.write_registers
         )
         if isinstance(result, ExceptionResponse):
             return result
-        registers = context.getValues(
+        registers = await context.async_getValues(
             self.function_code, self.read_address, self.read_count
         )
         return ReadWriteMultipleRegistersResponse(registers)

--- a/pymodbus/pdu/register_read_message.py
+++ b/pymodbus/pdu/register_read_message.py
@@ -332,11 +332,9 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
             return self.doException(merror.IllegalAddress)
         if not context.validate(self.function_code, self.read_address, self.read_count):
             return self.doException(merror.IllegalAddress)
-        result = await context.async_setValues(
+        await context.async_setValues(
             self.function_code, self.write_address, self.write_registers
         )
-        if isinstance(result, ExceptionResponse):
-            return result
         registers = await context.async_getValues(
             self.function_code, self.read_address, self.read_count
         )

--- a/pymodbus/pdu/register_write_message.py
+++ b/pymodbus/pdu/register_write_message.py
@@ -68,10 +68,12 @@ class WriteSingleRegisterRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, [self.value])
+        result = await context.async_setValues(
+            self.function_code, self.address, [self.value]
+        )
         if isinstance(result, ExceptionResponse):
             return result
-        values = context.getValues(self.function_code, self.address, 1)
+        values = await context.async_getValues(self.function_code, self.address, 1)
         return WriteSingleRegisterResponse(self.address, values[0])
 
     def get_response_pdu_size(self):
@@ -213,7 +215,9 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, self.values)
+        result = await context.async_setValues(
+            self.function_code, self.address, self.values
+        )
         if isinstance(result, ExceptionResponse):
             return result
         return WriteMultipleRegistersResponse(self.address, self.count)
@@ -333,11 +337,13 @@ class MaskWriteRegisterRequest(ModbusRequest):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
-        values = context.getValues(self.function_code, self.address, 1)[0]
+        values = (await context.async_getValues(self.function_code, self.address, 1))[0]
         if isinstance(values, ExceptionResponse):
             return values
         values = (values & self.and_mask) | (self.or_mask & ~self.and_mask)
-        result = context.setValues(self.function_code, self.address, [values])
+        result = await context.async_setValues(
+            self.function_code, self.address, [values]
+        )
         if isinstance(result, ExceptionResponse):
             return result
         return MaskWriteRegisterResponse(self.address, self.and_mask, self.or_mask)

--- a/pymodbus/pdu/register_write_message.py
+++ b/pymodbus/pdu/register_write_message.py
@@ -68,11 +68,9 @@ class WriteSingleRegisterRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
 
-        result = await context.async_setValues(
+        await context.async_setValues(
             self.function_code, self.address, [self.value]
         )
-        if isinstance(result, ExceptionResponse):
-            return result
         values = await context.async_getValues(self.function_code, self.address, 1)
         return WriteSingleRegisterResponse(self.address, values[0])
 
@@ -215,11 +213,9 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
 
-        result = await context.async_setValues(
+        await context.async_setValues(
             self.function_code, self.address, self.values
         )
-        if isinstance(result, ExceptionResponse):
-            return result
         return WriteMultipleRegistersResponse(self.address, self.count)
 
     def get_response_pdu_size(self):
@@ -341,11 +337,9 @@ class MaskWriteRegisterRequest(ModbusRequest):
         if isinstance(values, ExceptionResponse):
             return values
         values = (values & self.and_mask) | (self.or_mask & ~self.and_mask)
-        result = await context.async_setValues(
+        await context.async_setValues(
             self.function_code, self.address, [values]
         )
-        if isinstance(result, ExceptionResponse):
-            return result
         return MaskWriteRegisterResponse(self.address, self.and_mask, self.or_mask)
 
 


### PR DESCRIPTION
Take into use of async_getValues and async_setValues in modbus-server message handling, allowing datastore (mainly remote datastore) to use async flow.

Originally split from https://github.com/pymodbus-dev/pymodbus/pull/2127

