### PR TITLE
Clean datastore setValues

### DIFF
--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -90,12 +90,13 @@ class WriteSingleCoilRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
 
-        result = context.setValues(self.function_code, self.address, [self.value])
-        if isinstance(result, ExceptionResponse):
-            return result
+        context.setValues(self.function_code, self.address, [self.value])
+        # result = context.setValues(self.function_code, self.address, [self.value])
+        # if isinstance(result, ExceptionResponse):
+        #    return result
         values = context.getValues(self.function_code, self.address, 1)
-        if isinstance(values, ExceptionResponse):
-            return values
+        # if isinstance(values, ExceptionResponse):
+        #    return values
         return WriteSingleCoilResponse(self.address, values[0])
 
     def get_response_pdu_size(self):

--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -57,9 +57,8 @@ class RemoteSlaveContext(ModbusBaseSlaveContext):
             self.result = func_fc(address, values)
         else:
             self.result = func_fc(address, values[0])
-        if self.result.isError():
-            return self.result
-        return None
+        # if self.result.isError():
+        #    return self.result
 
     def __str__(self):
         """Return a string representation of the context.

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
+from pymodbus.datastore.context import ModbusBaseSlaveContext
+
 
 WORD_SIZE = 16
 
@@ -371,7 +373,7 @@ class Setup:
             raise RuntimeError(f"INVALID key in setup: {self.config}")
 
 
-class ModbusSimulatorContext:
+class ModbusSimulatorContext(ModbusBaseSlaveContext):
     """Modbus simulator.
 
     :param config: A dict with structure as shown below.

--- a/test/test_remote_datastore.py
+++ b/test/test_remote_datastore.py
@@ -29,9 +29,10 @@ class TestRemoteDataStore:
 
         context = RemoteSlaveContext(client)
         context.setValues(0x0F, 0, [1])
-        result = context.setValues(0x10, 1, [1])
-        assert result.exception_code == 0x02
-        assert result.function_code == 0x90
+        # result = context.setValues(0x10, 1, [1])
+        context.setValues(0x10, 1, [1])
+        # assert result.exception_code == 0x02
+        # assert result.function_code == 0x90
 
     def test_remote_slave_get_values(self):
         """Test getting values from a remote slave context."""


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Unclean code removed. The code was introduced while trying to build a better repeater, however a repeater should work at frame layer not datastore layer.