### PR TITLE
ModbusServerRequestHandler._asyncc_execute() 

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -189,7 +189,7 @@ class ModbusServerRequestHandler(ModbusProtocol):
                     if asyncio.iscoroutine(response):
                         response = await response
             else:
-                context = self.server.context[request.slave_id]
+                context = self.server.context[request.slave_id][request.slave_id]
                 response = request.execute(context)
 
                 # Temporary check while we move execute to async method


### PR DESCRIPTION
a dict was passed to request.execute() instead the context

fixes #2148 


