### PR TITLE
Fix condition to eliminate TID overflow issue

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -451,7 +451,7 @@ class ModbusTransactionManager:
 
         """
         Log.debug("Getting transaction {}", tid)
-        if not tid:
+        if tid is None:
             if self.transactions:
                 return self.transactions.popitem()[1]
             return None


### PR DESCRIPTION
Fix tid overflow issue when tid is zero.

These two snippets are NOT the same - the difference appears when the numeric variable reaches zero (i.e. overflows):

```
if not tid :
    ...
```

```
if tid is None :
    ....
```
Reference:
#2173 
