### PR TITLE
Don't initialize the event loop until needed.

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -49,7 +49,6 @@ class ModbusServerRequestHandler(ModbusProtocol):
         self.receive_queue: asyncio.Queue = asyncio.Queue()
         self.handler_task = None  # coroutine to be run on asyncio loop
         self.framer: ModbusFramer
-        self.loop = asyncio.get_running_loop()
 
     def _log_exception(self):
         """Show log exception."""
@@ -262,7 +261,6 @@ class ModbusBaseServer(ModbusProtocol):
             params,
             True,
         )
-        self.loop = asyncio.get_running_loop()
         self.decoder = ServerDecoder()
         self.context = context or ModbusServerContext()
         self.control = ModbusControlBlock()

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -149,7 +149,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
         self.is_closing = False
 
         self.transport: asyncio.BaseTransport = None  # type: ignore[assignment]
-        self.loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        self._loop: asyncio.AbstractEventLoop | None = None
         self.recv_buffer: bytes = b""
         self.call_create: Callable[[], Coroutine[Any, Any, Any]] = None  # type: ignore[assignment]
         if self.is_server:
@@ -189,6 +189,18 @@ class ModbusProtocol(asyncio.BaseProtocol):
             parts = host.split(":")
             host, port = parts[1][2:], int(parts[2])
         self.init_setup_connect_listen(host, port)
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """Get the event loop as needed."""
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+        return self._loop
+
+    @loop.setter
+    def loop(self, loop: asyncio.AbstractEventLoop):
+        """Set the event loop."""
+        self._loop = loop
 
     def init_setup_connect_listen(self, host: str, port: int) -> None:
         """Handle connect/listen handler."""


### PR DESCRIPTION
Initializing the event loop during class init can cause issues in some cases where the event loop is not yet running.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
