### PR TITLE
Fix writing to serial (rs485) on windows os.

### DIFF
--- a/pymodbus/transport/serialtransport.py
+++ b/pymodbus/transport/serialtransport.py
@@ -55,8 +55,16 @@ class SerialTransport(asyncio.Transport):
     def write(self, data) -> None:
         """Write some data to the transport."""
         self.intern_write_buffer.append(data)
-        if not self.poll_task:
+        if not self.poll_task and os.name != "nt":
             self.async_loop.add_writer(self.sync_serial.fileno(), self.intern_write_ready)
+        elif not self.poll_task and os.name == "nt":
+            self.poll_task = self.async_loop.create_task(self.write_task())
+
+    async def write_task(self):
+        while self.intern_write_buffer:
+            data = self.intern_write_buffer.pop(0)
+            self.sync_serial.write(data)
+            await asyncio.sleep(0)  # Yield control to the event loop
 
     def flush(self) -> None:
         """Clear output buffer and stops any more data being written."""


### PR DESCRIPTION
The issue with the write method on Windows is that it's trying to use self.sync_serial.fileno(), which doesn't work on Windows because the pySerial library doesn't provide a valid file descriptor.

To fix this, you can modify the write method to directly write to the serial port without using asyncio's add_writer method.