### PR TITLE
Fix writing to serial (rs485) on windows os.

### DIFF
--- a/pymodbus/transport/serialtransport.py
+++ b/pymodbus/transport/serialtransport.py
@@ -13,7 +13,7 @@ with contextlib.suppress(ImportError):
 class SerialTransport(asyncio.Transport):
     """An asyncio serial transport."""
 
-    force_poll: bool = False
+    force_poll: bool = os.name == "nt"
 
     def __init__(self, loop, protocol, *args, **kwargs) -> None:
         """Initialize."""
@@ -29,7 +29,7 @@ class SerialTransport(asyncio.Transport):
 
     def setup(self) -> None:
         """Prepare to read/write."""
-        if os.name == "nt" or self.force_poll:
+        if self.force_poll:
             self.poll_task = asyncio.create_task(self.polling_task())
             self.poll_task.set_name("SerialTransport poll")
         else:
@@ -56,17 +56,8 @@ class SerialTransport(asyncio.Transport):
     def write(self, data) -> None:
         """Write some data to the transport."""
         self.intern_write_buffer.append(data)
-        if not self.poll_task and os.name != "nt":
+        if not self.force_poll:
             self.async_loop.add_writer(self.sync_serial.fileno(), self.intern_write_ready)
-        elif not self.poll_task and os.name == "nt":
-            self.poll_task = self.async_loop.create_task(self.write_task())
-
-    async def write_task(self):
-        """Write data to the serial port."""
-        while self.intern_write_buffer:
-            data = self.intern_write_buffer.pop(0)
-            self.sync_serial.write(data)
-            await asyncio.sleep(0)  # Yield control to the event loop
 
     def flush(self) -> None:
         """Clear output buffer and stops any more data being written."""

--- a/test/transport/test_comm.py
+++ b/test/transport/test_comm.py
@@ -179,7 +179,6 @@ class TestTransportComm:
         SerialTransport.force_poll = True
         assert await client.connect()
         await asyncio.sleep(0.5)
-        SerialTransport.force_poll = False
         assert len(server.active_connections) == 1
         server_connected = list(server.active_connections.values())[0]
         test_data = b"abcd" * 1000

--- a/test/transport/test_serial.py
+++ b/test/transport/test_serial.py
@@ -100,6 +100,7 @@ class TestTransportSerial:
         )
         await asyncio.sleep(0)
         transport.write(b"abcd")
+        await asyncio.sleep(0.5)
         transport.close()
         SerialTransport.force_poll = False
 


### PR DESCRIPTION
The issue with the write method on Windows is that it's trying to use self.sync_serial.fileno(), which doesn't work on Windows because the pySerial library doesn't provide a valid file descriptor.

To fix this, you can modify the write method to directly write to the serial port without using asyncio's add_writer method.