### PR TITLE
Add should_respond attribute to ModbusRequest

### DIFF
--- a/examples/client_custom_msg.py
+++ b/examples/client_custom_msg.py
@@ -17,6 +17,7 @@ from pymodbus import FramerType
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
 from pymodbus.pdu import ModbusExceptions, ModbusRequest, ModbusResponse
 from pymodbus.pdu.bit_read_message import ReadCoilsRequest
+from pymodbus.pdu.register_write_message import WriteSingleRegisterRequest
 
 
 # --------------------------------------------------------------------------- #
@@ -108,6 +109,18 @@ class Read16CoilsRequest(ReadCoilsRequest):
         ReadCoilsRequest.__init__(self, address, 16, **kwargs)
 
 
+
+# --------------------------------------------------------------------------- #
+# Write registers to a buggy device that doesn't send a response
+# --------------------------------------------------------------------------- #
+
+
+class WriteSingleRegisterRequestOneshot(WriteSingleRegisterRequest):
+    """WriteSingleRegisterRequest without a response expected."""
+
+    should_respond = False
+
+
 # --------------------------------------------------------------------------- #
 # execute the request with your client
 # --------------------------------------------------------------------------- #
@@ -120,6 +133,11 @@ async def main(host="localhost", port=5020):
     """Run versions of read coil."""
     async with ModbusClient(host=host, port=port, framer_name=FramerType.SOCKET) as client:
         await client.connect()
+
+        # no response request
+        request = WriteSingleRegisterRequestOneshot(32, 42, slave=1)
+        result = await client.execute(request)
+        print(result)
 
         # new modbus function code.
         client.register(CustomModbusResponse)

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -167,7 +167,10 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
                 if not count or not self.no_resend_on_retry:
                     self.ctx.framer.resetFrame()
                     self.ctx.send(packet)
-                if self.broadcast_enable and not request.slave_id:
+                if (
+                    not request.should_respond
+                    or (self.broadcast_enable and not request.slave_id)
+                ):
                     resp = None
                     break
                 try:

--- a/pymodbus/pdu/pdu.py
+++ b/pymodbus/pdu/pdu.py
@@ -98,8 +98,15 @@ class ModbusPDU:
 
 
 class ModbusRequest(ModbusPDU):
-    """Base class for a modbus request PDU."""
+    """Base class for a modbus request PDU.
 
+    .. attribute:: should_respond
+
+        A flag that indicates if this request returns a result back
+        to the client issuing the request
+    """
+
+    should_respond = True
     function_code = -1
 
     def __init__(self, slave=0, **kwargs):

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -229,6 +229,9 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                 ):
                     self._transact(request, None, broadcast=True)
                     response = b"Broadcast write sent - no response expected"
+                elif not request.should_respond:
+                    self._transact(request, None, broadcast=True)
+                    response = b"Request write sent - no response expected"
                 else:
                     expected_response_length = None
                     if not isinstance(self.client.framer, ModbusSocketFramer):


### PR DESCRIPTION
Allows for custom ModbusRequest classes where responses may not be expected.

