### PR TITLE
Block draft PRs to use CPU minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - dev
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Sunday at 02:10 UTC.
     - cron: '10 2 * * 0'
@@ -18,6 +19,7 @@ on:
 jobs:
   testing:
     name: ${{ matrix.os }} - ${{ matrix.python }}
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -114,6 +116,7 @@ jobs:
 
   analyze:
     name: Analyze Python
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
When a contributor does a lot of force pushed to a pull request it exhausts our CPU limit.

Normally a contributor would test locally, and only push when there are something (nearly) ready for review, that way then number of CI runs are limited.

#2238 is an example of the contrary, force pushing every single file exhausted the CPU limit, and caused the night jobs not to be run.

With this PR, PR´s in draft status do not run the full CI.

