### PR TITLE
Fix some mypy type checking errors in test_transaction.py

### DIFF
--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -195,33 +195,20 @@ class TestTransaction:  # pylint: disable=too-many-public-methods
 
     def test_get_transaction_manager_transaction(self):
         """Test the getting a transaction from the transaction manager."""
-
-        class Request:  # pylint: disable=too-few-public-methods
-            """Request."""
-
         self._manager.reset()
-        handle = Request()
-        handle.transaction_id = (  # pylint: disable=attribute-defined-outside-init
-            self._manager.getNextTID()
+        handle = ModbusRequest(
+            0, self._manager.getNextTID(), 0, False
         )
-        handle.message = b"testing"  # pylint: disable=attribute-defined-outside-init
         self._manager.addTransaction(handle)
         result = self._manager.getTransaction(handle.transaction_id)
-        assert handle.message == result.message
+        assert handle is result
 
     def test_delete_transaction_manager_transaction(self):
         """Test deleting a transaction from the dict transaction manager."""
-
-        class Request:  # pylint: disable=too-few-public-methods
-            """Request."""
-
         self._manager.reset()
-        handle = Request()
-        handle.transaction_id = (  # pylint: disable=attribute-defined-outside-init
-            self._manager.getNextTID()
+        handle = ModbusRequest(
+            0, self._manager.getNextTID(), 0, False
         )
-        handle.message = b"testing"  # pylint: disable=attribute-defined-outside-init
-
         self._manager.addTransaction(handle)
         self._manager.delTransaction(handle.transaction_id)
         assert not self._manager.getTransaction(handle.transaction_id)

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -120,10 +120,9 @@ class TestTransaction:  # pylint: disable=too-many-public-methods
         assert trans.retries == 3
         assert not trans.retry_on_empty
 
-        trans.getTransaction = mock.MagicMock()
-        trans.getTransaction.return_value = "response"
+        trans.getTransaction = mock.MagicMock(return_value = b"response")
         response = trans.execute(request)
-        assert response == "response"
+        assert response == b"response"
         # No response
         trans._recv = mock.MagicMock(  # pylint: disable=protected-access
             return_value=b"abcdef"


### PR DESCRIPTION
Let's start over with #2249.

I've cherry-picked the least contentious changes.  Rather than just making `mypy` happy, let's use it to make simpler and more robust tests.
