### PR TITLE
WIP: Sim add actions to setvalues

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import dataclasses
 import random
 import struct
+import enum
+import inspect
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
@@ -81,7 +83,7 @@ class Label:  # pylint: disable=too-many-instance-attributes
     timestamp: str = "timestamp"
     repeat_to: str = "to"
     type: str = "type"
-    type_bits = "bits"
+    type_bits: str = "bits"
     type_exception: str = "type exception"
     type_uint16: str = "uint16"
     type_uint32: str = "uint32"
@@ -98,6 +100,12 @@ class Label:  # pylint: disable=too-many-instance-attributes
             txt = f"ERROR Configuration invalid, missing {key} in {config_part}"
             raise RuntimeError(txt)
         return config_part[key]
+
+
+class AccessType(enum.Enum):
+    """Simulator register value access type"""
+    GET = 1
+    SET = 2
 
 
 class Setup:
@@ -801,3 +809,10 @@ class ModbusSimulatorContext(ModbusBaseSlaveContext):
         else:
             value = struct.unpack(">f", value_bytes)[0]
         return value
+
+    @classmethod
+    def get_method_parameters(cls, method):
+        """Returns True if method uses 'access_type' parameter"""
+        signature = inspect.signature(method)
+        params = {signature.parameters[key].name for key in signature.parameters.keys()}
+        return params

--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -1,10 +1,10 @@
 """Pymodbus ModbusSimulatorContext."""
+
 from __future__ import annotations
 
 import dataclasses
 import random
 import struct
-import enum
 import inspect
 from collections.abc import Callable
 from datetime import datetime
@@ -100,12 +100,6 @@ class Label:  # pylint: disable=too-many-instance-attributes
             txt = f"ERROR Configuration invalid, missing {key} in {config_part}"
             raise RuntimeError(txt)
         return config_part[key]
-
-
-class AccessType(enum.Enum):
-    """Simulator register value access type"""
-    GET = 1
-    SET = 2
 
 
 class Setup:
@@ -600,7 +594,9 @@ class ModbusSimulatorContext(ModbusBaseSlaveContext):
                 kwargs = reg.action_kwargs if reg.action_kwargs else {}
                 if reg.action:
                     action_method = self.action_methods[reg.action]
-                    if set(("func_code", "access_type")).issubset(self.get_method_parameters(action_method)):
+                    if set(("func_code", "access_type")).issubset(
+                        self.get_method_parameters(action_method)
+                    ):
                         kwargs.update({"func_code": func_code, "access_type": "get"})
                     action_method(self.registers, i, reg, **kwargs)
                 self.registers[i].count_read += 1
@@ -615,7 +611,9 @@ class ModbusSimulatorContext(ModbusBaseSlaveContext):
                 if reg.action:
                     kwargs = reg.action_kwargs or {}
                     action_method = self.action_methods[reg.action]
-                    if set(("func_code", "access_type")).issubset(self.get_method_parameters(action_method)):
+                    if set(("func_code", "access_type")).issubset(
+                        self.get_method_parameters(action_method)
+                    ):
                         kwargs.update({"func_code": func_code, "access_type": "get"})
                     action_method(self.registers, i, reg, **kwargs)
                 self.registers[i].count_read += 1
@@ -642,7 +640,9 @@ class ModbusSimulatorContext(ModbusBaseSlaveContext):
                 if reg.action:
                     action_method = self.action_methods[reg.action]
                     kwargs = reg.action_kwargs if reg.action_kwargs else {}
-                    if set(("func_code", "access_type")).issubset(self.get_method_parameters(action_method)):
+                    if set(("func_code", "access_type")).issubset(
+                        self.get_method_parameters(action_method)
+                    ):
                         kwargs.update({"func_code": func_code, "access_type": "set"})
                     action_method(self.registers, i, reg, **kwargs)
             return
@@ -668,7 +668,9 @@ class ModbusSimulatorContext(ModbusBaseSlaveContext):
             if reg.action:
                 action_method = self.action_methods[reg.action]
                 kwargs = reg.action_kwargs if reg.action_kwargs else {}
-                if set(("func_code", "access_type")).issubset(self.get_method_parameters(action_method)):
+                if set(("func_code", "access_type")).issubset(
+                    self.get_method_parameters(action_method)
+                ):
                     kwargs.update({"func_code": func_code, "access_type": "set"})
                 action_method(self.registers, i, reg, **kwargs)
         return

--- a/test/sub_server/test_simulator.py
+++ b/test/sub_server/test_simulator.py
@@ -20,6 +20,12 @@ FX_WRITE_BIT = 5
 FX_WRITE_REG = 6
 
 
+def custom_action3(_registers, _inx, cell, func_code, access_type):
+    """Test action which includes function code and access type as parameters."""
+    if func_code == 6 and access_type == "set":
+        cell.value = 0x5555
+
+
 def custom_actions_test_module():
     module_contents = (
          "from test_simulator import TestSimulator\n"
@@ -199,11 +205,6 @@ class TestSimulator:
     @classmethod
     def custom_action2(cls, _inx, _cell):
         """Test action."""
-    @classmethod
-    def custom_action3(cls, registers, inx, _cell, func_code, access_type):
-        """Test action which includes function code and access type as parameters."""
-        if func_code == 6 and access_type == "set":
-            registers[inx] = 0xA5A5
 
     custom_actions = {
         "custom1": custom_action1,
@@ -407,6 +408,7 @@ class TestSimulator:
             (FX_READ_REG, 19, 1, [14662]),
             (FX_READ_REG, 16, 2, [3124, 5678]),
             (FX_READ_REG, 16, 2, [3124, 5678]),
+            (FX_READ_REG, 49, 1, [0XAAAA]),
         ):
             values = self.simulator.getValues(entry[0], entry[1], entry[2])
             assert entry[3] == values, f"at entry {entry}"
@@ -435,6 +437,12 @@ class TestSimulator:
         result = exc_simulator.getValues(FX_READ_BIT, 86, 3)
         assert [True, False, False] == result
         exc_simulator.setValues(FX_WRITE_BIT, 80, [True] * 17)
+
+        value = [0x5555]
+        exc_simulator.setValues(FX_WRITE_REG, 49, [0xAAAA])
+        result = exc_simulator.getValues(FX_READ_REG, 49)
+        assert value == result
+
 
     def test_simulator_get_text(self):
         """Test get_text_register()."""
@@ -611,8 +619,8 @@ class TestSimulator:
     def test_simulator_get_method_parameters(self):
         params = self.simulator.get_method_parameters(self.custom_action1)
         assert params == {"_inx", "_cell"}
-        params = self.simulator.get_method_parameters(self.custom_action3)
-        assert params == {"registers", "inx", "_cell", "func_code", "access_type"}
+        params = self.simulator.get_method_parameters(custom_action3)
+        assert params == {"_registers", "_inx", "cell", "func_code", "access_type"}
 
     @patch(
         "builtins.open",

--- a/test/sub_server/test_simulator.py
+++ b/test/sub_server/test_simulator.py
@@ -28,15 +28,15 @@ def custom_action3(_registers, _inx, cell, func_code, access_type):
 
 def custom_actions_test_module():
     module_contents = (
-         "from test_simulator import TestSimulator\n"
-         "\n"
-         "def custom_action(registers, inx, _cell, func_code, access_type):\n"
-         "    return TestSimulator.custom_action3(registers, inx, _cell, func_code, access_type)\n"
-         "\n"
-         "custom_actions_dict = {\n"
-         "    \"custom3\": custom_action\n"
-         "}"
-         "\n"
+        "from test_simulator import TestSimulator\n"
+        "\n"
+        "def custom_action(registers, inx, _cell, func_code, access_type):\n"
+        "    return TestSimulator.custom_action3(registers, inx, _cell, func_code, access_type)\n"
+        "\n"
+        "custom_actions_dict = {\n"
+        '    "custom3": custom_action\n'
+        "}"
+        "\n"
     )
     return module_contents
 
@@ -327,7 +327,6 @@ class TestSimulator:
         with pytest.raises(RuntimeError):
             ModbusSimulatorContext(exc_setup, self.custom_actions)
 
-
     def test_simulator_validate_illegal(self):
         """Test validation without exceptions."""
         illegal_cell_list = (0, 1, 2, 3, 4, 6, 9, 15)
@@ -408,7 +407,7 @@ class TestSimulator:
             (FX_READ_REG, 19, 1, [14662]),
             (FX_READ_REG, 16, 2, [3124, 5678]),
             (FX_READ_REG, 16, 2, [3124, 5678]),
-            (FX_READ_REG, 49, 1, [0XAAAA]),
+            (FX_READ_REG, 49, 1, [0xAAAA]),
         ):
             values = self.simulator.getValues(entry[0], entry[1], entry[2])
             assert entry[3] == values, f"at entry {entry}"
@@ -442,7 +441,6 @@ class TestSimulator:
         exc_simulator.setValues(FX_WRITE_REG, 49, [0xAAAA])
         result = exc_simulator.getValues(FX_READ_REG, 49)
         assert value == result
-
 
     def test_simulator_get_text(self):
         """Test get_text_register()."""
@@ -566,7 +564,7 @@ class TestSimulator:
                 regs = exc_simulator.getValues(FX_READ_REG, 30, reg_count)
             else:
                 reg_bits = exc_simulator.getValues(FX_READ_BIT, 30 * 16, 16)
-                reg_value = sum([ bit * 2 ** i for i, bit in enumerate(reg_bits)])
+                reg_value = sum([bit * 2**i for i, bit in enumerate(reg_bits)])
                 regs = [reg_value]
             if reg_count == 1:
                 assert expect_value == regs[0], f"type({celltype})"
@@ -606,7 +604,7 @@ class TestSimulator:
                 regs = exc_simulator.getValues(FX_READ_REG, 30, reg_count)
             else:
                 reg_bits = exc_simulator.getValues(FX_READ_BIT, 30 * 16, 16)
-                reg_value = sum([ bit * 2 ** i for i, bit in enumerate(reg_bits)])
+                reg_value = sum([bit * 2**i for i, bit in enumerate(reg_bits)])
                 regs = [reg_value]
             if reg_count == 1:
                 new_value = regs[0]
@@ -639,11 +637,13 @@ class TestSimulator:
         test_tmp_path.mkdir()
         custom_actions_module_path = test_tmp_path / "custom_actions.py"
         sys.path.append(str(test_tmp_path))
-        custom_actions_module_path.write_text(custom_actions_test_module(), encoding="utf-8")
+        custom_actions_module_path.write_text(
+            custom_actions_test_module(), encoding="utf-8"
+        )
 
         task = ModbusSimulatorServer(
             http_port=unused_tcp_port,
-            custom_actions_module=str(custom_actions_module_path.stem)
+            custom_actions_module=str(custom_actions_module_path.stem),
         )
         await task.run_forever(only_start=True)
         await asyncio.sleep(0.5)


### PR DESCRIPTION
WIP: Simulator add actions to setvalues

Aims to address #2158:
- Adds actions to setValues() in ModbusSimulatorContext.
- Introduces new arguments of "func_code" and "access_type" to custom actions.
- Existing custom actions will work unchanged. This is achieved by:
  - inspecting the custom action function signature
  - determining if the additional parameters of "func_code" and "access_type" are present, and if so
  - adding them to the action_kwargs (to be updated to action_parameters as per latest in dev branch).

Please note:
- PR is draft
- Still needs to be rebased on dev and squashed
- Opportunities for refactoring exist

Feedback would be appreciated.