### PR TITLE
Feature/simulator addressing

### DIFF
--- a/doc/source/library/simulator/config.rst
+++ b/doc/source/library/simulator/config.rst
@@ -69,7 +69,7 @@ The entry “framer” allows the following values:
 - “socket” to use :class:`pymodbus.framer.ModbusSocketFramer`.
 
 Optional entry "device_id" will limit server to only accept if. If
-not set, the server will respond to all addresses.
+not set, the server will accept all device id.
 
 .. warning::
 

--- a/doc/source/library/simulator/config.rst
+++ b/doc/source/library/simulator/config.rst
@@ -68,7 +68,7 @@ The entry “framer” allows the following values:
 - “tls” to use :class:`pymodbus.framer.ModbusTlsFramer`,
 - “socket” to use :class:`pymodbus.framer.ModbusSocketFramer`.
 
-Optional entry "device_id" will limit server to only accept if. If
+Optional entry "device_id" will limit server to only accept a single id. If
 not set, the server will accept all device id.
 
 .. warning::

--- a/doc/source/library/simulator/config.rst
+++ b/doc/source/library/simulator/config.rst
@@ -68,6 +68,9 @@ The entry “framer” allows the following values:
 - “tls” to use :class:`pymodbus.framer.ModbusTlsFramer`,
 - “socket” to use :class:`pymodbus.framer.ModbusSocketFramer`.
 
+Optional entry "device_id" will enable address-specific server addressing. If
+not set, the server will respond to all addresses.
+
 .. warning::
 
     not all "framer" types can be used with all “comm” types.

--- a/doc/source/library/simulator/config.rst
+++ b/doc/source/library/simulator/config.rst
@@ -68,7 +68,7 @@ The entry “framer” allows the following values:
 - “tls” to use :class:`pymodbus.framer.ModbusTlsFramer`,
 - “socket” to use :class:`pymodbus.framer.ModbusSocketFramer`.
 
-Optional entry "device_id" will enable address-specific server addressing. If
+Optional entry "device_id" will limit server to only accept if. If
 not set, the server will respond to all addresses.
 
 .. warning::

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -154,7 +154,14 @@ class ModbusSimulatorServer:
         self.datastore_context = ModbusSimulatorContext(
             device, custom_actions_dict or {}
         )
-        datastore = ModbusServerContext(slaves=self.datastore_context, single=True)
+        datastore = None
+        if "device_id" in server:
+            # Designated ModBus unit address. Will only serve data if the address matches
+            datastore = ModbusServerContext(slaves={int(server["device_id"]): self.datastore_context}, single=False)
+        else:
+            # Will server any request regardless of addressing
+            datastore = ModbusServerContext(slaves=self.datastore_context, single=True)
+
         comm = comm_class[server.pop("comm")]
         framer = server.pop("framer")
         if "identity" in server:

--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -157,7 +157,7 @@ class ModbusSimulatorServer:
         datastore = None
         if "device_id" in server:
             # Designated ModBus unit address. Will only serve data if the address matches
-            datastore = ModbusServerContext(slaves={int(server["device_id"]): self.datastore_context}, single=False)
+            datastore = ModbusServerContext(slaves={int(server["device_id"]): self.datastore_context}, single=True)
         else:
             # Will server any request regardless of addressing
             datastore = ModbusServerContext(slaves=self.datastore_context, single=True)


### PR DESCRIPTION
# Summary

In order to be able to limit the simulation to only specific ModBus unit address, check for existence of `unit_address` in the configuration file. If present, construct the `ModbusServerContext` as specified for non-single unit address.

Note that field `address` is already reserved for TCP addressing. Hence the term `unit_address` should be close enough for the context.

# Testing

1. Only tested this manually on personal setup, so no extensive testing was done.
2. Made sure the setup behaved the same as before without the field being present.
3. Ran pytest, no regressions