### PR TITLE
More descriptive decoder exceptions

### DIFF
--- a/pymodbus/factory.py
+++ b/pymodbus/factory.py
@@ -236,8 +236,6 @@ class ClientDecoder:
             return self._helper(message)
         except ModbusException as exc:
             Log.error("Unable to decode response {}", exc)
-        except Exception as exc:  # pylint: disable=broad-except
-            Log.error("General exception: {}", exc)
         return None
 
     def _helper(self, data: str):

--- a/pymodbus/pdu/register_read_message.py
+++ b/pymodbus/pdu/register_read_message.py
@@ -4,6 +4,7 @@
 # pylint: disable=missing-type-doc
 import struct
 
+from pymodbus.exceptions import ModbusIOException
 from pymodbus.pdu import ModbusExceptions as merror
 from pymodbus.pdu import ModbusRequest, ModbusResponse
 
@@ -88,6 +89,8 @@ class ReadRegistersResponseBase(ModbusResponse):
         :param data: The request to decode
         """
         byte_count = int(data[0])
+        if byte_count < 2 or byte_count > 246 or byte_count % 2 == 1 or byte_count != len(data) - 1:
+            raise ModbusIOException(f"Invalid response {data} has byte count of {byte_count}")
         self.registers = []
         for i in range(1, byte_count + 1, 2):
             self.registers.append(struct.unpack(">H", data[i : i + 2])[0])

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -6,16 +6,11 @@ from pymodbus.factory import ClientDecoder, ServerDecoder
 from pymodbus.pdu import ModbusRequest, ModbusResponse
 
 
-def _raise_exception(_):
-    """Raise exception."""
-    raise ModbusException("something")
-
-
 class TestFactory:
     """Unittest for the pymod.exceptions module."""
 
-    client = None
-    server = None
+    client: ClientDecoder
+    server: ServerDecoder
     request = (
         (0x01, b"\x01\x00\x01\x00\x01"),  # read coils
         (0x02, b"\x02\x00\x01\x00\x01"),  # read discrete inputs
@@ -139,15 +134,13 @@ class TestFactory:
 
     def test_client_factory_fails(self):
         """Tests that a client factory will fail to decode a bad message."""
-        self.client._helper = _raise_exception  # pylint: disable=protected-access
-        actual = self.client.decode(None)
-        assert not actual
+        with pytest.raises(TypeError):
+            self.client.decode(None)
 
     def test_server_factory_fails(self):
         """Tests that a server factory will fail to decode a bad message."""
-        self.server._helper = _raise_exception  # pylint: disable=protected-access
-        actual = self.server.decode(None)
-        assert not actual
+        with pytest.raises(TypeError):
+            self.server.decode(None)
 
     def test_server_register_custom_request(self):
         """Test server register custom request."""


### PR DESCRIPTION
Closes https://github.com/pymodbus-dev/pymodbus/issues/2259.

Three current tests are relevant for badly encoded `Response`.

(1) 
`test_client_factory_fails()` calls `ClientDecoder.decode(None)` and expects `None`.
This would cause a `TypeError`, but it's monkey-patched to throw a `ModbusException` instead.  (The monkey patching was never necessary with the catch-all `Except`)

(2) `test_server_factory_fails()` calls  `ServerDecoder.decode(None)` and expects `None`.
This would cause a `TypeError`, but it's monkey-patched to throw a `ModbusException` instead.  This is caught normally.

I'm assuming that in (1) and (2) we should actually throw the `TypeError` to the caller, so I changed as such.  I see no valid use case for decoding `None`...

(3)  `test_processincomingpacket_not_ok()` calls `ClientDecoder.decode(b'\x03\x01\x00\n')` and expects a `ModbusIOException`.  The real exception is a `struct.error` because the payload has only 3 bytes.  The register values must be an even number of bytes i.e. 6 bytes for 3 registers.
![image](https://github.com/user-attachments/assets/9a2e7977-4205-4a02-bac1-c75dcb2da14a)

This bad message is caught by `decode()`, losing information on the error.  Later on `frameProcessIncomingPacket` notices that `decode` returned None and `raise ModbusIOException`.

I think it's better to explicitly raise a descriptive exception in this case.