### PR TITLE
buildPacket can be used for Request and Response

### DIFF
--- a/pymodbus/framer/old_framer_base.py
+++ b/pymodbus/framer/old_framer_base.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from pymodbus.factory import ClientDecoder, ServerDecoder
 from pymodbus.framer.base import FramerBase
 from pymodbus.logging import Log
-from pymodbus.pdu import ModbusRequest
+from pymodbus.pdu import ModbusRequest, ModbusResponse
 
 
 if TYPE_CHECKING:
@@ -158,7 +158,7 @@ class ModbusFramer:
     ) -> None:
         """Process new packet pattern."""
 
-    def buildPacket(self, message: ModbusRequest) -> bytes:
+    def buildPacket(self, message: ModbusRequest | ModbusResponse) -> bytes:
         """Create a ready to send modbus packet.
 
         :param message: The populated request/response to send


### PR DESCRIPTION
Fixes a small oversight from https://github.com/pymodbus-dev/pymodbus/pull/2232
﻿<!--  Please raise your PR's against the `dev` branch instead of `master` -->
