### PR TITLE
simulator: Fix context single parameter

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -157,7 +157,7 @@ class ModbusSimulatorServer:
         datastore = None
         if "device_id" in server:
             # Designated ModBus unit address. Will only serve data if the address matches
-            datastore = ModbusServerContext(slaves={int(server["device_id"]): self.datastore_context}, single=True)
+            datastore = ModbusServerContext(slaves={int(server["device_id"]): self.datastore_context}, single=False)
         else:
             # Will server any request regardless of addressing
             datastore = ModbusServerContext(slaves=self.datastore_context, single=True)


### PR DESCRIPTION
# Summary

Fixes an incomplete feature in `Commit:
d32947517087214d28d71cdcbf3c02355526ab68 Feature/simulator addressing`.

The `single` parameter was used incorrectly when ModbusServerContext was initialized. This caused the simulator to not work correctly when the configuration "device_id" was used. The context would wrap the dict in another, having completely incorrect, resulting in using an invalid object.

Fix it by defining single correctly.

The ModbusServerContext initialization looks like this:

```python
    def __init__(self, slaves=None, single=True):
        """Initialize a new instance of a modbus server context.

        :param slaves: A dictionary of client contexts
        :param single: Set to true to treat this as a single context
        """
        self.single = single
        self._slaves = slaves or {}
        if self.single:
            self._slaves = {0: self._slaves}
```

So if single == True AND `device_id` is defined with an address, this will eventuall result in `self._slaves` being initialized as 

```python
self._slaves = {0: {<address>:<context>}}
```

instead of

```python
self._slaves = {<address>:<context>}
```

# Testing

1. Ran pytest, no regressions
2. Ran simulator with device_id defined.
