### PR TITLE
Fix example docstrings for PDU changes

### DIFF
--- a/examples/client_async_calls.py
+++ b/examples/client_async_calls.py
@@ -13,8 +13,8 @@ All available modbus calls are present.
 If you are performing a request that is not available in the client
 mixin, you have to perform the request like this instead::
 
-    from pymodbus.diag_message import ClearCountersRequest
-    from pymodbus.diag_message import ClearCountersResponse
+    from pymodbus.pdu.diag_message import ClearCountersRequest
+    from pymodbus.pdu.diag_message import ClearCountersResponse
 
     request  = ClearCountersRequest()
     response = client.execute(request)

--- a/examples/client_calls.py
+++ b/examples/client_calls.py
@@ -13,8 +13,8 @@ All available modbus calls are present.
 If you are performing a request that is not available in the client
 mixin, you have to perform the request like this instead::
 
-    from pymodbus.diag_message import ClearCountersRequest
-    from pymodbus.diag_message import ClearCountersResponse
+    from pymodbus.pdu.diag_message import ClearCountersRequest
+    from pymodbus.pdu.diag_message import ClearCountersResponse
 
     request  = ClearCountersRequest()
     response = client.execute(request)


### PR DESCRIPTION
The docstrings were missed in https://github.com/pymodbus-dev/pymodbus/pull/2160
