### PR TITLE
Update repl requirement to >= 2.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ serial = [
     "pyserial>=3.5"
 ]
 repl = [
-   "pymodbus-repl>=2.0.3"
+   "pymodbus-repl>=2.0.4"
 ]
 
 simulator = [


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
* Update repl requirements to be in sync with pymodbus 3.7.x