### PR TITLE
Update BinaryPayloadDecoder._unpack_words documentation

### DIFF
--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -330,7 +330,7 @@ class BinaryPayloadDecoder:
         # Change Word order if little endian word order  #
         # Pack values back based on correct byte order   #
         # ---------------------------------------------- #
-        :param fstring:
+
         :param handle: Value to be unpacked
         :return:
         """


### PR DESCRIPTION
There is no parameter "fstring" for this function
