### PR TITLE
Fix encoding & decoding of ReadFileRecordResponse

### DIFF
--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -185,11 +185,14 @@ class ReadFileRecordResponse(ModbusResponse):
             response_length, reference_type = struct.unpack(
                 ">BB", data[count : count + 2]
             )
-            count += response_length + 1  # the count is not included
+            count += 2
+
+            record_length = response_length - 1 # response length includes the type byte
             record = FileRecord(
                 response_length=response_length,
-                record_data=data[count - response_length + 1 : count],
+                record_data=data[count : count + record_length],
             )
+            count += record_length
             if reference_type == 0x06:
                 self.records.append(record)
 

--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -170,7 +170,7 @@ class ReadFileRecordResponse(ModbusResponse):
         total = sum(record.response_length + 1 for record in self.records)
         packet = struct.pack("B", total)
         for record in self.records:
-            packet += struct.pack(">BB", record.record_length, 0x06)
+            packet += struct.pack(">BB", record.response_length, 0x06)
             packet += record.record_data
         return packet
 

--- a/test/test_file_message.py
+++ b/test/test_file_message.py
@@ -167,13 +167,18 @@ class TestBitMessage:
 
     def test_read_file_record_response_decode(self):
         """Test basic bit message encoding/decoding."""
-        record = FileRecord(
+        record1 = FileRecord(
             file_number=0x00, record_number=0x00, record_data=b"\x0d\xfe\x00\x20"
         )
-        request = b"\x0c\x05\x06\x0d\xfe\x00\x20\x05\x05\x06\x33\xcd\x00\x40"
+        record2 = FileRecord(
+            file_number=0x00, record_number=0x00, record_data=b"\x33\xcd\x00\x40"
+        )
+        response = b"\x0c\x05\x06\x0d\xfe\x00\x20\x05\x06\x33\xcd\x00\x40"
         handle = ReadFileRecordResponse()
-        handle.decode(request)
-        assert handle.records[0] == record
+        handle.decode(response)
+
+        assert handle.records[0] == record1
+        assert handle.records[1] == record2
 
     def test_read_file_record_response_rtu_frame_size(self):
         """Test basic bit message encoding/decoding."""

--- a/test/test_file_message.py
+++ b/test/test_file_message.py
@@ -163,7 +163,7 @@ class TestBitMessage:
         records = [FileRecord(record_data=b"\x00\x01\x02\x03\x04\x05")]
         handle = ReadFileRecordResponse(records)
         result = handle.encode()
-        assert result == b"\x08\x03\x06\x00\x01\x02\x03\x04\x05"
+        assert result == b"\x08\x07\x06\x00\x01\x02\x03\x04\x05"
 
     def test_read_file_record_response_decode(self):
         """Test basic bit message encoding/decoding."""


### PR DESCRIPTION
Encode fix:
```
The sub-req file response length is in bytes, not registers, and needs
to also count the reference type byte. We already calculate the correct
value in `FileRecord.response_length` so make use of it here.
```

Decode fix:
```
The `count` increment was incorrect, because `response_length` already
includes the 1 byte for reference type. This moved the pointer too far
ahead, leading to incorrect slicing of record_data.

Also corrected the unit test for this; it seems to be copied from the
Modbus spec example but had a typo (repeated \x05) and did not assert
correctness of the second sub-req in the PDU.
```