### PR TITLE
Fixes the unexpected implementation of the ModbusSerialClient.connected property

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -208,9 +208,9 @@ class ModbusSerialClient(ModbusBaseSyncClient):
         self.silent_interval = round(self.silent_interval, 6)
 
     @property
-    def connected(self):
-        """Connect internal."""
-        return self.connect()
+    def connected(self) -> bool:
+        """Check if socket exists."""
+        return self.socket is not None        
 
     def connect(self) -> bool:
         """Connect to the modbus serial server."""

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -210,7 +210,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
     @property
     def connected(self) -> bool:
         """Check if socket exists."""
-        return self.socket is not None        
+        return self.socket is not None
 
     def connect(self) -> bool:
         """Connect to the modbus serial server."""

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -160,7 +160,7 @@ class ModbusTcpClient(ModbusBaseSyncClient):
 
     @property
     def connected(self) -> bool:
-        """Connect internal."""
+        """Check if socket exists."""
         return self.socket is not None
 
     def connect(self):


### PR DESCRIPTION
Fixes the implementation of the connected property in sync client to just check if socket exists without calling connect. See Discussion #2325 and Discussion #1854.

Note that this `connected` property [is not used by the pymodbus lib currently](https://github.com/search?q=repo%3Apymodbus-dev%2Fpymodbus%20connected&type=code).
