### PR TITLE
CI run on demand on non-protected branches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
       - dev
       - master
       - wait_next_API
-      - dev_*
     tags:
       - v*
   pull_request:


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
