### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Server Features
 * callback to intercept requests/responses
 * work on RS485 in parallel with other devices
 
-`Server documentation <https://pymodbus.readthedocs.io/en/latest/source/library/server.html>`_
+`Server documentation <https://pymodbus.readthedocs.io/en/latest/source/server.html>`_
 
 
 REPL Features


### PR DESCRIPTION
URL for Server Documentation Updated.

Previous URL - <https://pymodbus.readthedocs.io/en/latest/source/library/server.html>
Proposed URL - <https://pymodbus.readthedocs.io/en/latest/source/server.html>