### PR TITLE
Use @abstractmethod for ModbusEvent

### DIFF
--- a/pymodbus/events.py
+++ b/pymodbus/events.py
@@ -5,27 +5,25 @@ can be any one of four types. The type is defined by bit 7
 (the high-order bit) in each byte. It may be further defined by bit 6.
 """
 # pylint: disable=missing-type-doc
-from pymodbus.exceptions import NotImplementedException, ParameterException
+from abc import ABC, abstractmethod
+
+from pymodbus.exceptions import ParameterException
 from pymodbus.utilities import pack_bitstring, unpack_bitstring
 
 
-class ModbusEvent:
+class ModbusEvent(ABC):
     """Define modbus events."""
 
-    def encode(self):
-        """Encode the status bits to an event message.
+    @abstractmethod
+    def encode(self) -> bytes:
+        """Encode the status bits to an event message."""
 
-        :raises NotImplementedException:
-        """
-        raise NotImplementedException
-
+    @abstractmethod
     def decode(self, event):
         """Decode the event message to its status bits.
 
         :param event: The event to decode
-        :raises NotImplementedException:
         """
-        raise NotImplementedException
 
 
 class RemoteReceiveEvent(ModbusEvent):

--- a/test/sub_current/test_device.py
+++ b/test/sub_current/test_device.py
@@ -6,7 +6,7 @@ from pymodbus.device import (
     ModbusDeviceIdentification,
     ModbusPlusStatistics,
 )
-from pymodbus.events import ModbusEvent, RemoteReceiveEvent
+from pymodbus.events import RemoteReceiveEvent
 
 
 # ---------------------------------------------------------------------------#
@@ -281,7 +281,7 @@ class TestDataStore:
     def test_clearing_control_events(self):
         """Test adding and clearing modbus events."""
         assert self.control.Events == []
-        event = ModbusEvent()
+        event = RemoteReceiveEvent()
         self.control.addEvent(event)
         assert self.control.Events == [event]
         assert self.control.Counter.Event == 1

--- a/test/sub_current/test_events.py
+++ b/test/sub_current/test_events.py
@@ -4,23 +4,14 @@ import pytest
 from pymodbus.events import (
     CommunicationRestartEvent,
     EnteredListenModeEvent,
-    ModbusEvent,
     RemoteReceiveEvent,
     RemoteSendEvent,
 )
-from pymodbus.exceptions import NotImplementedException, ParameterException
+from pymodbus.exceptions import ParameterException
 
 
 class TestEvents:
     """Unittest for the pymodbus.device module."""
-
-    def test_modbus_event_base_class(self):
-        """Test modbus event base class."""
-        event = ModbusEvent()
-        with pytest.raises(NotImplementedException):
-            event.encode()
-        with pytest.raises(NotImplementedException):
-            event.decode(None)
 
     def test_remote_receive_event(self):
         """Test remove receive event."""


### PR DESCRIPTION
This simplifies and eliminates an unnecessary test.
