### PR TITLE
Add `no_response_expected` argument to write requests

### DIFF
--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -191,9 +191,9 @@ The logical devices represented by the device is addressed with the :mod:`slave=
 With **Serial**, the comm port is defined when creating the object.
 The physical devices are addressed with the :mod:`slave=` parameter.
 
-:mod:`slave=0` is used as broadcast in order to address all devices. To accommodate non-standard behaviour of devices, all request calls to :mod:`slave=0` will expect and wait for at least one response. If multiple devices on the bus are expected to respond to broadcast requests (for example for the purpose of device detection), the application can get upto 254 responses on a single request, and this is not handled with the normal API calls. If an application is expecting multiple responses to a broadcast request, it must call :mod:`client.execute` and deal with the responses.
+:mod:`slave=0` is used as broadcast (in accordance with the modbus standard). To accommodate non-standard behaviour of devices, all request calls to :mod:`slave=0` will expect and wait for one response. If multiple devices on the bus are expected to respond to broadcast requests (for example for the purpose of device detection), the application can get upto 254 responses on a single request, and this is not handled with the normal API calls. If an application is expecting multiple responses to a broadcast request, it must call :mod:`client.execute` and deal with the responses.
 
-If no response is expected to a broadcast or unicast write request, the :mod:`no_response_expected=True` argument can be used in the normal write API calls. However, these write operations will not return indication of failure or success, and will not respect the turnaround delay after sending a broadcast message, therefore, it is the application's responsibility to allow time for the slaves to process the broadcast request before the next request is made on the bus.
+If no response is expected to a request, the :mod:`no_response_expected=True` argument can be used in the normal API calls. However, these requests will not return indication of failure or success, and will not respect the turnaround delay after sending a broadcast message, therefore, it is the application's responsibility to allow time for the slaves to process the broadcast request before the next request is made on the bus.
 
 
 Client response handling

--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -191,14 +191,9 @@ The logical devices represented by the device is addressed with the :mod:`slave=
 With **Serial**, the comm port is defined when creating the object.
 The physical devices are addressed with the :mod:`slave=` parameter.
 
-:mod:`slave=0` is used as broadcast in order to address all devices.
-However experience shows that modern devices do not allow broadcast, mostly because it is
-inheriently dangerous. With :mod:`slave=0` the application can get upto 254 responses on a single request,
-and this is not handled with the normal API calls!
+:mod:`slave=0` is used as broadcast in order to address all devices. To accommodate non-standard behaviour of devices, all request calls to :mod:`slave=0` will expect and wait for at least one response. If multiple devices on the bus are expected to respond to broadcast requests (for example for the purpose of device detection), the application can get upto 254 responses on a single request, and this is not handled with the normal API calls. If an application is expecting multiple responses to a broadcast request, it must call :mod:`client.execute` and deal with the responses.
 
-The simple request calls (mixin) do NOT support broadcast, if an application wants to use broadcast
-it must call :mod:`client.execute` and deal with the responses.
-
+If no response is expected to a broadcast or unicast write request, the :mod:`no_response_expected=True` argument can be used in the normal write API calls. However, these write operations will not return indication of failure or success, and will not respect the turnaround delay after sending a broadcast message, therefore, it is the application's responsibility to allow time for the slaves to process the broadcast request before the next request is made on the bus.
 
 
 Client response handling

--- a/examples/client_custom_msg.py
+++ b/examples/client_custom_msg.py
@@ -36,9 +36,9 @@ class CustomModbusResponse(ModbusResponse):
     function_code = 55
     _rtu_byte_count_pos = 2
 
-    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize."""
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.values = values or []
 
     def encode(self):
@@ -68,9 +68,9 @@ class CustomRequest(ModbusPDU):
     function_code = 55
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize."""
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.count = 16
 

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -108,7 +108,8 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
             async with self._lock:
                 req = self.build_response(request)
                 self.ctx.send(packet)
-                if not request.slave_id:
+                no_response_expected = hasattr(request, "no_response_expected") and request.no_response_expected is True
+                if no_response_expected:
                     resp = None
                     break
                 try:

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -95,7 +95,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
             raise ConnectionException(f"Not connected[{self!s}]")
         return self.async_execute(request)
 
-    async def async_execute(self, request) -> ModbusResponse:
+    async def async_execute(self, request) -> ModbusResponse | None:
         """Execute requests asynchronously.
 
         :meta private:
@@ -108,8 +108,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
             async with self._lock:
                 req = self.build_response(request)
                 self.ctx.send(packet)
-                no_response_expected = hasattr(request, "no_response_expected") and request.no_response_expected is True
-                if no_response_expected:
+                if request.no_response_expected:
                     resp = None
                     break
                 try:
@@ -125,7 +124,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
                 f"ERROR: No response received after {self.retries} retries"
             )
 
-        return resp  # type: ignore[return-value]
+        return resp
 
     def build_response(self, request: ModbusPDU):
         """Return a deferred response for the current request.

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -125,7 +125,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusResponse]]):
                 f"ERROR: No response received after {self.retries} retries"
             )
 
-        return resp
+        return resp  # type: ignore[return-value]
 
     def build_response(self, request: ModbusPDU):
         """Return a deferred response for the current request.

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -101,25 +101,33 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_reg_read.ReadInputRegistersRequest(address, count, slave=slave))
 
-    def write_coil(self, address: int, value: bool, slave: int = 1) -> T:
+    def write_coil(self, address: int, value: bool, slave: int = 1, no_response_expected: bool = False) -> T:
         """Write single coil (code 0x05).
 
         :param address: Address to write to
         :param value: Boolean to write
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_bit_write.WriteSingleCoilRequest(address, value, slave=slave))
+        return self.execute(pdu_bit_write.WriteSingleCoilRequest(address,
+                                                                 value,
+                                                                 slave=slave,
+                                                                 no_response_expected=no_response_expected))
 
-    def write_register(self, address: int, value: bytes | int, slave: int = 1) -> T:
+    def write_register(self, address: int, value: bytes | int, slave: int = 1, no_response_expected: bool = False) -> T:
         """Write register (code 0x06).
 
         :param address: Address to write to
         :param value: Value to write
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_req_write.WriteSingleRegisterRequest(address, value, slave=slave))
+        return self.execute(pdu_req_write.WriteSingleRegisterRequest(address,
+                                                                     value,
+                                                                     slave=slave,
+                                                                     no_response_expected=no_response_expected))
 
     def read_exception_status(self, slave: int = 1) -> T:
         """Read Exception Status (code 0x07).
@@ -309,30 +317,43 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         address: int,
         values: list[bool] | bool,
         slave: int = 1,
+        no_response_expected: bool = False
     ) -> T:
         """Write coils (code 0x0F).
 
         :param address: Start address to write to
         :param values: List of booleans to write, or a single boolean to write
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_bit_write.WriteMultipleCoilsRequest(address, values, slave)
+            pdu_bit_write.WriteMultipleCoilsRequest(address, values, slave, no_response_expected=no_response_expected)
         )
 
     def write_registers(
-        self, address: int, values: list[bytes | int], slave: int = 1, skip_encode: bool = False) -> T:
+        self,
+        address: int,
+        values: list[bytes | int],
+        slave: int = 1,
+        skip_encode: bool = False,
+        no_response_expected: bool = False
+    ) -> T:
         """Write registers (code 0x10).
 
         :param address: Start address to write to
         :param values: List of values to write
         :param slave: (optional) Modbus slave ID
         :param skip_encode: (optional) do not encode values
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_req_write.WriteMultipleRegistersRequest(address, values, slave=slave, skip_encode=skip_encode)
+            pdu_req_write.WriteMultipleRegistersRequest(address,
+                                                        values,
+                                                        slave=slave,
+                                                        skip_encode=skip_encode,
+                                                        no_response_expected=no_response_expected)
         )
 
     def report_slave_id(self, slave: int = 1) -> T:
@@ -352,14 +373,17 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         """
         return self.execute(pdu_file_msg.ReadFileRecordRequest(records, slave=slave))
 
-    def write_file_record(self, records: list[tuple], slave: int = 1) -> T:
+    def write_file_record(self, records: list[tuple], slave: int = 1, no_response_expected: bool = False) -> T:
         """Write file record (code 0x15).
 
         :param records: List of (Reference type, File number, Record Number, Record Length)
         :param slave: (optional) Device id
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_file_msg.WriteFileRecordRequest(records, slave=slave))
+        return self.execute(pdu_file_msg.WriteFileRecordRequest(records,
+                                                                slave=slave,
+                                                                no_response_expected=no_response_expected))
 
     def mask_write_register(
         self,
@@ -367,6 +391,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         and_mask: int = 0xFFFF,
         or_mask: int = 0x0000,
         slave: int = 1,
+        no_response_expected: bool = False
     ) -> T:
         """Mask write register (code 0x16).
 
@@ -374,10 +399,15 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         :param and_mask: The and bitmask to apply to the register address
         :param or_mask: The or bitmask to apply to the register address
         :param slave: (optional) device id
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_req_write.MaskWriteRegisterRequest(address, and_mask, or_mask, slave=slave)
+            pdu_req_write.MaskWriteRegisterRequest(address,
+                                                   and_mask,
+                                                   or_mask,
+                                                   slave=slave,
+                                                   no_response_expected=no_response_expected)
         )
 
     def readwrite_registers(

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -61,45 +61,73 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         """
         raise NotImplementedError("execute of ModbusClientMixin needs to be overridden")
 
-    def read_coils(self, address: int, count: int = 1, slave: int = 1) -> T:
+    def read_coils(self, address: int, count: int = 1, slave: int = 1, no_response_expected: bool = False) -> T:
         """Read coils (code 0x01).
 
         :param address: Start address to read from
         :param count: (optional) Number of coils to read
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_bit_read.ReadCoilsRequest(address, count, slave=slave))
+        return self.execute(pdu_bit_read.ReadCoilsRequest(address,
+                                                          count,
+                                                          slave=slave,
+                                                          no_response_expected=no_response_expected))
 
-    def read_discrete_inputs(self, address: int, count: int = 1, slave: int = 1) -> T:
+    def read_discrete_inputs(self,
+                             address: int,
+                             count: int = 1,
+                             slave: int = 1,
+                             no_response_expected: bool = False) -> T:
         """Read discrete inputs (code 0x02).
 
         :param address: Start address to read from
         :param count: (optional) Number of coils to read
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_bit_read.ReadDiscreteInputsRequest(address, count, slave=slave))
+        return self.execute(pdu_bit_read.ReadDiscreteInputsRequest(address,
+                                                                   count,
+                                                                   slave=slave,
+                                                                   no_response_expected=no_response_expected))
 
-    def read_holding_registers(self, address: int, count: int = 1, slave: int = 1) -> T:
+    def read_holding_registers(self,
+                               address: int,
+                               count: int = 1,
+                               slave: int = 1,
+                               no_response_expected: bool = False) -> T:
         """Read holding registers (code 0x03).
 
         :param address: Start address to read from
         :param count: (optional) Number of coils to read
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_reg_read.ReadHoldingRegistersRequest(address, count, slave=slave))
+        return self.execute(pdu_reg_read.ReadHoldingRegistersRequest(address,
+                                                                     count,
+                                                                     slave=slave,
+                                                                     no_response_expected=no_response_expected))
 
-    def read_input_registers(self, address: int, count: int = 1, slave: int = 1) -> T:
+    def read_input_registers(self,
+                             address: int,
+                             count: int = 1,
+                             slave: int = 1,
+                             no_response_expected: bool = False) -> T:
         """Read input registers (code 0x04).
 
         :param address: Start address to read from
         :param count: (optional) Number of coils to read
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_reg_read.ReadInputRegistersRequest(address, count, slave=slave))
+        return self.execute(pdu_reg_read.ReadInputRegistersRequest(address,
+                                                                   count,
+                                                                   slave=slave,
+                                                                   no_response_expected=no_response_expected))
 
     def write_coil(self, address: int, value: bool, slave: int = 1, no_response_expected: bool = False) -> T:
         """Write single coil (code 0x05).
@@ -129,188 +157,210 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
                                                                      slave=slave,
                                                                      no_response_expected=no_response_expected))
 
-    def read_exception_status(self, slave: int = 1) -> T:
+    def read_exception_status(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Read Exception Status (code 0x07).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_other_msg.ReadExceptionStatusRequest(slave=slave))
+        return self.execute(pdu_other_msg.ReadExceptionStatusRequest(slave=slave,
+                                                                     no_response_expected=no_response_expected))
 
-
-    def diag_query_data(
-        self, msg: bytes, slave: int = 1) -> T:
+    def diag_query_data(self, msg: bytes, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose query data (code 0x08 sub 0x00).
 
         :param msg: Message to be returned
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.ReturnQueryDataRequest(msg, slave=slave))
+        return self.execute(pdu_diag.ReturnQueryDataRequest(msg,
+                                                            slave=slave,
+                                                            no_response_expected=no_response_expected))
 
-    def diag_restart_communication(
-        self, toggle: bool, slave: int = 1) -> T:
+    def diag_restart_communication(self, toggle: bool, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose restart communication (code 0x08 sub 0x01).
 
         :param toggle: True if toggled.
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.RestartCommunicationsOptionRequest(toggle, slave=slave)
+            pdu_diag.RestartCommunicationsOptionRequest(toggle, slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_diagnostic_register(self, slave: int = 1) -> T:
+    def diag_read_diagnostic_register(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read diagnostic register (code 0x08 sub 0x02).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnDiagnosticRegisterRequest(slave=slave)
+            pdu_diag.ReturnDiagnosticRegisterRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_change_ascii_input_delimeter(self, slave: int = 1) -> T:
+    def diag_change_ascii_input_delimeter(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose change ASCII input delimiter (code 0x08 sub 0x03).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ChangeAsciiInputDelimiterRequest(slave=slave)
+            pdu_diag.ChangeAsciiInputDelimiterRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_force_listen_only(self, slave: int = 1) -> T:
+    def diag_force_listen_only(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose force listen only (code 0x08 sub 0x04).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.ForceListenOnlyModeRequest(slave=slave))
+        return self.execute(pdu_diag.ForceListenOnlyModeRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_clear_counters(self, slave: int = 1) -> T:
+    def diag_clear_counters(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose clear counters (code 0x08 sub 0x0A).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.ClearCountersRequest(slave=slave))
+        return self.execute(pdu_diag.ClearCountersRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_read_bus_message_count(self, slave: int = 1) -> T:
+    def diag_read_bus_message_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read bus message count (code 0x08 sub 0x0B).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnBusMessageCountRequest(slave=slave)
+            pdu_diag.ReturnBusMessageCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_bus_comm_error_count(self, slave: int = 1) -> T:
+    def diag_read_bus_comm_error_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Bus Communication Error Count (code 0x08 sub 0x0C).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnBusCommunicationErrorCountRequest(slave=slave)
+            pdu_diag.ReturnBusCommunicationErrorCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_bus_exception_error_count(self, slave: int = 1) -> T:
+    def diag_read_bus_exception_error_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Bus Exception Error Count (code 0x08 sub 0x0D).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnBusExceptionErrorCountRequest(slave=slave)
+            pdu_diag.ReturnBusExceptionErrorCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_slave_message_count(self, slave: int = 1) -> T:
+    def diag_read_slave_message_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Slave Message Count (code 0x08 sub 0x0E).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnSlaveMessageCountRequest(slave=slave)
+            pdu_diag.ReturnSlaveMessageCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_slave_no_response_count(self, slave: int = 1) -> T:
+    def diag_read_slave_no_response_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Slave No Response Count (code 0x08 sub 0x0F).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnSlaveNoResponseCountRequest(slave=slave)
+            pdu_diag.ReturnSlaveNoResponseCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_slave_nak_count(self, slave: int = 1) -> T:
+    def diag_read_slave_nak_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Slave NAK Count (code 0x08 sub 0x10).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.ReturnSlaveNAKCountRequest(slave=slave))
+        return self.execute(pdu_diag.ReturnSlaveNAKCountRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_read_slave_busy_count(self, slave: int = 1) -> T:
+    def diag_read_slave_busy_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Slave Busy Count (code 0x08 sub 0x11).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.ReturnSlaveBusyCountRequest(slave=slave))
+        return self.execute(pdu_diag.ReturnSlaveBusyCountRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_read_bus_char_overrun_count(self, slave: int = 1) -> T:
+    def diag_read_bus_char_overrun_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Bus Character Overrun Count (code 0x08 sub 0x12).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnSlaveBusCharacterOverrunCountRequest(slave=slave)
+            pdu_diag.ReturnSlaveBusCharacterOverrunCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_read_iop_overrun_count(self, slave: int = 1) -> T:
+    def diag_read_iop_overrun_count(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose read Iop overrun count (code 0x08 sub 0x13).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_diag.ReturnIopOverrunCountRequest(slave=slave)
+            pdu_diag.ReturnIopOverrunCountRequest(slave=slave, no_response_expected=no_response_expected)
         )
 
-    def diag_clear_overrun_counter(self, slave: int = 1) -> T:
+    def diag_clear_overrun_counter(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose Clear Overrun Counter and Flag (code 0x08 sub 0x14).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.ClearOverrunCountRequest(slave=slave))
+        return self.execute(pdu_diag.ClearOverrunCountRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_getclear_modbus_response(self, slave: int = 1) -> T:
+    def diag_getclear_modbus_response(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose Get/Clear modbus plus (code 0x08 sub 0x15).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_diag.GetClearModbusPlusRequest(slave=slave))
+        return self.execute(pdu_diag.GetClearModbusPlusRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_get_comm_event_counter(self, slave: int = 1) -> T:
+    def diag_get_comm_event_counter(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose get event counter (code 0x0B).
 
+        :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_other_msg.GetCommEventCounterRequest(slave=slave))
+        return self.execute(pdu_other_msg.GetCommEventCounterRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def diag_get_comm_event_log(self, slave: int = 1) -> T:
+    def diag_get_comm_event_log(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Diagnose get event counter (code 0x0C).
 
+        :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_other_msg.GetCommEventLogRequest(slave=slave))
+        return self.execute(pdu_other_msg.GetCommEventLogRequest(slave=slave, no_response_expected=no_response_expected))
 
     def write_coils(
         self,
@@ -356,28 +406,31 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
                                                         no_response_expected=no_response_expected)
         )
 
-    def report_slave_id(self, slave: int = 1) -> T:
+    def report_slave_id(self, slave: int = 1, no_response_expected: bool = False) -> T:
         """Report slave ID (code 0x11).
 
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_other_msg.ReportSlaveIdRequest(slave=slave))
+        return self.execute(pdu_other_msg.ReportSlaveIdRequest(slave=slave, no_response_expected=no_response_expected))
 
-    def read_file_record(self, records: list[tuple], slave: int = 1) -> T:
+    def read_file_record(self, records: list[tuple], slave: int = 1, no_response_expected: bool = False) -> T:
         """Read file record (code 0x14).
 
         :param records: List of (Reference type, File number, Record Number, Record Length)
         :param slave: device id
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_file_msg.ReadFileRecordRequest(records, slave=slave))
+        return self.execute(pdu_file_msg.ReadFileRecordRequest(records, slave=slave, no_response_expected=no_response_expected))
 
     def write_file_record(self, records: list[tuple], slave: int = 1, no_response_expected: bool = False) -> T:
         """Write file record (code 0x15).
 
         :param records: List of (Reference type, File number, Record Number, Record Length)
         :param slave: (optional) Device id
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
@@ -418,6 +471,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         address: int | None = None,
         values: list[int] | int = 0,
         slave: int = 1,
+        no_response_expected: bool = False
     ) -> T:
         """Read/Write registers (code 0x17).
 
@@ -427,6 +481,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         :param address: (optional) use as read/write address
         :param values: List of values to write, or a single value to write
         :param slave: (optional) Modbus slave ID
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         if address:
@@ -439,31 +494,41 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
                 write_address=write_address,
                 write_registers=values,
                 slave=slave,
+                no_response_expected=no_response_expected
             )
         )
 
-    def read_fifo_queue(self, address: int = 0x0000, slave: int = 1) -> T:
+    def read_fifo_queue(self, address: int = 0x0000, slave: int = 1, no_response_expected: bool = False) -> T:
         """Read FIFO queue (code 0x18).
 
         :param address: The address to start reading from
         :param slave: (optional) device id
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
-        return self.execute(pdu_file_msg.ReadFifoQueueRequest(address, slave=slave))
+        return self.execute(pdu_file_msg.ReadFifoQueueRequest(address,
+                                                              slave=slave,
+                                                              no_response_expected=no_response_expected))
 
     # code 0x2B sub 0x0D: CANopen General Reference Request and Response, NOT IMPLEMENTED
 
-    def read_device_information(
-        self, read_code: int | None = None, object_id: int = 0x00, slave: int = 1) -> T:
+    def read_device_information(self, read_code: int | None = None,
+                                object_id: int = 0x00,
+                                slave: int = 1,
+                                no_response_expected: bool = False) -> T:
         """Read FIFO queue (code 0x2B sub 0x0E).
 
         :param read_code: The device information read code
         :param object_id: The object to read from
         :param slave: (optional) Device id
+        :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
         """
         return self.execute(
-            pdu_mei.ReadDeviceInformationRequest(read_code, object_id, slave=slave)
+            pdu_mei.ReadDeviceInformationRequest(read_code,
+                                                 object_id,
+                                                 slave=slave,
+                                                 no_response_expected=no_response_expected)
         )
 
     # ------------------

--- a/pymodbus/factory.py
+++ b/pymodbus/factory.py
@@ -120,7 +120,7 @@ class ServerDecoder:
         function_code = int(data[0])
         if not (request := self.lookup.get(function_code, lambda: None)()):
             Log.debug("Factory Request[{}]", function_code)
-            request = pdu.IllegalFunctionRequest(function_code, 0, 0, False)
+            request = pdu.IllegalFunctionRequest(function_code, 0, 0, False, False)
         else:
             fc_string = "{}: {}".format(  # pylint: disable=consider-using-f-string
                 str(self.lookup[function_code])  # pylint: disable=use-maxsplit-arg

--- a/pymodbus/pdu/bit_read_message.py
+++ b/pymodbus/pdu/bit_read_message.py
@@ -13,14 +13,14 @@ class ReadBitsRequestBase(ModbusPDU):
 
     _rtu_frame_size = 8
 
-    def __init__(self, address, count, slave, transaction, skip_encode):
+    def __init__(self, address, count, slave, transaction, skip_encode, no_response_expected):
         """Initialize the read request data.
 
         :param address: The start address to read from
         :param count: The number of bits after "address" to read
         :param slave: Modbus slave slave ID
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected)
         self.address = address
         self.count = count
 
@@ -67,13 +67,13 @@ class ReadBitsResponseBase(ModbusResponse):
 
     _rtu_byte_count_pos = 2
 
-    def __init__(self, values, slave, transaction, skip_encode):
+    def __init__(self, values, slave, transaction, skip_encode, no_response_expected):
         """Initialize a new instance.
 
         :param values: The requested values to be returned
         :param slave: Modbus slave slave ID
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected)
 
         #: A list of booleans representing bit values
         self.bits = values or []
@@ -138,14 +138,14 @@ class ReadCoilsRequest(ReadBitsRequestBase):
     function_code = 1
     function_code_name = "read_coils"
 
-    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start reading from
         :param count: The number of bits to read
         :param slave: Modbus slave slave ID
         """
-        ReadBitsRequestBase.__init__(self, address, count, slave, transaction, skip_encode)
+        ReadBitsRequestBase.__init__(self, address, count, slave, transaction, skip_encode, no_response_expected)
 
     async def execute(self, context):
         """Run a read coils request against a datastore.
@@ -185,13 +185,13 @@ class ReadCoilsResponse(ReadBitsResponseBase):
 
     function_code = 1
 
-    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param values: The request values to respond with
         :param slave: Modbus slave slave ID
         """
-        ReadBitsResponseBase.__init__(self, values, slave, transaction, skip_encode)
+        ReadBitsResponseBase.__init__(self, values, slave, transaction, skip_encode, no_response_expected)
 
 
 class ReadDiscreteInputsRequest(ReadBitsRequestBase):
@@ -206,14 +206,14 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
     function_code = 2
     function_code_name = "read_discrete_input"
 
-    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start reading from
         :param count: The number of bits to read
         :param slave: Modbus slave slave ID
         """
-        ReadBitsRequestBase.__init__(self, address, count, slave, transaction, skip_encode)
+        ReadBitsRequestBase.__init__(self, address, count, slave, transaction, skip_encode, no_response_expected)
 
     async def execute(self, context):
         """Run a read discrete input request against a datastore.
@@ -253,10 +253,10 @@ class ReadDiscreteInputsResponse(ReadBitsResponseBase):
 
     function_code = 2
 
-    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param values: The request values to respond with
         :param slave: Modbus slave slave ID
         """
-        ReadBitsResponseBase.__init__(self, values, slave, transaction, skip_encode)
+        ReadBitsResponseBase.__init__(self, values, slave, transaction, skip_encode, no_response_expected)

--- a/pymodbus/pdu/bit_write_message.py
+++ b/pymodbus/pdu/bit_write_message.py
@@ -49,7 +49,7 @@ class WriteSingleCoilRequest(ModbusPDU):
         :param address: The variable address to write
         :param value: The value to write at address
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.value = bool(value)
         self.no_response_expected = no_response_expected
@@ -114,13 +114,13 @@ class WriteSingleCoilResponse(ModbusResponse):
     function_code = 5
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, value=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, value=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The variable address written to
         :param value: The value written at address
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.value = value
 
@@ -174,7 +174,7 @@ class WriteMultipleCoilsRequest(ModbusPDU):
         :param address: The starting request address
         :param values: The values to write
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         if values is None:
             values = []
@@ -252,13 +252,13 @@ class WriteMultipleCoilsResponse(ModbusResponse):
     function_code = 15
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The starting variable address written to
         :param count: The number of values written
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.count = count
 

--- a/pymodbus/pdu/bit_write_message.py
+++ b/pymodbus/pdu/bit_write_message.py
@@ -43,7 +43,7 @@ class WriteSingleCoilRequest(ModbusRequest):
 
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, value=None, slave=None, transaction=0, skip_encode=0):
+    def __init__(self, address=None, value=None, slave=None, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The variable address to write
@@ -52,6 +52,7 @@ class WriteSingleCoilRequest(ModbusRequest):
         ModbusRequest.__init__(self, slave, transaction, skip_encode)
         self.address = address
         self.value = bool(value)
+        self.no_response_expected = no_response_expected
 
     def encode(self):
         """Encode write coil request.
@@ -167,7 +168,7 @@ class WriteMultipleCoilsRequest(ModbusRequest):
     function_code_name = "write_coils"
     _rtu_byte_count_pos = 6
 
-    def __init__(self, address=None, values=None, slave=None, transaction=0, skip_encode=0):
+    def __init__(self, address=None, values=None, slave=None, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The starting request address
@@ -181,6 +182,7 @@ class WriteMultipleCoilsRequest(ModbusRequest):
             values = [values]
         self.values = values
         self.byte_count = (len(self.values) + 7) // 8
+        self.no_response_expected = no_response_expected
 
     def encode(self):
         """Encode write coils request.

--- a/pymodbus/pdu/diag_message.py
+++ b/pymodbus/pdu/diag_message.py
@@ -31,9 +31,9 @@ class DiagnosticStatusRequest(ModbusPDU):
     function_code_name = "diagnostic_status"
     _rtu_frame_size = 8
 
-    def __init__(self, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a diagnostic request."""
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.message = None
 
     def encode(self):
@@ -93,9 +93,9 @@ class DiagnosticStatusResponse(ModbusResponse):
     function_code = 0x08
     _rtu_frame_size = 8
 
-    def __init__(self, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a diagnostic response."""
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.message = None
 
     def encode(self):
@@ -150,7 +150,7 @@ class DiagnosticStatusSimpleRequest(DiagnosticStatusRequest):
     the execute method
     """
 
-    def __init__(self, data=0x0000, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, data=0x0000, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a simple diagnostic request.
 
         The data defaults to 0x0000 if not provided as over half
@@ -158,7 +158,11 @@ class DiagnosticStatusSimpleRequest(DiagnosticStatusRequest):
 
         :param data: The data to send along with the request
         """
-        DiagnosticStatusRequest.__init__(self, slave=slave, transaction=transaction, skip_encode=skip_encode)
+        DiagnosticStatusRequest.__init__(self,
+                                         slave=slave,
+                                         transaction=transaction,
+                                         skip_encode=skip_encode,
+                                         no_response_expected=no_response_expected)
         self.message = data
 
     async def execute(self, *args):
@@ -175,12 +179,16 @@ class DiagnosticStatusSimpleResponse(DiagnosticStatusResponse):
     2 bytes of data.
     """
 
-    def __init__(self, data=0x0000, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, data=0x0000, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Return a simple diagnostic response.
 
         :param data: The resulting data to return to the client
         """
-        DiagnosticStatusResponse.__init__(self, slave=slave, transaction=transaction, skip_encode=skip_encode)
+        DiagnosticStatusResponse.__init__(self,
+                                          slave=slave,
+                                          transaction=transaction,
+                                          skip_encode=skip_encode,
+                                          no_response_expected=no_response_expected)
         self.message = data
 
 
@@ -197,12 +205,16 @@ class ReturnQueryDataRequest(DiagnosticStatusRequest):
 
     sub_function_code = 0x0000
 
-    def __init__(self, message=b"\x00\x00", slave=1, transaction=0, skip_encode=False):
+    def __init__(self, message=b"\x00\x00", slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance of the request.
 
         :param message: The message to send to loopback
         """
-        DiagnosticStatusRequest.__init__(self, slave=slave, transaction=transaction, skip_encode=skip_encode)
+        DiagnosticStatusRequest.__init__(self,
+                                         slave=slave,
+                                         transaction=transaction,
+                                         skip_encode=skip_encode,
+                                         no_response_expected=no_response_expected)
         if not isinstance(message, bytes):
             raise ModbusException(f"message({type(message)}) must be bytes")
         self.message = message
@@ -252,12 +264,16 @@ class RestartCommunicationsOptionRequest(DiagnosticStatusRequest):
 
     sub_function_code = 0x0001
 
-    def __init__(self, toggle=False, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, toggle=False, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new request.
 
         :param toggle: Set to True to toggle, False otherwise
         """
-        DiagnosticStatusRequest.__init__(self, slave=slave, transaction=transaction, skip_encode=skip_encode)
+        DiagnosticStatusRequest.__init__(self,
+                                         slave=slave,
+                                         transaction=transaction,
+                                         skip_encode=skip_encode,
+                                         no_response_expected=no_response_expected)
         if toggle:
             self.message = [ModbusStatus.ON]
         else:
@@ -778,9 +794,12 @@ class GetClearModbusPlusRequest(DiagnosticStatusSimpleRequest):
 
     sub_function_code = 0x0015
 
-    def __init__(self, data=0, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, data=0, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize."""
-        super().__init__(slave=slave, transaction=transaction, skip_encode=skip_encode)
+        super().__init__(slave=slave,
+                         transaction=transaction,
+                         skip_encode=skip_encode,
+                         no_response_expected=no_response_expected)
         self.message=data
 
     def get_response_pdu_size(self):

--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -210,13 +210,14 @@ class WriteFileRecordRequest(ModbusRequest):
     function_code_name = "write_file_record"
     _rtu_byte_count_pos = 2
 
-    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param records: The file record requests to be read
         """
         ModbusRequest.__init__(self, slave, transaction, skip_encode)
         self.records = records or []
+        self.no_response_expected = no_response_expected
 
     def encode(self):
         """Encode the request packet.

--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -154,12 +154,12 @@ class ReadFileRecordResponse(ModbusResponse):
     function_code = 0x14
     _rtu_byte_count_pos = 2
 
-    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param records: The requested file records
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.records = records or []
 
     def encode(self):
@@ -215,7 +215,7 @@ class WriteFileRecordRequest(ModbusPDU):
 
         :param records: The file record requests to be read
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.records = records or []
         self.no_response_expected = no_response_expected
 
@@ -275,12 +275,12 @@ class WriteFileRecordResponse(ModbusResponse):
     function_code = 0x15
     _rtu_byte_count_pos = 2
 
-    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param records: The file record requests to be read
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.records = records or []
 
     def encode(self):
@@ -401,12 +401,12 @@ class ReadFifoQueueResponse(ModbusResponse):
         lo_byte = int(buffer[3])
         return (hi_byte << 16) + lo_byte + 6
 
-    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, values=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param values: The list of values of the fifo to return
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.values = values or []
 
     def encode(self):

--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -89,12 +89,12 @@ class ReadFileRecordRequest(ModbusPDU):
     function_code_name = "read_file_record"
     _rtu_byte_count_pos = 2
 
-    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, records=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param records: The file record requests to be read
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.records = records or []
 
     def encode(self):
@@ -340,12 +340,12 @@ class ReadFifoQueueRequest(ModbusPDU):
     function_code_name = "read_fifo_queue"
     _rtu_frame_size = 6
 
-    def __init__(self, address=0x0000, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=0x0000, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The fifo pointer address (0x0000 to 0xffff)
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.values = []  # this should be added to the context
 

--- a/pymodbus/pdu/mei_message.py
+++ b/pymodbus/pdu/mei_message.py
@@ -52,13 +52,13 @@ class ReadDeviceInformationRequest(ModbusPDU):
     function_code_name = "read_device_information"
     _rtu_frame_size = 7
 
-    def __init__(self, read_code=None, object_id=0x00, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, read_code=None, object_id=0x00, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param read_code: The device information read code
         :param object_id: The object to read from
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.read_code = read_code or DeviceInformation.BASIC
         self.object_id = object_id
 
@@ -130,13 +130,19 @@ class ReadDeviceInformationResponse(ModbusResponse):
         except struct.error as exc:
             raise IndexError from exc
 
-    def __init__(self, read_code=None, information=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self,
+                 read_code=None,
+                 information=None,
+                 slave=1,
+                 transaction=0,
+                 skip_encode=False,
+                 no_response_expected=False):
         """Initialize a new instance.
 
         :param read_code: The device information read code
         :param information: The requested information request
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.read_code = read_code or DeviceInformation.BASIC
         self.information = information or {}
         self.number_of_objects = 0

--- a/pymodbus/pdu/other_message.py
+++ b/pymodbus/pdu/other_message.py
@@ -30,9 +30,9 @@ class ReadExceptionStatusRequest(ModbusPDU):
     function_code_name = "read_exception_status"
     _rtu_frame_size = 4
 
-    def __init__(self, slave=None, transaction=0, skip_encode=0):
+    def __init__(self, slave=None, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance."""
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
     def encode(self):
         """Encode the message."""
@@ -72,12 +72,12 @@ class ReadExceptionStatusResponse(ModbusResponse):
     function_code = 0x07
     _rtu_frame_size = 5
 
-    def __init__(self, status=0x00, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, status=0x00, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param status: The status response to report
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.status = status if status < 256 else 255
 
     def encode(self):
@@ -135,9 +135,9 @@ class GetCommEventCounterRequest(ModbusPDU):
     function_code_name = "get_event_counter"
     _rtu_frame_size = 4
 
-    def __init__(self, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance."""
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
     def encode(self):
         """Encode the message."""
@@ -178,12 +178,12 @@ class GetCommEventCounterResponse(ModbusResponse):
     function_code = 0x0B
     _rtu_frame_size = 8
 
-    def __init__(self, count=0x0000, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, count=0x0000, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param count: The current event counter value
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.count = count
         self.status = True  # this means we are ready, not waiting
 
@@ -246,9 +246,9 @@ class GetCommEventLogRequest(ModbusPDU):
     function_code_name = "get_event_log"
     _rtu_frame_size = 4
 
-    def __init__(self, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance."""
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
     def encode(self):
         """Encode the message."""
@@ -293,7 +293,15 @@ class GetCommEventLogResponse(ModbusResponse):
     function_code = 0x0C
     _rtu_byte_count_pos = 2
 
-    def __init__(self, status=True, message_count=0, event_count=0, events=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self,
+                 status=True,
+                 message_count=0,
+                 event_count=0,
+                 events=None,
+                 slave=1,
+                 transaction=0,
+                 skip_encode=False,
+                 no_response_expected=False):
         """Initialize a new instance.
 
         :param status: The status response to report
@@ -301,7 +309,7 @@ class GetCommEventLogResponse(ModbusResponse):
         :param event_count: The current event count
         :param events: The collection of events to send
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.status = status
         self.message_count = message_count
         self.event_count = event_count
@@ -367,13 +375,13 @@ class ReportSlaveIdRequest(ModbusPDU):
     function_code_name = "report_slave_id"
     _rtu_frame_size = 4
 
-    def __init__(self, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param slave: Modbus slave slave ID
 
         """
-        ModbusPDU.__init__(self, slave, transaction, skip_encode)
+        ModbusPDU.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
     def encode(self):
         """Encode the message."""
@@ -426,13 +434,18 @@ class ReportSlaveIdResponse(ModbusResponse):
     function_code = 0x11
     _rtu_byte_count_pos = 2
 
-    def __init__(self, identifier=b"\x00", status=True, slave=1, transaction=0, skip_encode=False):
+    def __init__(self,
+                 identifier=b"\x00",
+                 status=True, slave=1,
+                 transaction=0,
+                 skip_encode=False,
+                 no_response_expected=False):
         """Initialize a new instance.
 
         :param identifier: The identifier of the slave
         :param status: The status response to report
         """
-        ModbusResponse.__init__(self, slave, transaction, skip_encode)
+        ModbusResponse.__init__(self, slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.identifier = identifier
         self.status = status
         self.byte_count = None

--- a/pymodbus/pdu/register_read_message.py
+++ b/pymodbus/pdu/register_read_message.py
@@ -14,14 +14,14 @@ class ReadRegistersRequestBase(ModbusPDU):
 
     _rtu_frame_size = 8
 
-    def __init__(self, address, count, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address, count, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start the read from
         :param count: The number of registers to read
         :param slave: Modbus slave slave ID
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.count = count
 
@@ -62,13 +62,13 @@ class ReadRegistersResponseBase(ModbusResponse):
 
     _rtu_byte_count_pos = 2
 
-    def __init__(self, values, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, values, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param values: The values to write to
         :param slave: Modbus slave slave ID
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
         #: A list of register values
         self.registers = values or []
@@ -124,14 +124,14 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
     function_code = 3
     function_code_name = "read_holding_registers"
 
-    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=0):
+    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance of the request.
 
         :param address: The starting address to read from
         :param count: The number of registers to read from address
         :param slave: Modbus slave slave ID
         """
-        super().__init__(address, count, slave, transaction, skip_encode)
+        super().__init__(address, count, slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
     async def execute(self, context):
         """Run a read holding request against a datastore.
@@ -186,14 +186,14 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
     function_code = 4
     function_code_name = "read_input_registers"
 
-    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=0):
+    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance of the request.
 
         :param address: The starting address to read from
         :param count: The number of registers to read from address
         :param slave: Modbus slave slave ID
         """
-        super().__init__(address, count, slave, transaction, skip_encode)
+        super().__init__(address, count, slave, transaction, skip_encode, no_response_expected=no_response_expected)
 
     async def execute(self, context):
         """Run a read input request against a datastore.
@@ -255,7 +255,15 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
     function_code_name = "read_write_multiple_registers"
     _rtu_byte_count_pos = 10
 
-    def __init__(self, read_address=0x00, read_count=0, write_address=0x00, write_registers=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self,
+                 read_address=0x00,
+                 read_count=0,
+                 write_address=0x00,
+                 write_registers=None,
+                 slave=1,
+                 transaction=0,
+                 skip_encode=False,
+                 no_response_expected=False):
         """Initialize a new request message.
 
         :param read_address: The address to start reading from
@@ -263,7 +271,7 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
         :param write_address: The address to start writing to
         :param write_registers: The registers to write to the specified address
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.read_address = read_address
         self.read_count = read_count
         self.write_address = write_address

--- a/pymodbus/pdu/register_write_message.py
+++ b/pymodbus/pdu/register_write_message.py
@@ -20,7 +20,7 @@ class WriteSingleRegisterRequest(ModbusRequest):
     function_code_name = "write_register"
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, value=None, slave=None, transaction=0, skip_encode=0):
+    def __init__(self, address=None, value=None, slave=None, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start writing add
@@ -29,6 +29,7 @@ class WriteSingleRegisterRequest(ModbusRequest):
         super().__init__(slave, transaction, skip_encode)
         self.address = address
         self.value = value
+        self.no_response_expected = no_response_expected
 
     def encode(self):
         """Encode a write single register packet packet request.
@@ -152,7 +153,7 @@ class WriteMultipleRegistersRequest(ModbusRequest):
     _rtu_byte_count_pos = 6
     _pdu_length = 5  # func + adress1 + adress2 + outputQuant1 + outputQuant2
 
-    def __init__(self, address=None, values=None, slave=None, transaction=0, skip_encode=0):
+    def __init__(self, address=None, values=None, slave=None, transaction=0, skip_encode=0, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start writing to
@@ -167,6 +168,7 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         self.values = values
         self.count = len(self.values)
         self.byte_count = self.count * 2
+        self.no_response_expected = no_response_expected
 
     def encode(self):
         """Encode a write single register packet packet request.
@@ -290,17 +292,26 @@ class MaskWriteRegisterRequest(ModbusRequest):
     function_code_name = "mask_write_register"
     _rtu_frame_size = 10
 
-    def __init__(self, address=0x0000, and_mask=0xFFFF, or_mask=0x0000, slave=1, transaction=0, skip_encode=False):
+    def __init__(self,
+                 address=0x0000,
+                 and_mask=0xFFFF,
+                 or_mask=0x0000,
+                 slave=1,
+                 transaction=0,
+                 skip_encode=False,
+                 no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The mask pointer address (0x0000 to 0xffff)
         :param and_mask: The and bitmask to apply to the register address
         :param or_mask: The or bitmask to apply to the register address
+        :param no_response_expected: (optional) The client will not expect a response to the request
         """
         super().__init__(slave, transaction, skip_encode)
         self.address = address
         self.and_mask = and_mask
         self.or_mask = or_mask
+        self.no_response_expected = no_response_expected
 
     def encode(self):
         """Encode the request packet.

--- a/pymodbus/pdu/register_write_message.py
+++ b/pymodbus/pdu/register_write_message.py
@@ -26,7 +26,7 @@ class WriteSingleRegisterRequest(ModbusPDU):
         :param address: The address to start writing add
         :param value: The values to write
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.value = value
         self.no_response_expected = no_response_expected
@@ -92,13 +92,13 @@ class WriteSingleRegisterResponse(ModbusResponse):
     function_code = 6
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, value=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, value=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start writing add
         :param value: The values to write
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.value = value
 
@@ -159,7 +159,7 @@ class WriteMultipleRegistersRequest(ModbusPDU):
         :param address: The address to start writing to
         :param values: The values to write
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         if values is None:
             values = []
@@ -244,13 +244,13 @@ class WriteMultipleRegistersResponse(ModbusResponse):
     function_code = 16
     _rtu_frame_size = 8
 
-    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False):
+    def __init__(self, address=None, count=None, slave=1, transaction=0, skip_encode=False, no_response_expected=False):
         """Initialize a new instance.
 
         :param address: The address to start writing to
         :param count: The number of registers to write to
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.count = count
 
@@ -307,7 +307,7 @@ class MaskWriteRegisterRequest(ModbusPDU):
         :param or_mask: The or bitmask to apply to the register address
         :param no_response_expected: (optional) The client will not expect a response to the request
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.and_mask = and_mask
         self.or_mask = or_mask
@@ -356,14 +356,21 @@ class MaskWriteRegisterResponse(ModbusResponse):
     function_code = 0x16
     _rtu_frame_size = 10
 
-    def __init__(self, address=0x0000, and_mask=0xFFFF, or_mask=0x0000, slave=1, transaction=0, skip_encode=False):
+    def __init__(self,
+                 address=0x0000,
+                 and_mask=0xFFFF,
+                 or_mask=0x0000,
+                 slave=1,
+                 transaction=0,
+                 skip_encode=False,
+                 no_response_expected=False):
         """Initialize new instance.
 
         :param address: The mask pointer address (0x0000 to 0xffff)
         :param and_mask: The and bitmask applied to the register address
         :param or_mask: The or bitmask applied to the register address
         """
-        super().__init__(slave, transaction, skip_encode)
+        super().__init__(slave, transaction, skip_encode, no_response_expected=no_response_expected)
         self.address = address
         self.and_mask = and_mask
         self.or_mask = or_mask

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -191,7 +191,6 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                 ):
                     Log.debug("Clearing current Frame: - {}", _buffer)
                     self.client.framer.databuffer = b''
-                broadcast = not request.slave_id
                 expected_response_length = None
                 if not isinstance(self.client.framer, FramerSocket):
                     if hasattr(request, "get_response_pdu_size"):
@@ -216,8 +215,9 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                     request,
                     expected_response_length,
                     full=full,
-                    broadcast=broadcast,
                 )
+                if hasattr(request, "no_response_expected") and request.no_response_expected is True:
+                    return "Broadcast write sent - no response expected"
                 while retries > 0:
                     if self._validate_response(response):
                         if (
@@ -276,14 +276,13 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                     return result, None
         return self._transact(packet, response_length, full=full)
 
-    def _transact(self, request: ModbusPDU, response_length, full=False, broadcast=False):
+    def _transact(self, request: ModbusPDU, response_length, full=False):
         """Do a Write and Read transaction.
 
         :param packet: packet to be sent
         :param response_length:  Expected response length
         :param full: the target device was notorious for its no response. Dont
             waste time this time by partial querying
-        :param broadcast:
         :return: response
         """
         last_exception = None
@@ -305,7 +304,8 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
             if self.client.comm_params.handle_local_echo is True:
                 if self._recv(size, full) != packet:
                     return b"", "Wrong local echo"
-            if broadcast:
+            no_response_expected = hasattr(request, "no_response_expected") and request.no_response_expected is True
+            if no_response_expected:
                 if size:
                     Log.debug(
                         'Changing transaction state from "SENDING" '

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -218,7 +218,7 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                     expected_response_length,
                     full=full,
                 )
-                if hasattr(request, "no_response_expected") and request.no_response_expected is True:
+                if request.no_response_expected is True:
                     return "Broadcast write sent - no response expected"
                 while retries > 0:
                     if self._validate_response(response):
@@ -284,7 +284,6 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
     def _transact(self, request: ModbusPDU, response_length, full=False):
         """Do a Write and Read transaction.
 
-        :param packet: packet to be sent
         :param response_length:  Expected response length
         :param full: the target device was notorious for its no response. Dont
             waste time this time by partial querying
@@ -309,8 +308,7 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
             if self.client.comm_params.handle_local_echo is True:
                 if self._recv(size, full) != packet:
                     return b"", "Wrong local echo"
-            no_response_expected = hasattr(request, "no_response_expected") and request.no_response_expected is True
-            if no_response_expected:
+            if request.no_response_expected is True:
                 if size:
                     Log.debug(
                         'Changing transaction state from "SENDING" '

--- a/test/framers/test_framer.py
+++ b/test/framers/test_framer.py
@@ -432,7 +432,7 @@ class TestFramerType:
     def test_framer_encode(self, test_framer, msg):
         """Test a tcp frame transaction."""
         with mock.patch.object(ModbusPDU, "encode") as mock_encode:
-            message = ModbusPDU(0, 0, False)
+            message = ModbusPDU(0, 0, False, False)
             message.transaction_id = 0x0001
             message.slave_id = 0xFF
             message.function_code = 0x01

--- a/test/pdu/test_pdu.py
+++ b/test/pdu/test_pdu.py
@@ -14,7 +14,7 @@ from pymodbus.pdu import (
 class TestPdu:
     """Unittest for the pymod.pdu module."""
 
-    illegal = IllegalFunctionRequest(1, 0, 0, False)
+    illegal = IllegalFunctionRequest(1, 0, 0, False, False)
     exception = ExceptionResponse(1, 1, 0, 0, False)
 
     async def test_error_methods(self):
@@ -29,7 +29,7 @@ class TestPdu:
 
     def test_request_exception_factory(self):
         """Test all error methods."""
-        request = ModbusPDU(0, 0, False)
+        request = ModbusPDU(0, 0, False, False)
         request.function_code = 1
         errors = {ModbusExceptions.decode(c): c for c in range(1, 20)}
         for error, code in iter(errors.items()):

--- a/test/sub_client/test_client.py
+++ b/test/sub_client/test_client.py
@@ -241,7 +241,7 @@ async def test_client_instanciate(
     client.connect = lambda: False
     client.transport = None
     with pytest.raises(ConnectionException):
-        client.execute(ModbusPDU(0, 0, False))
+        client.execute(ModbusPDU(0, 0, False, False))
 
 async def test_client_modbusbaseclient():
     """Test modbus base client class."""
@@ -677,13 +677,13 @@ async def test_client_build_response():
         comm_params=CommParams(),
     )
     with pytest.raises(ConnectionException):
-        await client.build_response(ModbusPDU(0, 0, False))
+        await client.build_response(ModbusPDU(0, 0, False, False))
 
 
 async def test_client_mixin_execute():
     """Test dummy execute for both sync and async."""
     client = ModbusClientMixin()
     with pytest.raises(NotImplementedError):
-        client.execute(ModbusPDU(0, 0, False))
+        client.execute(ModbusPDU(0, 0, False, False))
     with pytest.raises(NotImplementedError):
-        await client.execute(ModbusPDU(0, 0, False))
+        await client.execute(ModbusPDU(0, 0, False, False))

--- a/test/sub_current/test_transaction.py
+++ b/test/sub_current/test_transaction.py
@@ -167,7 +167,7 @@ class TestTransaction:  # pylint: disable=too-many-public-methods
         """Test the getting a transaction from the transaction manager."""
         self._manager.reset()
         handle = ModbusPDU(
-            0, self._manager.getNextTID(), False
+            0, self._manager.getNextTID(), False, False
         )
         self._manager.addTransaction(handle)
         result = self._manager.getTransaction(handle.transaction_id)
@@ -177,7 +177,7 @@ class TestTransaction:  # pylint: disable=too-many-public-methods
         """Test deleting a transaction from the dict transaction manager."""
         self._manager.reset()
         handle = ModbusPDU(
-            0, self._manager.getNextTID(), False
+            0, self._manager.getNextTID(), False, False
         )
         self._manager.addTransaction(handle)
         self._manager.delTransaction(handle.transaction_id)

--- a/test/sub_function_codes/test_bit_read_messages.py
+++ b/test/sub_function_codes/test_bit_read_messages.py
@@ -40,17 +40,17 @@ class TestModbusBitMessage:
 
     def test_read_bit_base_class_methods(self):
         """Test basic bit message encoding/decoding."""
-        handle = ReadBitsRequestBase(1, 1, 0, 0, False)
+        handle = ReadBitsRequestBase(1, 1, 0, 0, False, False)
         msg = "ReadBitRequest(1,1)"
         assert msg == str(handle)
-        handle = ReadBitsResponseBase([1, 1], 0, 0, False)
+        handle = ReadBitsResponseBase([1, 1], 0, 0, False, False)
         msg = "ReadBitsResponseBase(2)"
         assert msg == str(handle)
 
     def test_bit_read_base_request_encoding(self):
         """Test basic bit message encoding/decoding."""
         for i in range(20):
-            handle = ReadBitsRequestBase(i, i, 0, 0, False)
+            handle = ReadBitsRequestBase(i, i, 0, 0, False, False)
             result = struct.pack(">HH", i, i)
             assert handle.encode() == result
             handle.decode(result)
@@ -60,7 +60,7 @@ class TestModbusBitMessage:
         """Test basic bit message encoding/decoding."""
         for i in range(20):
             data = [True] * i
-            handle = ReadBitsResponseBase(data, 0, 0, False)
+            handle = ReadBitsResponseBase(data, 0, 0, False, False)
             result = handle.encode()
             handle.decode(result)
             assert handle.bits[:i] == data
@@ -68,7 +68,7 @@ class TestModbusBitMessage:
     def test_bit_read_base_response_helper_methods(self):
         """Test the extra methods on a ReadBitsResponseBase."""
         data = [False] * 8
-        handle = ReadBitsResponseBase(data, 0, 0, False)
+        handle = ReadBitsResponseBase(data, 0, 0, False, False)
         for i in (1, 3, 5):
             handle.setBit(i, True)
         for i in (1, 3, 5):
@@ -79,8 +79,8 @@ class TestModbusBitMessage:
     def test_bit_read_base_requests(self):
         """Test bit read request encoding."""
         messages = {
-            ReadBitsRequestBase(12, 14, 0, 0, False): b"\x00\x0c\x00\x0e",
-            ReadBitsResponseBase([1, 0, 1, 1, 0], 0, 0, False): b"\x01\x0d",
+            ReadBitsRequestBase(12, 14, 0, 0, False, False): b"\x00\x0c\x00\x0e",
+            ReadBitsResponseBase([1, 0, 1, 1, 0], 0, 0, False, False): b"\x01\x0d",
         }
         for request, expected in iter(messages.items()):
             assert request.encode() == expected


### PR DESCRIPTION
Adds the `no_response_expected` argument to write requests, see discussion in #2378 

All requests will expect and wait for a response, exept write requests when the `no_response_expected=True` argument is set.

Assumptions:
1. When a read request is made to the broadcast address (slave==0), it is treated as a request to any other slave and at least one response is expected and waited for. If one wasn't expecing a response, a read request would not be made intentionally to the broadcast address
2. When a write request is made to the broadcast address, opposed to the specification, at least one response is expected and waited for.
3. If a response to a write request is not expected, the `no_response_expected=True` argument can be set when `write_coil`, `write_register`, `write_registers`, `write_file_record` and `mask_write_register` are called. This will result in the modbus message sent, then no valid response returned without delay.