### PR TITLE
Wrong close, when transaction do not match.

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -186,7 +186,10 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                     ModbusTransactionState.to_string(self.client.state),
                 )
                 retries = self.retries
-                request.transaction_id = self.getNextTID()
+                if isinstance(self.client.framer, FramerSocket):
+                    request.transaction_id = self.getNextTID()
+                else:
+                    request.transaction_id = 0
                 Log.debug("Running transaction {}", request.transaction_id)
                 if _buffer := hexlify_packets(
                     self.client.framer.databuffer
@@ -239,7 +242,7 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                 self.databuffer = self.databuffer[used_len:]
                 if pdu:
                     self.addTransaction(pdu)
-                if not (result := self.getTransaction(0)):
+                if not (result := self.getTransaction(request.transaction_id)):
                     if len(self.transactions):
                         result = self.getTransaction(0)
                     else:

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -239,9 +239,9 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                 self.databuffer = self.databuffer[used_len:]
                 if pdu:
                     self.addTransaction(pdu)
-                if not (result := self.getTransaction(request.transaction_id)):
+                if not (result := self.getTransaction(0)):
                     if len(self.transactions):
-                        result = self.getTransaction(tid=0)
+                        result = self.getTransaction(0)
                     else:
                         last_exception = last_exception or (
                             "No Response received from the remote slave"
@@ -250,7 +250,7 @@ class SyncModbusTransactionManager(ModbusTransactionManager):
                         result = ModbusIOException(
                             last_exception, request.function_code
                         )
-                    self.client.close()
+                        self.client.close()
                 if hasattr(self.client, "state"):
                     Log.debug(
                         "Changing transaction state from "


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
fixes #2398 

a client.close() was not indented correctly (should have been in an else: and not general).

While at it, optimized the transaction code a little bit, by always retrieving the newest transaction.