### PR TITLE
Improve type of parameter values of write_registers

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import struct
+from collections.abc import Sequence
 from enum import Enum
 from typing import Generic, TypeVar
-from collections.abc import Sequence
 
 import pymodbus.pdu.bit_read_message as pdu_bit_read
 import pymodbus.pdu.bit_write_message as pdu_bit_write

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import struct
 from enum import Enum
-from typing import Generic, TypeVar, Sequence
+from typing import Generic, TypeVar
+from collections.abc import Sequence
 
 import pymodbus.pdu.bit_read_message as pdu_bit_read
 import pymodbus.pdu.bit_write_message as pdu_bit_write

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import struct
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Sequence
 
 import pymodbus.pdu.bit_read_message as pdu_bit_read
 import pymodbus.pdu.bit_write_message as pdu_bit_write
@@ -341,7 +341,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
     def write_registers(
         self,
         address: int,
-        values: list[bytes | int],
+        values: Sequence[bytes | int],
         slave: int = 1,
         skip_encode: bool = False,
         no_response_expected: bool = False


### PR DESCRIPTION
To use write_registers type correctly with inhomogeneous lists of type list[int] or list[bytes] as values, we promote the type of the parameter values from list to Sequence (see Issue #2368)