### PR TITLE
Rtu decode frames without byte count.

### DIFF
--- a/pymodbus/framer/rtu.py
+++ b/pymodbus/framer/rtu.py
@@ -112,7 +112,7 @@ class FramerRTU(FramerBase):
             if data_len < used_len +size:
                 Log.debug("Frame - not ready")
                 return used_len, dev_id, 0, self.EMPTY
-            for test_len in range(data_len, used_len + size - 1):
+            for test_len in range(data_len, used_len + size - 1, -1):
                 start_crc = test_len -2
                 crc = data[start_crc : start_crc + 2]
                 crc_val = (int(crc[0]) << 8) + int(crc[1])

--- a/pymodbus/framer/rtu.py
+++ b/pymodbus/framer/rtu.py
@@ -112,13 +112,14 @@ class FramerRTU(FramerBase):
             if data_len < used_len +size:
                 Log.debug("Frame - not ready")
                 return used_len, dev_id, 0, self.EMPTY
-            start_crc = used_len + size -2
-            crc = data[start_crc : start_crc + 2]
-            crc_val = (int(crc[0]) << 8) + int(crc[1])
-            if not FramerRTU.check_CRC(data[used_len : start_crc], crc_val):
-                Log.debug("Frame check failed, ignoring!!")
-                continue
-            return start_crc + 2, dev_id, 0, data[used_len + 1 : start_crc]
+            for test_len in range(data_len, used_len + size - 1):
+                start_crc = test_len -2
+                crc = data[start_crc : start_crc + 2]
+                crc_val = (int(crc[0]) << 8) + int(crc[1])
+                if not FramerRTU.check_CRC(data[used_len : start_crc], crc_val):
+                    Log.debug("Frame check failed, possible garbage after frame, testing..")
+                    continue
+                return start_crc + 2, dev_id, 0, data[used_len + 1 : start_crc]
         return 0, 0, 0, self.EMPTY
 
 


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
The current RTU frame, fails to decode response frames without a byte count, this causes a number of diag and mei messages to fail.
