### PR TITLE
No more 3.7 versions !!

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -2,6 +2,9 @@ API changes
 ===========
 Versions (X.Y.Z) where Z > 0 e.g. 3.0.1 do NOT have API changes!
 
+API changes 3.8.0
+-----------------
+
 
 API changes 3.7.0
 -----------------

--- a/doc/source/roadmap.rst
+++ b/doc/source/roadmap.rst
@@ -15,13 +15,12 @@ It is the community that decides how pymodbus evolves NOT the maintainers !
 
 The following bullet points are what the maintainers focus on:
 
-- 3.7.5, bug fix release, hopefully with:
+- 3.7.X, bug fix release, hopefully with:
+    - Not planned
+- 3.8.0, with:
     - Simplify PDU classes
     - Simplify transaction manager (central control point)
     - Remove ModbusControlBlock
-- 3.7.6, bug fix release, with:
-    - Not planned
-- 3.8.0, with:
     - new transaction handling
     - transaction 100% coverage
     - skip_encode, zero_mode parameters removed

--- a/pymodbus/__init__.py
+++ b/pymodbus/__init__.py
@@ -18,5 +18,5 @@ from pymodbus.logging import pymodbus_apply_logging_config
 from pymodbus.pdu import ExceptionResponse
 
 
-__version__ = "3.7.5dev"
+__version__ = "3.8.0dev"
 __version_full__ = f"[pymodbus, version {__version__}]"


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
The refactoring of PDU is difficult or do not make sense, without API changes...like e.g. removing skip_encode.

For that reason it has been decided NOT to prepare a v3.7.5, but start working on releasing v3.8.0, due before X-mas.

If a user encounter a serious problem with v3.7.4, v3.7.5 will be made but ONLY with the needed bug fix.
