### PR TITLE
Fix client lock, Parallel API calls are not permitted.

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -101,8 +101,8 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusPDU]]):
         packet = self.ctx.framer.buildFrame(request)
 
         count = 0
-        while count <= self.retries:
-            async with self._lock:
+        async with self._lock:
+            while count <= self.retries:
                 req = self.build_response(request)
                 self.ctx.send(packet)
                 if no_response_expected:


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Issue #2433 showed a bug in the client locking.

Pymodbus do NOT allow parallel calls !  the lock ensures that.

The App can issue multiple calls, but the 2..n call will wait on the lock.