### PR TITLE
Allow configuring pyserial hardware RS485 settings

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -34,6 +34,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
     :param parity: 'E'ven, 'O'dd or 'N'one
     :param stopbits: Number of stop bits 1, 1.5, 2.
     :param handle_local_echo: Discard local echo from dongle.
+    :param rs485_settings: Allow configuring the underlying serial port for RS485 mode.
     :param name: Set communication name, used in logging
     :param reconnect_delay: Minimum delay in seconds.milliseconds before reconnecting.
     :param reconnect_delay_max: Maximum delay in seconds.milliseconds before reconnecting.
@@ -69,6 +70,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
         bytesize: int = 8,
         parity: str = "N",
         stopbits: int = 1,
+        rs485_settings: serial.rs485.RS485Settings | None = None,
         handle_local_echo: bool = False,
         name: str = "comm",
         reconnect_delay: float = 0.1,
@@ -92,6 +94,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
             bytesize=bytesize,
             parity=parity,
             stopbits=stopbits,
+            rs485_settings=rs485_settings,
             handle_local_echo=handle_local_echo,
             comm_name=name,
             reconnect_delay=reconnect_delay,
@@ -160,6 +163,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
         bytesize: int = 8,
         parity: str = "N",
         stopbits: int = 1,
+        rs485_settings: serial.rs485.RS485Settings | None = None,
         handle_local_echo: bool = False,
         name: str = "comm",
         reconnect_delay: float = 0.1,
@@ -182,6 +186,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
             bytesize=bytesize,
             parity=parity,
             stopbits=stopbits,
+            rs485_settings=rs485_settings,
             handle_local_echo=handle_local_echo,
             comm_name=name,
             reconnect_delay=reconnect_delay,

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -56,10 +56,14 @@ from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from enum import Enum
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pymodbus.logging import Log
 from pymodbus.transport.serialtransport import create_serial_connection
+
+
+if TYPE_CHECKING:
+    import serial
 
 
 NULLMODEM_HOST = "__pymodbus_nullmodem"
@@ -97,6 +101,9 @@ class CommParams:
     bytesize: int = -1
     parity: str = ''
     stopbits: int = -1
+
+    # RS485
+    rs485_settings: 'serial.rs485.RS485Settings' | None = None  # noqa: UP037
 
     @classmethod
     def generate_ssl(
@@ -204,6 +211,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
                 parity=self.comm_params.parity,
                 stopbits=self.comm_params.stopbits,
                 timeout=self.comm_params.timeout_connect,
+                rs485_settings=self.comm_params.rs485_settings,
             )
             return
         if self.comm_params.comm_type == CommType.UDP:

--- a/test/transport/test_serial.py
+++ b/test/transport/test_serial.py
@@ -23,17 +23,17 @@ class TestTransportSerial:
 
     async def test_init(self):
         """Test null modem init."""
-        SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
 
     async def test_loop(self):
         """Test asyncio abstract methods."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         assert comm.loop
 
     @pytest.mark.parametrize("inx", range(0, 11))
     async def test_abstract_methods(self, inx):
         """Test asyncio abstract methods."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         methods = [
             partial(comm.get_protocol),
             partial(comm.set_protocol, None),
@@ -52,7 +52,7 @@ class TestTransportSerial:
     @pytest.mark.parametrize("inx", range(0, 4))
     async def test_external_methods(self, inx):
         """Test external methods."""
-        comm = SerialTransport(mock.MagicMock(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(mock.MagicMock(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial.read = mock.MagicMock(return_value="abcd")
         comm.sync_serial.write = mock.MagicMock(return_value=4)
         comm.sync_serial.fileno = mock.MagicMock(return_value=2)
@@ -108,14 +108,14 @@ class TestTransportSerial:
 
     async def test_close(self):
         """Test close."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = None
         comm.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_polling(self):
         """Test polling."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.read.side_effect = asyncio.CancelledError("test")
         with contextlib.suppress(asyncio.CancelledError):
@@ -124,7 +124,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_poll_task(self):
         """Test polling."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.read.side_effect = serial.SerialException("test")
         await comm.polling_task()
@@ -132,7 +132,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_poll_task2(self):
         """Test polling."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.write.return_value = 4
@@ -144,7 +144,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_write_exception(self):
         """Test write exception."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.write.side_effect = BlockingIOError("test")
         comm.intern_write_ready()
@@ -154,7 +154,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_write_ok(self):
         """Test write exception."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.write.return_value = 4
         comm.intern_write_buffer.append(b"abcd")
@@ -163,7 +163,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_write_len(self):
         """Test write exception."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.write.return_value = 3
         comm.async_loop.add_writer = mock.Mock()
@@ -173,7 +173,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_write_force(self):
         """Test write exception."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.poll_task = True
         comm.sync_serial = mock.MagicMock()
         comm.sync_serial.write.return_value = 3
@@ -183,7 +183,7 @@ class TestTransportSerial:
     @pytest.mark.skipif(os.name == "nt", reason="Windows not supported")
     async def test_read_ready(self):
         """Test polling."""
-        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+        comm = SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)
         comm.sync_serial = mock.MagicMock()
         comm.intern_protocol = mock.Mock()
         comm.sync_serial.read = mock.Mock()
@@ -199,4 +199,4 @@ class TestTransportSerial:
         with mock.patch.dict(sys.modules, {'no_modules': None}) as mock_modules:
             del mock_modules['serial']
             with pytest.raises(RuntimeError):
-                SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None)
+                SerialTransport(asyncio.get_running_loop(), mock.Mock(), "dummy", None, None, None, None, None, None)


### PR DESCRIPTION
Loosely based on #2205 but is designed to configure the [native rs485 serial port settings via ioctl's](https://github.com/pyserial/pyserial/blob/v3.5/serial/serialposix.py#L164-L190) rather than using the weird [RS485  subclass](https://github.com/pyserial/pyserial/blob/v3.5/serial/rs485.py#L37-L94) that appears to try to implement some sort of software based rs485 support.