### PR TITLE
Add tip that values= will be modified to list[int].

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -514,6 +514,9 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
 
+        .. tip::
+            values= entries defined as bytes are silently converted to int !
+
         This function is used to write a block of contiguous registers
         (1 to approx. 120 registers) in a remote device.
         """
@@ -622,6 +625,9 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         :param slave: (optional) Modbus slave ID
         :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
+
+        .. tip::
+            values= entries defined as bytes are silently converted to int !
 
         This function performs a combination of one read operation and one
         write operation in a single MODBUS transaction. The write

--- a/pymodbus/pdu/pdu.py
+++ b/pymodbus/pdu/pdu.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import struct
 from abc import abstractmethod
-from collections.abc import Sequence
 from enum import Enum
 from typing import cast
 
@@ -26,7 +25,7 @@ class ModbusPDU:
             address: int = 0,
             count: int = 0,
             bits: list[bool] | None = None,
-            registers: Sequence[int | bytes] | None = None,
+            registers: list[int] | list[bytes] | list[bytes | int] | None = None,
             status: int = 1,
         ) -> None:
         """Initialize the base data for a modbus request."""

--- a/pymodbus/pdu/register_message.py
+++ b/pymodbus/pdu/register_message.py
@@ -149,9 +149,9 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
         await context.async_setValues(
             self.function_code, self.write_address, self.write_registers
         )
-        registers = await context.async_getValues(
+        registers = cast(list[int], await context.async_getValues(
             self.function_code, self.read_address, self.read_count
-        )
+        ))
         return ReadWriteMultipleRegistersResponse(registers=registers, slave_id=self.slave_id, transaction_id=self.transaction_id)
 
     def get_response_pdu_size(self) -> int:
@@ -197,7 +197,7 @@ class WriteSingleRegisterRequest(WriteSingleRegisterResponse):
         await context.async_setValues(
             self.function_code, self.address, self.registers
         )
-        values = await context.async_getValues(self.function_code, self.address, 1)
+        values = cast(list[int], await context.async_getValues(self.function_code, self.address, 1))
         return WriteSingleRegisterResponse(address=self.address, registers=values)
 
     def get_response_pdu_size(self) -> int:


### PR DESCRIPTION
Add tip that for write_register* that entries in the values= array will be converted silently to int !

Removed type Sequence from internal pdu methods.

Solves #2464, without sacrificing efficiency.