### PR TITLE
Restrict write_registers etc to list[int].

### DIFF
--- a/examples/client_async_calls.py
+++ b/examples/client_async_calls.py
@@ -165,10 +165,9 @@ async def async_write_registers_mypy(client: ModbusBaseClient) -> None:
     rr = await client.read_holding_registers(1, count=len(regs1), slave=SLAVE)
     assert not rr.isError()  # test that call was OK
 
-    regs2: list[bytes] = [b'\x01\x02', b'\x03\x04']
-    await client.write_registers(1, regs2, slave=SLAVE)
-    rr = await client.read_holding_registers(1, count=len(regs2), slave=SLAVE)
-    assert not rr.isError()  # test that call was OK
+    # regs2: list[bytes] = [b'\x01\x02', b'\x03\x04']
+    # await client.write_registers(1, regs2, slave=SLAVE)
+    # NOT ALLOWED
 
 
 async def async_handle_input_registers(client):

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import struct
-from collections.abc import Sequence
 from enum import Enum
 from typing import Generic, TypeVar
 
@@ -159,7 +158,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         pdu = pdu_bit.WriteSingleCoilRequest(address=address, bits=[value], slave_id=slave)
         return self.execute(no_response_expected, pdu)
 
-    def write_register(self, address: int, value: bytes | int, *, slave: int = 1, no_response_expected: bool = False) -> T:
+    def write_register(self, address: int, value: int, *, slave: int = 1, no_response_expected: bool = False) -> T:
         """Write register (code 0x06).
 
         :param address: Address to write to
@@ -502,7 +501,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
     def write_registers(
         self,
         address: int,
-        values: Sequence[int | bytes],
+        values: list[int],
         *,
         slave: int = 1,
         no_response_expected: bool = False
@@ -514,11 +513,6 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         :param slave: (optional) Modbus slave ID
         :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
-
-        .. tip::
-            values= parameter:
-            entries defined as bytes are silently converted to int !
-            only list[int], list[bytes] or list[bytes | int] are expected (others may work unsupported)
 
         This function is used to write a block of contiguous registers
         (1 to approx. 120 registers) in a remote device.
@@ -628,11 +622,6 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         :param slave: (optional) Modbus slave ID
         :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:
-
-        .. tip::
-            values= parameter:
-            entries defined as bytes are silently converted to int !
-            only list[int], list[bytes] or list[bytes | int] are expected (others may work unsupported)
 
         This function performs a combination of one read operation and one
         write operation in a single MODBUS transaction. The write

--- a/pymodbus/pdu/pdu.py
+++ b/pymodbus/pdu/pdu.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import asyncio
 import struct
 from abc import abstractmethod
-from collections.abc import Sequence
-from typing import cast
 
 from pymodbus.exceptions import NotImplementedException
 from pymodbus.logging import Log
@@ -25,7 +23,7 @@ class ModbusPDU:
             address: int = 0,
             count: int = 0,
             bits: list[bool] | None = None,
-            registers: Sequence[bytes | int] | None = None,
+            registers: list[int] | None = None,
             status: int = 1,
         ) -> None:
         """Initialize the base data for a modbus request."""
@@ -33,13 +31,8 @@ class ModbusPDU:
         self.transaction_id: int = transaction_id
         self.address: int = address
         self.bits: list[bool] = bits or []
-        if not registers:
-            registers = []
-        self.registers: list[int] = cast(list[int], registers)
-        for i, value in enumerate(registers):
-            if isinstance(value, bytes):
-                self.registers[i] = int.from_bytes(value, byteorder="big")
-        self.count: int = count or len(registers)
+        self.registers: list[int] = registers or []
+        self.count: int = count or len(self.registers)
         self.status: int = status
         self.fut: asyncio.Future
 

--- a/test/pdu/test_pdu.py
+++ b/test/pdu/test_pdu.py
@@ -183,10 +183,11 @@ class TestPdu:
     def test_pdu_register_as_byte(self):
         """Test validate functions."""
         registers =[b'ab', b'cd']
+        # NOT ALLOWED, NO conversion.
         req = reg_msg.ReadHoldingRegistersRequest(address=117, registers=registers, count=3)
         assert len(req.registers) == 2
-        assert req.registers[0] == 24930
-        assert req.registers[1] == 25444
+        assert req.registers[0] != 24930
+        assert req.registers[1] != 25444
 
     def test_pdu_validate_address(self):
         """Test validate functions."""


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Typing in python is really BAD !!

every developer would read this:
```
   values: list[int] | list[bytes]
```
as values can be either list[int] OR list[bytes], but mypy is stupid and requires values to be "list[int] | list[bytes]"

Using:
```
   values: Sequence[int | bytes]
```
solves this problem, but do NOT allow the array to be changed.

As a consequence of this, the API from now on only accept list[int], which are NOT modified !!

If an app wants to use bytes, it must be converted to int before calling. The API contains different from/to register conversions that can help if needed.
