### PR TITLE
Fix simulator with device_id in server config

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -157,6 +157,7 @@ class ModbusSimulatorServer:
         if "device_id" in server:
             # Designated ModBus unit address. Will only serve data if the address matches
             datastore = ModbusServerContext(slaves={int(server["device_id"]): self.datastore_context}, single=False)
+            del server["device_id"]
         else:
             # Will server any request regardless of addressing
             datastore = ModbusServerContext(slaves=self.datastore_context, single=True)


### PR DESCRIPTION
delete device_id from server config before creating modbus_server component. This should fix the error message "TypeError: ModbusTcpServer.__init__() got an unexpected keyword argument 'device_id'" as mentioned in issue #2470.

fixes #2470 
