### PR TITLE
Support providing framer type Enum or class

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -35,9 +35,11 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusPDU]]):
         """
         ModbusClientMixin.__init__(self)  # type: ignore[arg-type]
         self.comm_params = comm_params
+        if not isinstance(framer, type) or not issubclass(framer, FramerBase):
+            framer = FRAMER_NAME_TO_CLASS[FramerType(framer)]
         self.ctx = TransactionManager(
             comm_params,
-            FRAMER_NAME_TO_CLASS.get(framer, framer)(DecodePDU(False)),
+            framer(DecodePDU(False)),
             retries,
             False,
             trace_packet,
@@ -133,7 +135,9 @@ class ModbusBaseSyncClient(ModbusClientMixin[ModbusPDU]):
         self.slaves: list[int] = []
 
         # Common variables.
-        self.framer: FramerBase = FRAMER_NAME_TO_CLASS.get(framer, framer)(DecodePDU(False))
+        if not isinstance(framer, type) or not issubclass(framer, FramerBase):
+            framer = FRAMER_NAME_TO_CLASS[FramerType(framer)]
+        self.framer: FramerBase = framer(DecodePDU(False))
         self.transaction = TransactionManager(
             self.comm_params,
             self.framer,

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -22,7 +22,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusPDU]]):
 
     def __init__(
         self,
-        framer: FramerType,
+        framer: FramerType | type[FramerBase],
         retries: int,
         comm_params: CommParams,
         trace_packet: Callable[[bool, bytes], bytes] | None,
@@ -37,7 +37,7 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusPDU]]):
         self.comm_params = comm_params
         self.ctx = TransactionManager(
             comm_params,
-            (FRAMER_NAME_TO_CLASS[framer])(DecodePDU(False)),
+            FRAMER_NAME_TO_CLASS.get(framer, framer)(DecodePDU(False)),
             retries,
             False,
             trace_packet,
@@ -116,7 +116,7 @@ class ModbusBaseSyncClient(ModbusClientMixin[ModbusPDU]):
 
     def __init__(
         self,
-        framer: FramerType,
+        framer: FramerType | type[FramerBase],
         retries: int,
         comm_params: CommParams,
         trace_packet: Callable[[bool, bytes], bytes] | None,
@@ -133,7 +133,7 @@ class ModbusBaseSyncClient(ModbusClientMixin[ModbusPDU]):
         self.slaves: list[int] = []
 
         # Common variables.
-        self.framer: FramerBase = (FRAMER_NAME_TO_CLASS[framer])(DecodePDU(False))
+        self.framer: FramerBase = FRAMER_NAME_TO_CLASS.get(framer, framer)(DecodePDU(False))
         self.transaction = TransactionManager(
             self.comm_params,
             self.framer,

--- a/pymodbus/pdu/__init__.py
+++ b/pymodbus/pdu/__init__.py
@@ -2,7 +2,6 @@
 __all__ = [
     "DecodePDU",
     "ExceptionResponse",
-    "ExceptionResponse",
     "FileRecord",
     "ModbusPDU",
 ]

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -10,7 +10,7 @@ from contextlib import suppress
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.device import ModbusControlBlock, ModbusDeviceIdentification
 from pymodbus.exceptions import NoSuchSlaveException
-from pymodbus.framer import FRAMER_NAME_TO_CLASS, FramerType
+from pymodbus.framer import FRAMER_NAME_TO_CLASS, FramerType, FramerBase
 from pymodbus.logging import Log
 from pymodbus.pdu import DecodePDU, ModbusPDU
 from pymodbus.pdu.pdu import ExceptionResponse
@@ -201,7 +201,7 @@ class ModbusBaseServer(ModbusProtocol):
         ignore_missing_slaves: bool,
         broadcast_enable: bool,
         identity: ModbusDeviceIdentification | None,
-        framer: FramerType,
+        framer: FramerType | type[FramerBase],
         trace_packet: Callable[[bool, bytes], bytes] | None,
         trace_pdu: Callable[[bool, ModbusPDU], ModbusPDU] | None,
         trace_connect: Callable[[bool], None] | None,

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -223,8 +223,8 @@ class ModbusBaseServer(ModbusProtocol):
         self.handle_local_echo = False
         if isinstance(identity, ModbusDeviceIdentification):
             self.control.Identity.update(identity)
-
-        self.framer = FRAMER_NAME_TO_CLASS[framer]
+        # Support mapping of FramerType to a Framer class, or a Framer class
+        self.framer = FRAMER_NAME_TO_CLASS.get(framer, framer)
         self.serving: asyncio.Future = asyncio.Future()
 
     def callback_new_connection(self):

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -166,9 +166,10 @@ class ModbusServerRequestHandler(TransactionManager):
                 response = await request.update_datastore(context)
 
         except NoSuchSlaveException:
-            Log.error("requested slave does not exist: {}", request.dev_id)
             if self.server.ignore_missing_slaves:
+                Log.debug("ignored slave that does not exist: {}", request.slave_id)
                 return  # the client will simply timeout waiting for a response
+            Log.error("requested slave does not exist: {}", request.slave_id)
             response = ExceptionResponse(0x00, ExceptionResponse.GATEWAY_NO_RESPONSE)
         except Exception as exc:  # pylint: disable=broad-except
             Log.error(


### PR DESCRIPTION
Historically, one could create new Framer classes and supply them.  For example, to implement "evil" framers, to test sending various errors in Modbus.

This fix maintains support for supplying a FramerType Enum, and restores the ability to pass a Framer class.
