### PR TITLE
Raise exception on no response in async client.

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -151,9 +151,10 @@ class TransactionManager(ModbusProtocol):
                     f"ERROR: No response received of the last {self.accept_no_response_limit} request, CLOSING CONNECTION."
                 )
             self.count_no_responses += 1
-            Log.error(f"No response received after {self.retries} retries, continue with next request")
             self.response_future = asyncio.Future()
-            return None
+            txt = f"No response received after {self.retries} retries, continue with next request"
+            Log.error(txt)
+            raise ModbusIOException(txt)
 
     async def server_execute(self) -> tuple[ModbusPDU, int, Exception]:
         """Wait for request.

--- a/test/transaction/test_transaction.py
+++ b/test/transaction/test_transaction.py
@@ -161,7 +161,8 @@ class TestTransaction:
         elif scenario == 4: # wait receive,timeout, no_responses pass
             transact.comm_params.timeout_connect = 0.1
             transact.connection_lost = mock.Mock()
-            assert not await transact.execute(False, request)
+            with pytest.raises(ModbusIOException):
+                await transact.execute(False, request)
         else: # if scenario == 5: # response
             transact.comm_params.timeout_connect = 0.2
             transact.response_future.set_result(response)


### PR DESCRIPTION
This makes the async client behave the same as the sync client again.

Fixes #2500.