### PR TITLE
Fix asyncio.CancelledError on timeout

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -141,17 +141,17 @@ class TransactionManager(ModbusProtocol):
                         self.response_future, timeout=self.comm_params.timeout_connect
                     )
                     self.count_no_responses = 0
-                    self.response_future = asyncio.Future()
                     return response
                 except asyncio.exceptions.TimeoutError:
                     count_retries += 1
+                finally:
+                    self.response_future = asyncio.Future()
             if self.count_no_responses >= self.accept_no_response_limit:
                 self.connection_lost(asyncio.TimeoutError("Server not responding"))
                 raise ModbusIOException(
                     f"ERROR: No response received of the last {self.accept_no_response_limit} request, CLOSING CONNECTION."
                 )
             self.count_no_responses += 1
-            self.response_future = asyncio.Future()
             txt = f"No response received after {self.retries} retries, continue with next request"
             Log.error(txt)
             raise ModbusIOException(txt)

--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -178,7 +178,6 @@ class TransactionManager(ModbusProtocol):
         """Call when connection is succcesfull."""
         self.count_no_responses = 0
         self.next_tid = 0
-        self.response_future = asyncio.Future()
         self.trace_connect(True)
 
     def callback_disconnected(self, exc: Exception | None) -> None:


### PR DESCRIPTION
The change in #2501 causes constant cancelled errors for me, using the async serial client. I think this is the proper fix, but it should be tested before merging.

@alexis-care Would you be able to try this branch and see if it also fixes your issue?
