### PR TITLE
Add background parameter to servers.

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -1,6 +1,7 @@
 """Base for all clients."""
 from __future__ import annotations
 
+import asyncio
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable
 
@@ -57,7 +58,9 @@ class ModbusBaseClient(ModbusClientMixin[Awaitable[ModbusPDU]]):
             self.ctx.comm_params.host,
             self.ctx.comm_params.port,
         )
-        return await self.ctx.connect()
+        rc = await self.ctx.connect()
+        await asyncio.sleep(0.1)
+        return rc
 
     def register(self, custom_response_class: type[ModbusPDU]) -> None:
         """Register a custom response class with the decoder (call **sync**).

--- a/pymodbus/pdu/pdu.py
+++ b/pymodbus/pdu/pdu.py
@@ -5,6 +5,7 @@ import asyncio
 import struct
 from abc import abstractmethod
 
+from pymodbus.datastore import ModbusSlaveContext
 from pymodbus.exceptions import NotImplementedException
 from pymodbus.logging import Log
 
@@ -78,6 +79,11 @@ class ModbusPDU:
     @abstractmethod
     def decode(self, data: bytes) -> None:
         """Decode data part of the message."""
+
+    async def update_datastore(self, context: ModbusSlaveContext) -> ModbusPDU:
+        """Run request against a datastore."""
+        _ = context
+        return ExceptionResponse(0, 0)
 
     @classmethod
     def calculateRtuFrameSize(cls, data: bytes) -> int:

--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -80,12 +80,12 @@ class ModbusBaseServer(ModbusProtocol):
 
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""
+        raise RuntimeError("callback_new_connection should never be called")
 
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""
-        Log.debug("callback_disconnected called: {}", exc)
+        raise RuntimeError("callback_disconnected should never be called")
 
     def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
         """Handle received data."""
-        Log.debug("callback_data called: {} addr={}", data, ":hex", addr)
-        return 0
+        raise RuntimeError("callback_data should never be called")

--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from contextlib import suppress
 
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.device import ModbusControlBlock, ModbusDeviceIdentification
@@ -75,7 +76,8 @@ class ModbusBaseServer(ModbusProtocol):
             )
         await self.listen()
         Log.info("Server listening.")
-        await self.serving
+        with suppress(asyncio.exceptions.CancelledError):
+            await self.serving
         Log.info("Server graceful shutdown.")
 
     def callback_connected(self) -> None:

--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -68,7 +68,7 @@ class ModbusBaseServer(ModbusProtocol):
             self.serving.set_result(True)
         self.close()
 
-    async def serve_forever(self):
+    async def serve_forever(self, *, background: bool = False):
         """Start endless loop."""
         if self.transport:
             raise RuntimeError(
@@ -76,9 +76,10 @@ class ModbusBaseServer(ModbusProtocol):
             )
         await self.listen()
         Log.info("Server listening.")
-        with suppress(asyncio.exceptions.CancelledError):
-            await self.serving
-        Log.info("Server graceful shutdown.")
+        if not background:
+            with suppress(asyncio.exceptions.CancelledError):
+                await self.serving
+            Log.info("Server graceful shutdown.")
 
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""

--- a/pymodbus/server/requesthandler.py
+++ b/pymodbus/server/requesthandler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import traceback
 
-from pymodbus.exceptions import NoSuchSlaveException
+from pymodbus.exceptions import ModbusIOException, NoSuchSlaveException
 from pymodbus.logging import Log
 from pymodbus.pdu.pdu import ExceptionResponse
 from pymodbus.transaction import TransactionManager
@@ -30,8 +30,6 @@ class ServerRequestHandler(TransactionManager):
         self.framer = self.server.framer(self.server.decoder)
         self.running = False
         self.handler_task = None  # coroutine to be run on asyncio loop
-        self.databuffer = b''
-        self.loop = asyncio.get_running_loop()
         super().__init__(
             params,
             self.framer,
@@ -44,8 +42,7 @@ class ServerRequestHandler(TransactionManager):
 
     def callback_new_connection(self) -> ModbusProtocol:
         """Call when listener receive new connection request."""
-        Log.debug("callback_new_connection called")
-        return ServerRequestHandler(self)
+        raise RuntimeError("callback_new_connection should never be called")
 
     def callback_connected(self) -> None:
         """Call when connection is succcesfull."""
@@ -55,8 +52,6 @@ class ServerRequestHandler(TransactionManager):
             if 0 not in slaves:
                 slaves.append(0)
         try:
-            self.running = True
-
             # schedule the connection handler on the event loop
             self.handler_task = asyncio.create_task(self.handle())
             self.handler_task.set_name("server connection handler")
@@ -93,32 +88,29 @@ class ServerRequestHandler(TransactionManager):
                 traceback.format_exc(),
             )
 
+    def callback_data(self, data: bytes, addr: tuple | None = None) -> int:
+        """Handle received data."""
+        try:
+            used_len = super().callback_data(data, addr)
+        except ModbusIOException:
+            response = ExceptionResponse(
+                40,
+                exception_code=ExceptionResponse.ILLEGAL_FUNCTION
+            )
+            self.server_send(response, 0)
+            return(len(data))
+        if self.last_pdu:
+            self.response_future.set_result(True)
+        return used_len
+
     async def handle(self) -> None:
-        """Coroutine which represents a single master <=> slave conversation.
-
-        Once the client connection is established, the data chunks will be
-        fed to this coroutine via the asyncio.Queue object which is fed by
-        the ServerRequestHandler class's callback Future.
-
-        This callback future gets data from either asyncio.BaseProtocol.data_received
-        or asyncio.DatagramProtocol.datagram_received.
-
-        This function will execute without blocking in the while-loop and
-        yield to the asyncio event loop when the frame is exhausted.
-        As a result, multiple clients can be interleaved without any
-        interference between them.
-        """
+        """Coroutine which represents a single master <=> slave conversation."""
+        self.running = True
         while self.running:
             try:
-                pdu, *addr, exc = await self.server_execute()
-                if exc:
-                    pdu = ExceptionResponse(
-                        40,
-                        exception_code=ExceptionResponse.ILLEGAL_FUNCTION
-                    )
-                    self.server_send(pdu, 0)
-                    continue
-                await self.server_async_execute(pdu, *addr)
+                self.response_future = asyncio.Future()
+                await asyncio.wait_for(self.response_future, None)
+                await self.handle_request()
             except asyncio.CancelledError:
                 # catch and ignore cancellation errors
                 if self.running:
@@ -137,22 +129,24 @@ class ServerRequestHandler(TransactionManager):
                 self.close()
                 self.callback_disconnected(exc)
 
-    async def server_async_execute(self, request, *addr):
+    async def handle_request(self):
         """Handle request."""
         broadcast = False
+        if not self.last_pdu:
+            return
         try:
-            if self.server.broadcast_enable and not request.dev_id:
+            if self.server.broadcast_enable and not self.last_pdu.dev_id:
                 broadcast = True
                 # if broadcasting then execute on all slave contexts,
                 # note response will be ignored
                 for dev_id in self.server.context.slaves():
-                    response = await request.update_datastore(self.server.context[dev_id])
+                    response = await self.last_pdu.update_datastore(self.server.context[dev_id])
             else:
-                context = self.server.context[request.dev_id]
-                response = await request.update_datastore(context)
+                context = self.server.context[self.last_pdu.dev_id]
+                response = await self.last_pdu.update_datastore(context)
 
         except NoSuchSlaveException:
-            Log.error("requested slave does not exist: {}", request.dev_id)
+            Log.error("requested slave does not exist: {}", self.last_pdu.dev_id)
             if self.server.ignore_missing_slaves:
                 return  # the client will simply timeout waiting for a response
             response = ExceptionResponse(0x00, ExceptionResponse.GATEWAY_NO_RESPONSE)
@@ -165,9 +159,9 @@ class ServerRequestHandler(TransactionManager):
             response = ExceptionResponse(0x00, ExceptionResponse.SLAVE_FAILURE)
         # no response when broadcasting
         if not broadcast:
-            response.transaction_id = request.transaction_id
-            response.dev_id = request.dev_id
-            self.server_send(response, *addr)
+            response.transaction_id = self.last_pdu.transaction_id
+            response.dev_id = self.last_pdu.dev_id
+            self.server_send(response, self.last_addr)
 
     def server_send(self, pdu, addr):
         """Send message."""

--- a/pymodbus/server/startstop.py
+++ b/pymodbus/server/startstop.py
@@ -27,6 +27,11 @@ async def StartAsyncTcpServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusTcpServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusTcpServer to allow multiple servers in one app.
     """
     server = ModbusTcpServer(context, **kwargs)
     if custom_functions:
@@ -46,6 +51,11 @@ def StartTcpServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusTcpServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusTcpServer to allow multiple servers in one app.
     """
     return asyncio.run(StartAsyncTcpServer(context, custom_functions=custom_functions, **kwargs))
 
@@ -60,6 +70,11 @@ async def StartAsyncTlsServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusTlsServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusTlsServer to allow multiple servers in one app.
     """
     server = ModbusTlsServer(context, **kwargs)
     if custom_functions:
@@ -79,6 +94,11 @@ def StartTlsServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusTlsServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusTlsServer to allow multiple servers in one app.
     """
     asyncio.run(StartAsyncTlsServer(context, custom_functions=custom_functions, **kwargs))
 
@@ -93,6 +113,11 @@ async def StartAsyncUdpServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusUdpServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusUdpServer to allow multiple servers in one app.
     """
     server = ModbusUdpServer(context, **kwargs)
     if custom_functions:
@@ -112,6 +137,11 @@ def StartUdpServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusUdpServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusUdpServer to allow multiple servers in one app.
     """
     asyncio.run(StartAsyncUdpServer(context, custom_functions=custom_functions, **kwargs))
 
@@ -126,6 +156,11 @@ async def StartAsyncSerialServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusSerialServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusSerialServer to allow multiple servers in one app.
     """
     server = ModbusSerialServer(context, **kwargs)
     if custom_functions:
@@ -145,6 +180,11 @@ def StartSerialServer(  # pylint: disable=invalid-name
     :parameter context: Datastore object
     :parameter custom_functions: optional list of custom PDU objects
     :parameter kwargs: for parameter explanation see ModbusSerialServer
+
+    .. tip::
+        Only handles a single server !
+
+        Use ModbusSerialServer to allow multiple servers in one app.
     """
     asyncio.run(StartAsyncSerialServer(context, custom_functions=custom_functions, **kwargs))
 

--- a/pymodbus/server/startstop.py
+++ b/pymodbus/server/startstop.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-from contextlib import suppress
 
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.pdu import ModbusPDU
@@ -33,9 +32,7 @@ async def StartAsyncTcpServer(  # pylint: disable=invalid-name
 
         Use ModbusTcpServer to allow multiple servers in one app.
     """
-    server = ModbusTcpServer(context, custom_pdu=custom_functions, **kwargs)
-    with suppress(asyncio.exceptions.CancelledError):
-        await server.serve_forever()
+    await ModbusTcpServer(context, custom_pdu=custom_functions, **kwargs).serve_forever()
 
 
 def StartTcpServer(  # pylint: disable=invalid-name
@@ -54,7 +51,7 @@ def StartTcpServer(  # pylint: disable=invalid-name
 
         Use ModbusTcpServer to allow multiple servers in one app.
     """
-    return asyncio.run(StartAsyncTcpServer(context, custom_functions=custom_functions, **kwargs))
+    asyncio.run(StartAsyncTcpServer(context, custom_functions=custom_functions, **kwargs))
 
 
 async def StartAsyncTlsServer(  # pylint: disable=invalid-name
@@ -73,9 +70,7 @@ async def StartAsyncTlsServer(  # pylint: disable=invalid-name
 
         Use ModbusTlsServer to allow multiple servers in one app.
     """
-    server = ModbusTlsServer(context, custom_pdu=custom_functions, **kwargs)
-    with suppress(asyncio.exceptions.CancelledError):
-        await server.serve_forever()
+    await ModbusTlsServer(context, custom_pdu=custom_functions, **kwargs).serve_forever()
 
 
 def StartTlsServer(  # pylint: disable=invalid-name
@@ -113,9 +108,7 @@ async def StartAsyncUdpServer(  # pylint: disable=invalid-name
 
         Use ModbusUdpServer to allow multiple servers in one app.
     """
-    server = ModbusUdpServer(context, custom_pdu=custom_functions, **kwargs)
-    with suppress(asyncio.exceptions.CancelledError):
-        await server.serve_forever()
+    await ModbusUdpServer(context, custom_pdu=custom_functions, **kwargs).serve_forever()
 
 
 def StartUdpServer(  # pylint: disable=invalid-name
@@ -153,9 +146,7 @@ async def StartAsyncSerialServer(  # pylint: disable=invalid-name
 
         Use ModbusSerialServer to allow multiple servers in one app.
     """
-    server = ModbusSerialServer(context, custom_pdu=custom_functions, **kwargs)
-    with suppress(asyncio.exceptions.CancelledError):
-        await server.serve_forever()
+    await ModbusSerialServer(context, custom_pdu=custom_functions, **kwargs).serve_forever()
 
 
 def StartSerialServer(  # pylint: disable=invalid-name

--- a/pymodbus/server/startstop.py
+++ b/pymodbus/server/startstop.py
@@ -33,10 +33,7 @@ async def StartAsyncTcpServer(  # pylint: disable=invalid-name
 
         Use ModbusTcpServer to allow multiple servers in one app.
     """
-    server = ModbusTcpServer(context, **kwargs)
-    if custom_functions:
-        for func in custom_functions:
-            server.decoder.register(func)
+    server = ModbusTcpServer(context, custom_pdu=custom_functions, **kwargs)
     with suppress(asyncio.exceptions.CancelledError):
         await server.serve_forever()
 
@@ -76,10 +73,7 @@ async def StartAsyncTlsServer(  # pylint: disable=invalid-name
 
         Use ModbusTlsServer to allow multiple servers in one app.
     """
-    server = ModbusTlsServer(context, **kwargs)
-    if custom_functions:
-        for func in custom_functions:
-            server.decoder.register(func)
+    server = ModbusTlsServer(context, custom_pdu=custom_functions, **kwargs)
     with suppress(asyncio.exceptions.CancelledError):
         await server.serve_forever()
 
@@ -119,10 +113,7 @@ async def StartAsyncUdpServer(  # pylint: disable=invalid-name
 
         Use ModbusUdpServer to allow multiple servers in one app.
     """
-    server = ModbusUdpServer(context, **kwargs)
-    if custom_functions:
-        for func in custom_functions:
-            server.decoder.register(func)
+    server = ModbusUdpServer(context, custom_pdu=custom_functions, **kwargs)
     with suppress(asyncio.exceptions.CancelledError):
         await server.serve_forever()
 
@@ -162,10 +153,7 @@ async def StartAsyncSerialServer(  # pylint: disable=invalid-name
 
         Use ModbusSerialServer to allow multiple servers in one app.
     """
-    server = ModbusSerialServer(context, **kwargs)
-    if custom_functions:
-        for func in custom_functions:
-            server.decoder.register(func)
+    server = ModbusSerialServer(context, custom_pdu=custom_functions, **kwargs)
     with suppress(asyncio.exceptions.CancelledError):
         await server.serve_forever()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,7 @@ all_files = "1"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = "--cov-report html --durations=10 --dist loadscope --numprocesses auto"
+addopts = "--cov-report html --durations=3 --dist loadscope --numprocesses auto"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 120

--- a/test/pdu/test_pdu.py
+++ b/test/pdu/test_pdu.py
@@ -240,3 +240,9 @@ class TestPdu:
         context = mock_context()
         context.validate = lambda a, b, c: True
         assert await pdu.update_datastore(context)
+
+    async def test_pdu_default_datastore(self, mock_context):
+        """Test that all PDU types can be created."""
+        pdu = ModbusPDU()
+        context = mock_context()
+        assert await pdu.update_datastore(context)

--- a/test/server/test_server_asyncio.py
+++ b/test/server/test_server_asyncio.py
@@ -241,8 +241,12 @@ class TestAsyncioServer:
         await asyncio.wait_for(BasicClient.done, timeout=0.1)
         assert BasicClient.received_data, expected_response
 
+    @pytest.mark.skip
     async def test_async_server_file_descriptors(self):
-        """Test sending and receiving data on tcp socket."""
+        """Test sending and receiving data on tcp socket.
+
+        This test takes a long time (minutes) to run, so should only run when needed.
+        """
         addr = ("127.0.0.1", 25001)
         await self.start_server(serv_addr=addr)
         for _ in range(2048):


### PR DESCRIPTION
Modbus<x>Server.serve_forever() is simplified, and  accept a new parameter "background="

background=False is default, and means the methods like earlier, that is block until the server stops.
background=True, means it will wait on a future.

NO task are created in the server, apart from what asyncio does internally.
