### PR TITLE
Added keyword arguments to remote.py

### DIFF
--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -74,42 +74,42 @@ class RemoteSlaveContext(ModbusBaseSlaveContext):
             params["slave"] = self.slave
         self.__get_callbacks = {
             "d": lambda a, c: self._client.read_discrete_inputs(
-                a, c, **params
+                address=a, count=c, **params
             ),
             "c": lambda a, c: self._client.read_coils(
-                a, c, **params
+                address=a, count=c, **params
             ),
             "h": lambda a, c: self._client.read_holding_registers(
-                a, c, **params
+                address=a, count=c, **params
             ),
             "i": lambda a, c: self._client.read_input_registers(
-                a, c, **params
+                address=a, count=c, **params
             ),
         }
         self.__set_callbacks = {
             "d5": lambda a, v: self._client.write_coil(
-                a, v, **params
+                address=a, value=v, **params
             ),
             "d15": lambda a, v: self._client.write_coils(
-                a, v, **params
+                address=a, values=v, **params
             ),
             "c5": lambda a, v: self._client.write_coil(
-                a, v, **params
+                address=a, value=v, **params
             ),
             "c15": lambda a, v: self._client.write_coils(
-                a, v, **params
+                address=a, values=v, **params
             ),
             "h6": lambda a, v: self._client.write_register(
-                a, v, **params
+                address=a, value=v, **params
             ),
             "h16": lambda a, v: self._client.write_registers(
-                a, v, **params
+                address=a, values=v, **params
             ),
             "i6": lambda a, v: self._client.write_register(
-                a, v, **params
+                address=a, value=v, **params
             ),
             "i16": lambda a, v: self._client.write_registers(
-                a, v, **params
+                address=a, values=v, **params
             ),
         }
         self._write_fc = (0x05, 0x06, 0x0F, 0x10)


### PR DESCRIPTION
Got the following error:
TypeError: ModbusClientMixin.read_holding_registers() takes 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given

Fixed it by adding keywords to callbacks in __build_mapping(self)

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
