### PR TITLE
Typo arround `no_response_expected`

### DIFF
--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -199,12 +199,12 @@ The logical devices represented by the device is addressed with the :mod:`slave=
 With **Serial**, the comm port is defined when creating the object.
 The physical devices are addressed with the :mod:`slave=` parameter.
 
-:mod:`slave=0` is defined as broadcast in the modbus standard, but pymodbus treats is a normal device.
+:mod:`slave=0` is defined as broadcast in the modbus standard, but pymodbus treats it as a normal device.
 
 If an application is expecting multiple responses to a broadcast request, it must call :mod:`client.execute` and deal with the responses.
 
 If no response is expected to a request, the :mod:`no_response_expected=True` argument can be used
-in the normal API calls, this will cause the call to return imidiatble with :mod:`None`
+in the normal API calls, this will cause the call to return immediately with :mod:`None`.
 
 
 Client response handling
@@ -224,7 +224,7 @@ The application should evaluate the result generically::
         raise ModbusException(txt)
 
 :mod:`except ModbusException as exc:` happens generally when pymodbus experiences an internal error.
-There are a few situation where a unexpected response from a device can cause an exception.
+There are a few situation where an unexpected response from a device can cause an exception.
 
 :mod:`rr.isError()` is set whenever the device reports a problem.
 
@@ -257,7 +257,7 @@ There are a client class for each type of communication and for asynchronous/syn
 
 Client common
 ^^^^^^^^^^^^^
-Some methods are common to all client:
+Some methods are common to all clients:
 
 .. autoclass:: pymodbus.client.base.ModbusBaseClient
     :members:
@@ -323,7 +323,7 @@ Modbus calls
 
 Pymodbus makes all standard modbus requests/responses available as simple calls.
 
-Using Modbus<transport>Client.register() custom messagees can be added to pymodbus,
+Using Modbus<transport>Client.register() custom messages can be added to pymodbus,
 and handled automatically.
 
 .. autoclass:: pymodbus.client.mixin.ModbusClientMixin

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -37,10 +37,10 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
     Advanced modbus message call::
 
         request = ReadCoilsRequest(1,10)
-        response = client.execute(no_response_expected=False, request=request)
+        response = client.execute(False, request)
         # or
         request = ReadCoilsRequest(1,10)
-        response = await client.execute(no_response_expected=False, request=request)
+        response = await client.execute(False, request)
 
     .. tip::
         All methods can be used directly (synchronous) or

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -37,10 +37,10 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
     Advanced modbus message call::
 
         request = ReadCoilsRequest(1,10)
-        response = client.execute(request)
+        response = client.execute(no_response_expected=False, request=request)
         # or
         request = ReadCoilsRequest(1,10)
-        response = await client.execute(request)
+        response = await client.execute(no_response_expected=False, request=request)
 
     .. tip::
         All methods can be used directly (synchronous) or
@@ -51,7 +51,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         """Initialize."""
 
     @abstractmethod
-    def execute(self,  no_response_expected: bool, request: ModbusPDU,) -> T:
+    def execute(self, no_response_expected: bool, request: ModbusPDU) -> T:
         """Execute request."""
 
     def read_coils(self, address: int, *, count: int = 1, slave: int = 1, no_response_expected: bool = False) -> T:


### PR DESCRIPTION
Documentation typo and advanced modbus message call example.
No breaking change, only cosmetic.
