### PR TITLE
Flush recv_buffer before each transaction write.

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -137,6 +137,7 @@ class TransactionManager(ModbusProtocol):
             request.transaction_id = self.getNextTID()
             count_retries = 0
             while count_retries <= self.retries:
+                self.recv_buffer = b""
                 self.response_future = asyncio.Future()
                 self.pdu_send(request)
                 if no_response_expected:


### PR DESCRIPTION
Ensure we don't have any non-relevant data in the buffer.

Haven't tested yet but I think this is the expected behavior based on [this](https://github.com/pymodbus-dev/pymodbus/issues/2580#issuecomment-2675297181) comment.