### PR TITLE
Don't set_result on completed futures.

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -195,7 +195,10 @@ class TransactionManager(ModbusProtocol):
                     raise ModbusIOException(
                         f"ERROR: request ask for id={self.request_dev_id} but got id={pdu.dev_id}, CLOSING CONNECTION."
                     )
-                self.response_future.set_result(self.last_pdu)
+                if self.response_future.done():
+                    Log.warning("received unexpected pdu: {}", pdu, ":str")
+                else:
+                    self.response_future.set_result(self.last_pdu)
         return used_len
 
     def getNextTID(self) -> int:


### PR DESCRIPTION
We need to guard self.response_future.set_result with a `done()` check to prevent `asyncio.exceptions.InvalidStateError: invalid state` errors.

Similar to #2581 I think we also need to flush the `recv_buffer` if the transaction is cancelled by the caller(say by the caller executing a transaction inside of another `asyncio.wait_for` that times out before the `asyncio.wait_for` inside of the `execute` call), in this case however we should re-raise the exception after the flush so that no retries are attempted.

Since `self.response_future` is cancelled in this case we should also guard the `self.response_future.set_result` call.

Should hopefully fix #2580 in combination with #2581.

fixes #2580