### PR TITLE
Ensure CancelledError is re-raised properly

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -155,7 +155,8 @@ class TransactionManager(ModbusProtocol):
                 except asyncio.exceptions.TimeoutError:
                     count_retries += 1
                 except asyncio.exceptions.CancelledError as exc:
-                    raise ModbusIOException("Request cancelled outside pymodbus.") from exc
+                    exc.__context__ = ModbusIOException("Request cancelled outside pymodbus.")
+                    raise
             if self.count_until_disconnect < 0:
                 self.connection_lost(asyncio.TimeoutError("Server not responding"))
                 raise ModbusIOException(


### PR DESCRIPTION
Python's asyncio cancellation propagation requires `CancelledError` to be re-raised by any exception handlers catching it.

I'm pretty sure catching and replacing a `CancelledError` with a `ModbusIOException` is not correct as python's cancellation mechanism requires the `CancelledError` to propagate back to the cancellation initiator, instead what we could do is attach the `ModbusIOException` as exception context to the `CancelledError`.

Alternatively we could just remove this exception handler entirely as I don't think it's all that important to catch the `CancelledError` here unless we actually need to do some sort of cleanup operation.

Once pymodbus requires a minimum python version of 3.11 we could alternatively raise an `ExceptionGroup` with both the `CancelledError` and `ModbusIOException` in this exception handler.

Python 3.11+ `ExceptionGroup` syntax:
```python
except asyncio.exceptions.CancelledError as exc:
    raise ExceptionGroup("Request cancelled", [exc, ModbusIOException("Request cancelled outside pymodbus.")])
```