### PR TITLE
Refactor reconnect_task so that asyncio.CancelledError is not suppressed

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -468,9 +468,8 @@ class ModbusProtocol(asyncio.BaseProtocol):
             Log.debug("Wait 1s before reopening listener.")
             await asyncio.sleep(1)
             await self.listen()
-        except asyncio.CancelledError:
-            pass
-        self.reconnect_task = None
+        finally:
+            self.reconnect_task = None
 
     async def do_reconnect(self) -> None:
         """Handle reconnect as a task."""
@@ -490,8 +489,10 @@ class ModbusProtocol(asyncio.BaseProtocol):
                     self.comm_params.reconnect_delay_max,
                 )
         except asyncio.CancelledError:
-            pass
-        self.reconnect_task = None
+            self.reconnect_delay_current = self.comm_params.reconnect_delay or 0.0
+            raise
+        finally:
+            self.reconnect_task = None
 
     # ----------------- #
     # The magic methods #

--- a/test/transport/test_protocol.py
+++ b/test/transport/test_protocol.py
@@ -305,7 +305,8 @@ class TestTransportProtocol2:
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay * 2
         assert not client.reconnect_task
         client.connect.side_effect = asyncio.CancelledError("stop loop")
-        await client.do_reconnect()
+        with pytest.raises(asyncio.CancelledError):
+            await client.do_reconnect()
         assert client.reconnect_delay_current == client.comm_params.reconnect_delay
         assert not client.reconnect_task
 


### PR DESCRIPTION
Suppressing task cancellation in the reconnect_task is not necessary here and is likely to cause issues with application shutdown.