### PR TITLE
Flush the send buffer before each send

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -137,6 +137,8 @@ class TransactionManager(ModbusProtocol):
             request.transaction_id = self.getNextTID()
             count_retries = 0
             while count_retries <= self.retries:
+                if flush := getattr(self.transport, 'flush', None):
+                    flush()
                 self.recv_buffer = b""
                 self.response_future = asyncio.Future()
                 self.pdu_send(request)


### PR DESCRIPTION
We need to ensure the send buffer is flushed before calling `pdu_send` based on [this](https://github.com/pymodbus-dev/pymodbus/pull/2584#issuecomment-2683017353) comment.