### PR TITLE
Python 3.9 is EOL, not supported actively.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.9', '3.10', '3.11', '3.12', "3.13.0"]
+        python: ['3.10', '3.11', '3.12', "3.13.0"]
         include:
-          - python: '3.9'
+          - python: '3.10'
             run_lint: true
           - python: '3.13.0'
             run_doc: true

--- a/API_changes.rst
+++ b/API_changes.rst
@@ -2,6 +2,13 @@ API changes
 ===========
 Versions (X.Y.Z) where Z > 0 e.g. 3.0.1 do NOT have API changes!
 
+-----------------
+API changes 3.9.0
+-----------------
+- Python 3.9 is reaching end of life, and no longer supported.
+  Depending on the usage the code might still work
+
+-----------------
 API changes 3.8.0
 -----------------
 - ModbusSlaveContext, removed zero_mode parameter.

--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,9 @@ Common features
 * support all standard frames: socket, rtu, rtu-over-tcp, tcp and ascii
 * does not have third party dependencies, apart from pyserial (optional)
 * very lightweight project
-* requires Python >= 3.9
+* requires Python >= 3.10
 * thorough test suite, that test all corners of the library
-* automatically tested on Windows, Linux and MacOS combined with python 3.9 - 3.13
+* automatically tested on Windows, Linux and MacOS combined with python 3.10 - 3.13
 * strongly typed API (py.typed present)
 
 The modbus protocol specification: Modbus_Application_Protocol_V1_1b3.pdf can be found on
@@ -297,7 +297,7 @@ There are 2 bigger projects ongoing:
 
 Development instructions
 ------------------------
-The current code base is compatible with python >= 3.9.
+The current code base is compatible with python >= 3.10.
 
 Here are some of the common commands to perform a range of activities::
 


### PR DESCRIPTION
Python 3.9 ist at End Of Life, October 2025 it will no longer receive security updates, and are thus not supported at all.

Please see:
https://endoflife.date/python

Currently all of the code base with exception of the new SimData datastore works with python 3.9, but we no longer test with python 3.9.
