### PR TITLE
Simplify ruff config

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -219,7 +219,7 @@ class Setup:
     def handle_setup_section(self):
         """Load setup section."""
         layout = Label.try_get(Label.setup, self.config)
-        self.runtime.fc_offset = {key: 0 for key in range(25)}
+        self.runtime.fc_offset = dict.fromkeys(range(25), 0)
         size_co = Label.try_get(Label.co_size, layout)
         size_di = Label.try_get(Label.di_size, layout)
         size_hr = Label.try_get(Label.hr_size, layout)

--- a/pymodbus/pdu/device.py
+++ b/pymodbus/pdu/device.py
@@ -367,7 +367,7 @@ class ModbusCountersHandler:
     .. note:: I threw the event counter in here for convenience
     """
 
-    __data = {i: 0x0000 for i in range(9)}
+    __data = dict.fromkeys(range(9), 0x00)
     __names = [
         "BusMessage",
         "BusCommunicationError",
@@ -401,7 +401,7 @@ class ModbusCountersHandler:
 
     def reset(self):
         """Clear all of the system counters."""
-        self.__data = {i: 0x0000 for i in range(9)}
+        self.__data = dict.fromkeys(range(9), 0x00)
 
     def summary(self):
         """Return a summary of the counters current status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,11 +255,8 @@ skip = "./build,./doc/source/_static,venv,.venv,.git,htmlcov,CHANGELOG.rst,.mypy
 ignore-words-list = "asend"
 
 [tool.ruff]
-target-version="py38"
-exclude = [
-    "venv",
-    ".venv",
-    ".git",
+target-version="py39"
+extend-exclude = [
     "build",
     "doc",
     "contrib"


### PR DESCRIPTION
Use `extend-exclude` instead of `exclude` to take advantage of the default exclusions.
