### PR TITLE
Correction  : default argument of ModbusDeviceContext.__init__ was creating shared ModbusSequentialDataBlock between instances

### DIFF
--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -83,10 +83,10 @@ class ModbusDeviceContext(ModbusBaseDeviceContext):
     """
 
     def __init__(self, *_args,
-                    di: ModbusSequentialDataBlock = None,
-                    co: ModbusSequentialDataBlock = None,
-                    ir: ModbusSequentialDataBlock = None,
-                    hr: ModbusSequentialDataBlock = None,
+                    di: ModbusSequentialDataBlock | None = None,
+                    co: ModbusSequentialDataBlock | None = None,
+                    ir: ModbusSequentialDataBlock | None = None,
+                    hr: ModbusSequentialDataBlock | None = None,
                 ):
         """Initialize the datastores."""
         self.store = {}

--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -83,17 +83,17 @@ class ModbusDeviceContext(ModbusBaseDeviceContext):
     """
 
     def __init__(self, *_args,
-                    di=ModbusSequentialDataBlock.create(),
-                    co=ModbusSequentialDataBlock.create(),
-                    ir=ModbusSequentialDataBlock.create(),
-                    hr=ModbusSequentialDataBlock.create(),
+                    di: ModbusSequentialDataBlock = None,
+                    co: ModbusSequentialDataBlock = None,
+                    ir: ModbusSequentialDataBlock = None,
+                    hr: ModbusSequentialDataBlock = None,
                 ):
         """Initialize the datastores."""
         self.store = {}
-        self.store["d"] = di
-        self.store["c"] = co
-        self.store["i"] = ir
-        self.store["h"] = hr
+        self.store["d"] = di or ModbusSequentialDataBlock.create()
+        self.store["c"] = co or ModbusSequentialDataBlock.create()
+        self.store["i"] = ir or ModbusSequentialDataBlock.create()
+        self.store["h"] = hr or ModbusSequentialDataBlock.create()
 
     def __str__(self):
         """Return a string representation of the context.

--- a/test/server/test_server_context.py
+++ b/test/server/test_server_context.py
@@ -99,3 +99,15 @@ class TestServerMultipleContext:
         for dev_id, device in iter(devices.items()):
             actual = self.context[dev_id]
             assert device == actual
+
+    def test_edit_values(self):
+        """Test setValues and getValues in multiple device contexts."""
+        self.devices[0].setValues(fc_as_hex=3, address=1, values = [1,2,3])
+
+        for fc_as_hex in range(1,5):
+            if fc_as_hex == 3:
+                assert self.devices[0].getValues(fc_as_hex=fc_as_hex, address=1, count=3) == [1,2,3]
+            else:
+                assert self.devices[0].getValues(fc_as_hex=fc_as_hex, address=1, count=3) == [0,0,0]
+        for id in range(1,10):
+            assert self.devices[id].getValues(fc_as_hex=3, address=1, count=3) == [0,0,0]


### PR DESCRIPTION
PR for issue #2621 
`ModbusSlaveContext.__init__` was using default argument that are mutable, creating shared instance bug when using multiple ModbusSlaveContext

Adding a test that is failling in previous version of the code