### PR TITLE
Correct bit handling internally and API.

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -14,8 +14,7 @@ import pymodbus.pdu.other_message as pdu_other_msg
 import pymodbus.pdu.register_message as pdu_reg
 from pymodbus.constants import ModbusStatus
 from pymodbus.exceptions import ModbusException
-from pymodbus.pdu import ModbusPDU
-from pymodbus.utilities import pack_bitstring, unpack_bitstring
+from pymodbus.pdu.pdu import ModbusPDU, pack_bitstring, unpack_bitstring
 
 
 T = TypeVar("T", covariant=False)

--- a/pymodbus/pdu/bit_message.py
+++ b/pymodbus/pdu/bit_message.py
@@ -5,8 +5,7 @@ from typing import cast
 
 from pymodbus.constants import ModbusStatus
 from pymodbus.datastore import ModbusDeviceContext
-from pymodbus.pdu.pdu import ModbusPDU
-from pymodbus.utilities import pack_bitstring, unpack_bitstring
+from .pdu import ModbusPDU, pack_bitstring, unpack_bitstring
 
 
 class ReadCoilsRequest(ModbusPDU):

--- a/pymodbus/pdu/bit_message.py
+++ b/pymodbus/pdu/bit_message.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from pymodbus.constants import ModbusStatus
 from pymodbus.datastore import ModbusDeviceContext
+
 from .pdu import ModbusPDU, pack_bitstring, unpack_bitstring
 
 

--- a/pymodbus/pdu/diag_message.py
+++ b/pymodbus/pdu/diag_message.py
@@ -7,8 +7,7 @@ from typing import cast
 from pymodbus.constants import ModbusPlusOperation
 from pymodbus.datastore import ModbusDeviceContext
 from pymodbus.pdu.device import ModbusControlBlock
-from pymodbus.pdu.pdu import ModbusPDU
-from pymodbus.utilities import pack_bitstring
+from .pdu import ModbusPDU, pack_bitstring
 
 
 _MCB = ModbusControlBlock()

--- a/pymodbus/pdu/diag_message.py
+++ b/pymodbus/pdu/diag_message.py
@@ -7,6 +7,7 @@ from typing import cast
 from pymodbus.constants import ModbusPlusOperation
 from pymodbus.datastore import ModbusDeviceContext
 from pymodbus.pdu.device import ModbusControlBlock
+
 from .pdu import ModbusPDU, pack_bitstring
 
 

--- a/pymodbus/pdu/events.py
+++ b/pymodbus/pdu/events.py
@@ -8,6 +8,7 @@ can be any one of four types. The type is defined by bit 7
 from abc import ABC, abstractmethod
 
 from pymodbus.exceptions import ParameterException
+
 from .pdu import pack_bitstring, unpack_bitstring
 
 

--- a/pymodbus/pdu/events.py
+++ b/pymodbus/pdu/events.py
@@ -8,7 +8,7 @@ can be any one of four types. The type is defined by bit 7
 from abc import ABC, abstractmethod
 
 from pymodbus.exceptions import ParameterException
-from pymodbus.utilities import pack_bitstring, unpack_bitstring
+from .pdu import pack_bitstring, unpack_bitstring
 
 
 class ModbusEvent(ABC):

--- a/pymodbus/utilities.py
+++ b/pymodbus/utilities.py
@@ -45,56 +45,6 @@ def dict_property(store, index):
 
 
 # --------------------------------------------------------------------------- #
-# Bit packing functions
-# --------------------------------------------------------------------------- #
-def pack_bitstring(bits: list[bool]) -> bytes:
-    """Create a bytestring out of a list of bits.
-
-    :param bits: A list of bits
-
-    example::
-
-        bits   = [False, True, False, True]
-        result = pack_bitstring(bits)
-    """
-    ret = b""
-    i = packed = 0
-    for bit in bits:
-        if bit:
-            packed += 128
-        i += 1
-        if i == 8:
-            ret += struct.pack(">B", packed)
-            i = packed = 0
-        else:
-            packed >>= 1
-    if 0 < i < 8:
-        packed >>= 7 - i
-        ret += struct.pack(">B", packed)
-    return ret
-
-
-def unpack_bitstring(data: bytes) -> list[bool]:
-    """Create bit list out of a bytestring.
-
-    :param data: The modbus data packet to decode
-
-    example::
-
-        bytes  = "bytes to decode"
-        result = unpack_bitstring(bytes)
-    """
-    byte_count = len(data)
-    bits = []
-    for byte in range(byte_count):
-        value = int(data[byte])
-        for _ in range(8):
-            bits.append((value & 1) == 1)
-            value >>= 1
-    return bits
-
-
-# --------------------------------------------------------------------------- #
 # Error Detection Functions
 # --------------------------------------------------------------------------- #
 

--- a/pymodbus/utilities.py
+++ b/pymodbus/utilities.py
@@ -5,8 +5,8 @@ data computing checksums, and decode checksums.
 """
 from __future__ import annotations
 
+
 # pylint: disable=missing-type-doc
-import struct
 
 
 def dict_property(store, index):

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -138,32 +138,50 @@ class TestMixin:
             ),
             (
                 ModbusClientMixin.DATATYPE.BITS,
-                [True],
-                [256],
+                [True] + [False] * 15,
+                [1],  # 0x00 0x01
                 None,
             ),
             (
                 ModbusClientMixin.DATATYPE.BITS,
-                [True, False, True],
-                [1280],
+                [False] * 8 + [True] + [False] * 7,
+                [256],  # 0x01 0x00
                 None,
             ),
             (
                 ModbusClientMixin.DATATYPE.BITS,
-                [True, False, True] + [False] * 5 + [True],
-                [1281],
+                [False] * 15 + [True],
+                [32768],  # 0x80 0x00
                 None,
             ),
             (
                 ModbusClientMixin.DATATYPE.BITS,
-                [True, False, True] + [False] * 5 + [True] + [False] * 6 + [True],
-                [1409],
+                [True] + [False] * 14 + [True],
+                [32769],  # 0x80 0x01
                 None,
             ),
             (
                 ModbusClientMixin.DATATYPE.BITS,
-                [True, False, True] + [False] * 5 + [True] + [False] * 6 + [True] * 2,
-                [1409, 256],
+                [False] * 8 + [True, False, True] + [False] * 5,
+                [1280],  # 0x05 0x00
+                None,
+            ),
+            (
+                ModbusClientMixin.DATATYPE.BITS,
+                [True] + [False] * 7 + [True, False, True] + [False] * 5,
+                [1281],  # 0x05 0x01
+                None,
+            ),
+            (
+                ModbusClientMixin.DATATYPE.BITS,
+                [True] + [False] * 6 + [True, True, False, True] + [False] * 5,
+                [1409], # 0x05 0x81
+                None,
+            ),
+            (
+                ModbusClientMixin.DATATYPE.BITS,
+                [False] * 8 + [True] + [False] * 7 + [True] + [False] * 6 + [True, True, False, True] + [False] * 5,
+                [1409, 256],  # 92340480 = 0x05 0x81 0x01 0x00
                 None,
             ),
         ],
@@ -181,9 +199,6 @@ class TestMixin:
         result = ModbusClientMixin.convert_from_registers(registers, datatype, **kwargs)
         if datatype == ModbusClientMixin.DATATYPE.FLOAT32:
             result = round(result, 6)
-        if datatype == ModbusClientMixin.DATATYPE.BITS:
-            if (missing := len(value) % 16):
-                value = value + [False] * (16 - missing)
         assert result == value
 
     @pytest.mark.parametrize(

--- a/test/not_updated/test_utilities.py
+++ b/test/not_updated/test_utilities.py
@@ -1,8 +1,6 @@
 """Test utilities."""
 import struct
 
-import pytest
-
 from pymodbus.utilities import dict_property
 
 

--- a/test/not_updated/test_utilities.py
+++ b/test/not_updated/test_utilities.py
@@ -3,11 +3,7 @@ import struct
 
 import pytest
 
-from pymodbus.utilities import (
-    dict_property,
-    pack_bitstring,
-    unpack_bitstring,
-)
+from pymodbus.utilities import dict_property
 
 
 _test_master = {4: "d"}
@@ -64,18 +60,3 @@ class TestUtility:
         assert result.s_1 == "x"
         assert result.s_2 == "x"
         assert result.g_1 == "x"
-
-    @pytest.mark.parametrize(
-            ("bytestream", "bitlist"),
-            [
-                (b"\x55", [True, False, True, False, True, False, True, False]),
-                (b"\x80", [False] * 7 + [True]),
-                (b"\x01", [True] + [False] * 7),
-                (b"\x80\x00", [False] * 7 + [True] + [False] * 8),
-                (b"\x01\x00", [True] + [False] * 15),
-            ]
-    )
-    def test_bit_packing(self, bytestream, bitlist):
-        """Test all string <=> bit packing functions."""
-        assert pack_bitstring(bitlist) == bytestream
-        assert unpack_bitstring(bytestream) == bitlist

--- a/test/pdu/test_bit.py
+++ b/test/pdu/test_bit.py
@@ -12,8 +12,6 @@ class TestModbusBitMessage:
             data = [True] * i
             pdu = bit_msg.ReadCoilsResponse(bits=data)
             pdu.decode(pdu.encode())
-            if i % 8:
-                data.extend([False] * (8 - (i % 8)))
             assert pdu.bits == data
 
     def test_bit_read_base_requests(self):

--- a/test/pdu/test_pdu.py
+++ b/test/pdu/test_pdu.py
@@ -13,6 +13,10 @@ from pymodbus.pdu import (
     ExceptionResponse,
     ModbusPDU,
 )
+from pymodbus.pdu.pdu import (
+    pack_bitstring,
+    unpack_bitstring
+)
 
 
 class TestPdu:
@@ -250,3 +254,44 @@ class TestPdu:
         pdu = ModbusPDU()
         context = mock_context()
         assert await pdu.update_datastore(context)
+
+    @pytest.mark.parametrize(
+        ("bytestream", "bitlist"),
+        [
+            (b"\x00\x01", [True] + [False] * 15),
+            (b"\x01\x00", [False] * 8 + [True] + [False] * 7),
+            (b"\x80\x00", [False] * 15 + [True]),
+            (b"\x80\x01", [True] + [False] * 14 + [True]),
+            (b"\x05\x00", [False] * 8 + [True, False, True] + [False] * 5),
+            (b"\x05\x01", [True] + [False] * 7 + [True, False, True] + [False] * 5),
+            (b"\x05\x81", [True] + [False] * 6 + [True, True, False, True] + [False] * 5),
+            (b"\x05\x81\x01\x00", [False] * 8 + [True] + [False] * 7 + [True] + [False] * 6 + [True, True, False, True] + [False] * 5),
+
+            (b"\x00\x01", [True]),
+            (b"\x01\x00", [False] * 8 + [True]),
+            (b"\x05\x00", [False] * 8 + [True, False, True]),
+            (b"\x05\x01", [True] + [False] * 7 + [True, False, True]),
+            (b"\x05\x81", [True] + [False] * 6 + [True, True, False, True]),
+            (b"\x05\x81\x01\x00", [False] * 8 + [True] + [False] * 7 + [True] + [False] * 6 + [True, True, False, True]),
+        ],
+    )
+    def test_bit_packing(self, bytestream, bitlist):
+        """Test all string <=> bit packing functions."""
+        assert pack_bitstring(bitlist) == bytestream
+
+    @pytest.mark.parametrize(
+        ("bytestream", "bitlist"),
+        [
+            (b"\x00\x01", [True] + [False] * 15),
+            (b"\x01\x00", [False] * 8 + [True] + [False] * 7),
+            (b"\x80\x00", [False] * 15 + [True]),
+            (b"\x80\x01", [True] + [False] * 14 + [True]),
+            (b"\x05\x00", [False] * 8 + [True, False, True] + [False] * 5),
+            (b"\x05\x01", [True] + [False] * 7 + [True, False, True] + [False] * 5),
+            (b"\x05\x81", [True] + [False] * 6 + [True, True, False, True] + [False] * 5),
+            (b"\x05\x81\x01\x00", [False] * 8 + [True] + [False] * 7 + [True] + [False] * 6 + [True, True, False, True] + [False] * 5),
+        ],
+    )
+    def test_bit_unpacking(self, bytestream, bitlist):
+        """Test all string <=> bit packing functions."""
+        assert unpack_bitstring(bytestream) == bitlist


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Since at least pymodbus version 2.x, e.g. read_coils have returned bit coils in wrong order.

Thanks to #2623, the problem was identified and is not solved.

Even though this PR is technically not a breaking change, it will be released as such, due to the severity of the bug.


