### PR TITLE
Don't bool-test explicit datastores

### DIFF
--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -90,10 +90,10 @@ class ModbusDeviceContext(ModbusBaseDeviceContext):
                 ):
         """Initialize the datastores."""
         self.store = {}
-        self.store["d"] = di or ModbusSequentialDataBlock.create()
-        self.store["c"] = co or ModbusSequentialDataBlock.create()
-        self.store["i"] = ir or ModbusSequentialDataBlock.create()
-        self.store["h"] = hr or ModbusSequentialDataBlock.create()
+        self.store["d"] = di if di is not None else ModbusSequentialDataBlock.create()
+        self.store["c"] = co if di is not None else ModbusSequentialDataBlock.create()
+        self.store["i"] = ir if di is not None else ModbusSequentialDataBlock.create()
+        self.store["h"] = hr if di is not None else ModbusSequentialDataBlock.create()
 
     def __str__(self):
         """Return a string representation of the context.


### PR DESCRIPTION
Empty data stores tend to be false-y when tested,
which is not the intent here.

Should probably be backported to master