### PR TITLE
fixed string type handling in simulator

### DIFF
--- a/pymodbus/datastore/simulator.py
+++ b/pymodbus/datastore/simulator.py
@@ -198,14 +198,14 @@ class Setup:
 
     def handle_type_string(self, start, stop, value, action, action_parameters):
         """Handle type string."""
-        regs = stop - start
+        regs = stop - start + 1
         reg_len = regs * 2
         if len(value) > reg_len:
             raise RuntimeError(
                 f'ERROR "{Label.type_string}" {start} too long "{value}"'
             )
         value = value.ljust(reg_len)
-        for i in range(stop - start):
+        for i in range(stop - start + 1):
             reg = self.runtime.registers[start + i]
             if reg.type != CellType.INVALID:
                 raise RuntimeError(f'ERROR "{Label.type_string}" {start + i} used')


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

Hello. I was playing with the string functionality when I tried to allocate 3 16-bit registers to hold a 6 character string (which should be ok) and an exception was raised. I then noticed that the number of registers that the string allocates was being computed as `stop - start`, which actually undercounts the number of registers allocated by one. I just changed that calculation where necessary. I tested it and it worked okay, I hope I didn't miss anything. Cheers!
