### PR TITLE
Don't call trace_connect callback twice upon connect

### DIFF
--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -60,8 +60,6 @@ class ModbusBaseServer(ModbusProtocol):
 
     def callback_new_connection(self):
         """Handle incoming connect."""
-        if self.trace_connect:
-            self.trace_connect(True)
         return ServerRequestHandler(
             self,
             self.trace_packet,

--- a/test/server/test_server_asyncio.py
+++ b/test/server/test_server_asyncio.py
@@ -257,11 +257,16 @@ class TestAsyncioServer:
 
     async def test_async_tcp_server_connection_lost(self):
         """Test tcp stream interruption."""
+        trace_connect = mock.Mock()
         await self.start_server()
+        self.server.trace_connect = trace_connect
         await self.connect_server()
+        trace_connect.assert_called_once_with(True)
+        trace_connect.reset_mock()
 
         BasicClient.transport.close()
         await asyncio.sleep(0.2)  # so we have to wait a bit
+        trace_connect.assert_called_once_with(False)
 
     async def test_async_tcp_server_shutdown_connection(self):
         """Test server shutdown() while there are active TCP connections."""

--- a/test/transaction/test_transaction.py
+++ b/test/transaction/test_transaction.py
@@ -86,6 +86,25 @@ class TestTransaction:
         transact.pdu_send(ExceptionResponse(0xff), (0,0))
         assert transact.sent_buffer == b'\x01\xff\x00a\xf0'
 
+    async def test_transaction_connect(self, use_clc):
+        """Test tracers in disconnect."""
+        transact = TransactionManager(
+            use_clc,
+            FramerRTU(DecodePDU(False)),
+            5,
+            False,
+            None,
+            None,
+            None,
+        )
+        transact.trace_packet = mock.Mock()
+        transact.trace_pdu = mock.Mock()
+        transact.trace_connect = mock.Mock()
+        transact.callback_connected()
+        transact.trace_connect.assert_called_once_with(True)
+        transact.trace_packet.assert_not_called()
+        transact.trace_pdu.assert_not_called()
+
     async def test_transaction_disconnect(self, use_clc):
         """Test tracers in disconnect."""
         transact = TransactionManager(


### PR DESCRIPTION
Fixes #2669