### PR TITLE
Add retries to ModbusPDU class

### DIFF
--- a/pymodbus/pdu/pdu.py
+++ b/pymodbus/pdu/pdu.py
@@ -38,6 +38,7 @@ class ModbusPDU:
         self.status: int = status
         self.exception_code: int = 0
         self.fut: asyncio.Future
+        self.retries: int = 0
 
     def isError(self) -> bool:
         """Check if the error is a success or failure."""
@@ -67,7 +68,8 @@ class ModbusPDU:
             f"count={self.count}, "
             f"bits={self.bits!s}, "
             f"registers={self.registers!s}, "
-            f"status={self.status!s})"
+            f"status={self.status!s}"
+            f"retries={self.retries})"
         )
 
     def get_response_pdu_size(self) -> int:

--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -129,7 +129,9 @@ class TransactionManager(ModbusProtocol):
                 if no_response_expected:
                     return ExceptionResponse(0xff)
                 try:
-                    return self.sync_get_response(request.dev_id, request.transaction_id)
+                    response = self.sync_get_response(request.dev_id, request.transaction_id)
+                    response.retries = count_retries
+                    return response
                 except asyncio.exceptions.TimeoutError:
                     count_retries += 1
             if self.count_until_disconnect < 0:
@@ -170,6 +172,7 @@ class TransactionManager(ModbusProtocol):
                         raise ModbusIOException(
                             f"ERROR: request ask for id={request.dev_id} but got id={response.dev_id}, CLOSING CONNECTION."
                         )
+                    response.retries = count_retries
                     return response
                 except asyncio.exceptions.TimeoutError:
                     count_retries += 1


### PR DESCRIPTION
I tried doing this before by adding another return value, but it would break many things.

This time I have added an integer representing the number of retries to the ModbusPDU class and setting that value in both the async and sync transaction execute code path.