### PR TITLE
Issue 2675 correctly reverse fixed size datatypes

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -770,6 +770,17 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
             int.from_bytes(byte_list[x : x + 2], "big")
             for x in range(0, len(byte_list), 2)
         ]
-        if word_order == "little":
+        if word_order != "little":
+            return regs
+
+        data_type_len = data_type.value[1]
+        if data_type_len == 0:
             regs.reverse()
-        return regs
+            return regs
+
+        reversed_regs = []
+        for x in range(0, len(regs), data_type_len):
+            single_value_regs = regs[x: x + data_type_len]
+            single_value_regs.reverse()
+            reversed_regs = reversed_regs + single_value_regs
+        return reversed_regs

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -776,9 +776,8 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         return regs
 
     @classmethod
-    def _get_reversed_registers(cls, regs: list[int], data_type: DATATYPE) -> list[int]:
-        data_type_len = data_type.value[1]
-        if not data_type_len:
+    def _get_reversed_registers(cls, regs: list[int], data_type: DATATYPE) -> list[int]:        
+        if not (data_type_len := data_type.value[1]):
             regs.reverse()
             return regs
 

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -776,7 +776,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         return regs
 
     @classmethod
-    def _get_reversed_registers(cls, regs: list[int], data_type: DATATYPE) -> list[int]:        
+    def _get_reversed_registers(cls, regs: list[int], data_type: DATATYPE) -> list[int]:
         if not (data_type_len := data_type.value[1]):
             regs.reverse()
             return regs

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -778,7 +778,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
     @classmethod
     def _get_reversed_registers(cls, regs: list[int], data_type: DATATYPE) -> list[int]:
         data_type_len = data_type.value[1]
-        if data_type_len == 0:
+        if not data_type_len:
             regs.reverse()
             return regs
 

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -770,9 +770,13 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
             int.from_bytes(byte_list[x : x + 2], "big")
             for x in range(0, len(byte_list), 2)
         ]
-        if word_order != "little":
-            return regs
+        if word_order == "little":
+            return cls._get_reversed_registers(regs, data_type)
 
+        return regs
+
+    @classmethod
+    def _get_reversed_registers(cls, regs: list[int], data_type: DATATYPE) -> list[int]:
         data_type_len = data_type.value[1]
         if data_type_len == 0:
             regs.reverse()

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -781,7 +781,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
             regs.reverse()
             return regs
 
-        reversed_regs = []
+        reversed_regs: list[int] = []
         for x in range(0, len(regs), data_type_len):
             single_value_regs = regs[x: x + data_type_len]
             single_value_regs.reverse()

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -235,7 +235,7 @@ class TestMixin:
                     single_value_regs.reverse()
                     reversed_regs = reversed_regs + single_value_regs
                 registers = reversed_regs
-            
+
 
         kwargs = {**({"word_order": word_order} if word_order else {}),
                   **({"string_encoding": string_encoding} if string_encoding else {})}


### PR DESCRIPTION
As a response to issue #2675 this PR improves "convert_to_registers" in order to do the reversing of the bytes per word, and not for the complete data array.

String and bit fields might vary in size and way of handling so I didn't dare to change anything about then in this MR, it just works with datatypes that have a fixed known size.

fixes #2675