### PR TITLE
Change read_input_registers docstring count arg from coils to registers.

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -121,7 +121,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         """Read input registers (code 0x04).
 
         :param address: Start address to read from
-        :param count: (optional) Number of coils to read
+        :param count: (optional) Number of registers to read
         :param device_id: (optional) Modbus device ID
         :param no_response_expected: (optional) The client will not expect a response to the request
         :raises ModbusException:


### PR DESCRIPTION
Tiny one-word PR for docstring edit!

The docstring for `read_input_registers` specifies the arg `count: (optional) Number of coils to read`.
It seems that this should be `count: (optional) Number of registers to read`.

This is consistent with MODBUS Application Protocol Specification's[ request format for Read Input Registers](https://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf#page=16), which contains Quantity of Input Registers (as well as the arg descriptions for `read_holding_registers` in the same class).
