### PR TITLE
Fix serial_forwarder.py from examples/contrib

### DIFF
--- a/examples/contrib/serial_forwarder.py
+++ b/examples/contrib/serial_forwarder.py
@@ -74,7 +74,7 @@ def get_commandline():
     parser.add_argument("--server_port", help="server port", default=5020, type=int)
     parser.add_argument("--server_ip", help="server IP", default="127.0.0.1", type=str)
     parser.add_argument(
-        "--sdevice_ids", help="list of device_ids to forward", type=int, nargs="+"
+        "--device_ids", help="list of device_ids to forward", type=int, nargs="+"
     )
 
     args = parser.parse_args()

--- a/examples/contrib/serial_forwarder.py
+++ b/examples/contrib/serial_forwarder.py
@@ -9,6 +9,7 @@ import logging
 import signal
 
 from pymodbus.client import ModbusSerialClient
+from pymodbus.framer import FramerType
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.datastore.remote import RemoteDeviceContext
 from pymodbus.server import ModbusTcpServer
@@ -33,13 +34,13 @@ class SerialForwarderTCPServer:
     async def run(self):
         """Run the server"""
         port, baudrate, server_port, server_ip, device_ids = get_commandline()
-        client = ModbusSerialClient(method="rtu", port=port, baudrate=baudrate)
+        client = ModbusSerialClient(framer=FramerType.RTU, port=port, baudrate=baudrate)
         message = f"RTU bus on {port} - baudrate {baudrate}"
         _logger.info(message)
         store = {}
         for i in device_ids:
             store[i] = RemoteDeviceContext(client, device_id=i)
-        context = ModbusServerContext(device_ids=store, single=False)
+        context = ModbusServerContext(devices=store, single=False)
         self.server = ModbusTcpServer(
             context,
             address=(server_ip, server_port),


### PR DESCRIPTION
The changes fix a typo and adapt to the API changes.