### PR TITLE
Return 0x02 Illegal Data Address instead of 0x04 Server Device Failure

### DIFF
--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -51,7 +51,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any, Generic, TypeVar
 
-from pymodbus.exceptions import ParameterException
+from pymodbus.exceptions import NoSuchAddressException, ParameterException
 
 
 # ---------------------------------------------------------------------------#
@@ -259,8 +259,12 @@ class ModbusSparseDataBlock(BaseModbusDataBlock[dict[int, Any]]):
         :param address: The starting address
         :param count: The number of values to retrieve
         :returns: The requested values from a:a+c
+        :raises: NoSuchAddressException
         """
-        return [self.values[i] for i in range(address, address + count)]
+        try:
+            return [self.values[i] for i in range(address, address + count)]
+        except KeyError as e:
+            raise NoSuchAddressException(str(e)) from e
 
     def _process_values(self, values):
         """Process values."""

--- a/pymodbus/exceptions.py
+++ b/pymodbus/exceptions.py
@@ -69,6 +69,14 @@ class NoSuchIdException(ModbusException):
         message = f"[No Such id] {string}"
         ModbusException.__init__(self, message)
 
+class NoSuchAddressException(ModbusException):
+    """Error resulting from making a request for a register that does not exist."""
+
+    def __init__(self, string=""):
+        """Initialize."""
+        message = f"[No such register address] {string}"
+        ModbusException.__init__(self, message)
+
 
 class NotImplementedException(ModbusException):
     """Error resulting from not implemented function."""

--- a/pymodbus/server/requesthandler.py
+++ b/pymodbus/server/requesthandler.py
@@ -105,6 +105,9 @@ class ServerRequestHandler(TransactionManager):
             if self.server.ignore_missing_devices:
                 return  # the client will simply timeout waiting for a response
             response = ExceptionResponse(self.last_pdu.function_code, ExceptionResponse.GATEWAY_NO_RESPONSE)
+        except KeyError:
+            Log.error("Requested register address does not exist: {}", self.last_pdu.address)
+            response = ExceptionResponse(self.last_pdu.function_code, ExceptionResponse.ILLEGAL_ADDRESS)
         except Exception as exc:  # pylint: disable=broad-except
             Log.error(
                 "Datastore unable to fulfill request: {}; {}",

--- a/pymodbus/server/requesthandler.py
+++ b/pymodbus/server/requesthandler.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import asyncio
 import traceback
 
-from pymodbus.exceptions import ModbusIOException, NoSuchIdException
+from pymodbus.exceptions import (
+    ModbusIOException,
+    NoSuchAddressException,
+    NoSuchIdException,
+)
 from pymodbus.logging import Log
 from pymodbus.pdu.pdu import ExceptionResponse
 from pymodbus.transaction import TransactionManager
@@ -105,7 +109,7 @@ class ServerRequestHandler(TransactionManager):
             if self.server.ignore_missing_devices:
                 return  # the client will simply timeout waiting for a response
             response = ExceptionResponse(self.last_pdu.function_code, ExceptionResponse.GATEWAY_NO_RESPONSE)
-        except KeyError:
+        except NoSuchAddressException:
             Log.error("Requested register address does not exist: {}", self.last_pdu.address)
             response = ExceptionResponse(self.last_pdu.function_code, ExceptionResponse.ILLEGAL_ADDRESS)
         except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
Closes #2716

```
alex@antorak:~/Desktop$ python3 client_test.py 1

--- Reading register 1 ---
Register 1 value: 17

# before change
alex@antorak:~/Desktop$ python3 client_test.py 99

--- Reading register 99 ---
Exception code 0x04
DEVICE FAILURE

# after change
alex@antorak:~/Desktop$ python3 client_test.py 99

--- Reading register 99 

Exception code 0x02
ILLEGAL DATA ADDRESS
```
