### PR TITLE
Switch from venv+pip to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
         run: |
           uv run codespell --skip "*.lock"
 
-      # - name: documentation
-      #   if: matrix.run_doc == true
-      #   run: cd doc && ./build_html
+      - name: documentation
+        if: matrix.run_doc == true
+        run: cd doc && ./build_html
 
       - name: pylint
         if: matrix.run_lint == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,6 @@ jobs:
       - name: Checkout repo from github
         uses: actions/checkout@v4.2.2
 
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5.4.0
-        with:
-          python-version: ${{ matrix.python }}
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,11 @@ jobs:
 
       - name: documentation
         if: matrix.run_doc == true
-        run: cd doc && uv ./build_html
+        run: |
+          source .venv/bin/activate
+          cd doc 
+          ./build_html
+        # this won't work on Windows, but we run_doc == False on Windows
 
       - name: pylint
         if: matrix.run_lint == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
         run: |
           uv run codespell
 
-      # - name: documentation
-      #   if: matrix.run_doc == true
-      #   run: cd doc && ./build_html
+      - name: documentation
+        if: matrix.run_doc == true
+        run: cd doc && uv ./build_html
 
       - name: pylint
         if: matrix.run_lint == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: codespell
         if: matrix.run_doc == true
         run: |
-          uv run codespell
+          uv run codespell --skip "*.lock"
 
       # - name: documentation
       #   if: matrix.run_doc == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: codespell
         if: matrix.run_doc == true
         run: |
-          uv run codespell --skip "*.lock"
+          uv run codespell
 
       - name: documentation
         if: matrix.run_doc == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,70 +59,49 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Set venv path (NON Windows)
-        if: matrix.os != 'windows-latest'
-        run: |
-          echo "VIRTUAL_ENV=${{ github.workspace }}/venv" >> $GITHUB_ENV
-          echo ${{ github.workspace }}/venv/bin >> $GITHUB_PATH
-
-      - name: Set venv path (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "VIRTUAL_ENV=${{ github.workspace }}\\venv" >> $Env:GITHUB_ENV
-          echo "${{ github.workspace }}\\venv\\Scripts" >> $Env:GITHUB_PATH
-
-      - name: Restore base Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v4.2.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          path: ${{ env.VIRTUAL_ENV }}
-          key: >-
-            ${{ runner.os }}-${{ matrix.python }}-venv-${{
-              hashFiles('pyproject.toml') }}
+          python-version: ${{ matrix.python }}
+          enable-cache: true
 
-      - name: Create venv (NEW CACHE)
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+      - name: Create virtualenv and sync dependencies
         run: |
-          python -m venv ${{ env.VIRTUAL_ENV }}
-          python -m pip install --upgrade pip
-          pip install -e ".[all]"
+          uv sync --all-extras
 
       - name: codespell
         if: matrix.run_doc == true
         run: |
-          codespell
+          uv run codespell
 
-      - name: dcoumentation
-        if: matrix.run_doc == true
-        run: |
-          cd doc; ./build_html
+      # - name: documentation
+      #   if: matrix.run_doc == true
+      #   run: cd doc && ./build_html
 
       - name: pylint
         if: matrix.run_lint == true
         run: |
-          pylint --recursive=y examples pymodbus test
+          uv run pylint --recursive=y examples pymodbus test
 
       - name: mypy
         if: matrix.run_lint == true
         run: |
-          mypy pymodbus examples
+          uv run mypy pymodbus examples
 
       - name: ruff
         if: matrix.run_lint == true
         run: |
-          ruff check .
+          uv run ruff check .
 
       - name: pytest
-        if: ${{ (matrix.os != 'ubuntu-latest') || (matrix.python != '3.13') }}
-        run: |
-          env
-          pytest
+        if: ${{ (matrix.os != 'ubuntu-latest') || (matrix.python != '3.13.0') }}
+        run: | 
+          uv run pytest
 
       - name: pytest coverage
-        if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python == '3.13')  }}
+        if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python == '3.13.0') }}
         run: |
-          env
-          pytest --cov
+          uv run pytest --cov
 
   analyze:
     name: Analyze Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
         run: |
           uv run codespell
 
-      - name: documentation
-        if: matrix.run_doc == true
-        run: cd doc && ./build_html
+      # - name: documentation
+      #   if: matrix.run_doc == true
+      #   run: cd doc && ./build_html
 
       - name: pylint
         if: matrix.run_lint == true

--- a/doc/build_html
+++ b/doc/build_html
@@ -5,4 +5,10 @@ zip -9 doc/source/_static/examples.zip examples/*
 tar -czf doc/source/_static/examples.tgz examples
 popd
 
-sphinx-build -M html "." "../build/html" 
+if command -v uv &> /dev/null; then
+    echo "Using: uv run sphinx-build"
+    uv run sphinx-build -M html "." "../build/html"
+else
+    echo "Using: sphinx-build"
+    sphinx-build -M html "." "../build/html"
+fi

--- a/doc/build_html
+++ b/doc/build_html
@@ -5,10 +5,4 @@ zip -9 doc/source/_static/examples.zip examples/*
 tar -czf doc/source/_static/examples.tgz examples
 popd
 
-if command -v uv &> /dev/null; then
-    echo "Using: uv run sphinx-build"
-    uv run sphinx-build -M html "." "../build/html"
-else
-    echo "Using: sphinx-build"
-    sphinx-build -M html "." "../build/html"
-fi
+sphinx-build -M html "." "../build/html" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,7 @@ directory = "build/cov"
 
 
 [tool.codespell]
-skip = "./build,./doc/source/_static,venv,.venv,.git,htmlcov,CHANGELOG.rst,.mypy_cache"
+skip = "./build,./doc/source/_static,venv,.venv,.git,htmlcov,CHANGELOG.rst,.*_cache,*.lock"
 ignore-words-list = "asend"
 
 [tool.ruff]


### PR DESCRIPTION
[`uv` ](https://docs.astral.sh/uv/) is to `pip` and `venv` what `ruff` is to `pyflakes` and `black` - faster and better in every way.

It greatly speeds up dependency resolution and install, and eliminates the fuss of activating venv on Windows (which I remember was quite `fun` to setup for @janiversen ... )

The dependency setup with a cache miss is <2s, which is nearly as fast as a cache hit with the existing solution.