### PR TITLE
make base frame signature match subclasses

### DIFF
--- a/pymodbus/framer/ascii.py
+++ b/pymodbus/framer/ascii.py
@@ -60,14 +60,14 @@ class FramerAscii(FramerBase):
                 continue
             return used_len, dev_id, 0, msg[1:]
 
-    def encode(self, data: bytes, device_id: int, _tid: int) -> bytes:
+    def encode(self, pdu: bytes, device_id: int, _tid: int) -> bytes:
         """Encode ADU."""
         dev_id = device_id.to_bytes(1,'big')
-        checksum = self.compute_LRC(dev_id + data)
+        checksum = self.compute_LRC(dev_id + pdu)
         frame = (
             self.START +
             f"{device_id:02x}".encode() +
-            b2a_hex(data) +
+            b2a_hex(pdu) +
             f"{checksum:02x}".encode() +
             self.END
         ).upper()

--- a/pymodbus/framer/base.py
+++ b/pymodbus/framer/base.py
@@ -46,13 +46,13 @@ class FramerBase:
         """
         return 0, 0, 0, self.EMPTY
 
-    def encode(self, data: bytes, _dev_id: int, _tid: int) -> bytes:
+    def encode(self, pdu: bytes, _dev_id: int, _tid: int) -> bytes:
         """Encode ADU.
 
         returns:
             modbus ADU (bytes)
         """
-        return data
+        return pdu
 
     def buildFrame(self, message: ModbusPDU) -> bytes:
         """Create a ready to send modbus packet.


### PR DESCRIPTION
Simple method call signature cleanup.

Currently `FramerBase` and `FramerAscii` use the parameter `data: bytes`, and the others use `pdu: bytes`.  `pdu` is more descriptive.
