### PR TITLE
Ignore lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/html
 venv
 downloaded_files/
 pymodbus.log
+*.lock


### PR DESCRIPTION
I'm using `uv` but don't want to push that on everybody else.  (yet :)  )

By doing `*.lock` instead of `uv.lock` it might also help someone using e.g. `poetry` or `rye`
