### PR TITLE
Remove unused callback in ServerRequestHandler

### DIFF
--- a/examples/package_test_tool.py
+++ b/examples/package_test_tool.py
@@ -90,7 +90,7 @@ class TransportStub(ModbusProtocol):
         return len(data)
 
     def callback_connected(self) -> None:
-        """Call when connection is succcesfull."""
+        """Call when connection is successful."""
 
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""

--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -88,8 +88,8 @@ class ModbusBaseServer(ModbusProtocol):
             Log.info("Server graceful shutdown.")
 
     def callback_connected(self) -> None:
-        """Call when connection is succcesfull."""
-        raise RuntimeError("callback_new_connection should never be called")
+        """Call when connection is successful."""
+        raise RuntimeError("callback_connected should never be called")
 
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""

--- a/pymodbus/server/requesthandler.py
+++ b/pymodbus/server/requesthandler.py
@@ -9,7 +9,7 @@ from pymodbus.exceptions import ModbusIOException, NoSuchIdException
 from pymodbus.logging import Log
 from pymodbus.pdu.pdu import ExceptionResponse
 from pymodbus.transaction import TransactionManager
-from pymodbus.transport import CommParams, ModbusProtocol
+from pymodbus.transport import CommParams
 
 
 class ServerRequestHandler(TransactionManager):
@@ -39,10 +39,6 @@ class ServerRequestHandler(TransactionManager):
             trace_pdu,
             trace_connect,
         )
-
-    def callback_new_connection(self) -> ModbusProtocol:
-        """Call when listener receive new connection request."""
-        raise RuntimeError("callback_new_connection should never be called")
 
     def callback_disconnected(self, call_exc: Exception | None) -> None:
         """Call when connection is lost."""

--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -214,7 +214,7 @@ class TransactionManager(ModbusProtocol):
         """Call when listener receive new connection request."""
 
     def callback_connected(self) -> None:
-        """Call when connection is succcesfull."""
+        """Call when connection is successful."""
         self.count_until_disconnect = self.max_until_disconnect
         self.next_tid = 0
         self.trace_connect(True)

--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -361,7 +361,7 @@ class ModbusProtocol(asyncio.BaseProtocol):
 
     @abstractmethod
     def callback_connected(self) -> None:
-        """Call when connection is succcesfull."""
+        """Call when connection is successful."""
 
     @abstractmethod
     def callback_disconnected(self, exc: Exception | None) -> None:

--- a/test/transport/conftest.py
+++ b/test/transport/conftest.py
@@ -22,7 +22,7 @@ class DummyProtocol(ModbusProtocol):
         return DummyProtocol(params=self.comm_params, is_server=False)
 
     def callback_connected(self) -> None:
-        """Call when connection is succcesfull."""
+        """Call when connection is successful."""
 
     def callback_disconnected(self, exc: Exception | None) -> None:
         """Call when connection is lost."""


### PR DESCRIPTION
It will inherit a blank callback from `TransactionManager`, and I can't see any code depending on the `RuntimeError`.
