### PR TITLE
Correct "install uv".

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python }}
-          allow-prereleases: true
           enable-cache: true
 
       - name: Create virtualenv and sync dependencies


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Solves:

```
[macos-latest - 3.13](https://github.com/pymodbus-dev/pymodbus/actions/runs/16906384104/job/47897310542#step:21:1)
Unexpected input(s) 'allow-prereleases', valid inputs are ['version', 'version-file', 'python-version', 'activate-environment', 'working-directory', 'checksum', 'server-url', 'github-token', 'enable-cache', 'cache-dependency-glob', 'cache-suffix', 'cache-local-path', 'prune-cache', 'ignore-nothing-to-cache', 'ignore-empty-workdir', 'tool-dir', 'tool-bin-dir', 'manifest-file']
```
