### PR TITLE
Fix reg_count calc

### DIFF
--- a/pymodbus/simulator/simruntime.py
+++ b/pymodbus/simulator/simruntime.py
@@ -56,13 +56,13 @@ class SimRuntime:
         """Handle coils and discrete input."""
         start_address, register_count, registers, _ = self.block[block_id]
         offset = (int(address / 16) if self.use_bit_addressing else address) - start_address
-        reg_count = int(count / 16) + 1
-        if register_count <= offset < 0 or offset + reg_count > register_count:
+        bit_offset = address % 16
+        reg_count = (bit_offset + count + 15) // 16
+        if offset < 0 or offset + reg_count > register_count:
             return ExcCodes.ILLEGAL_ADDRESS
         if (result := await self.__check_block(func_code, block_id, address, reg_count, offset, values)):
             return result
         list_bools = SimUtils.registersToBits(registers[offset:offset+reg_count])
-        bit_offset = address % 16
         if values:
             list_bools[bit_offset:bit_offset+count] = values
             registers[offset:offset+reg_count] = SimUtils.bitsToRegisters(list_bools)


### PR DESCRIPTION
The current formula computes the number of 16-bit registers needed based only on the bit count, ignoring where within the first register the read starts. It breaks when bit_offset + count > 16, i.e., the requested bits actually span a register boundary.

Also, when address is a multiple of 16, the formula over-allocates by 1 register.

The first part of the following "if" also does not seem correct.