### PR TITLE
Fix address bounds check in get_reg_block

### DIFF
--- a/pymodbus/simulator/simruntime.py
+++ b/pymodbus/simulator/simruntime.py
@@ -72,7 +72,7 @@ class SimRuntime:
         """Handle holding registers and input registers."""
         start_address, register_count, registers, _ = self.block[block_id]
         offset = address - start_address
-        if register_count <= offset < 0 or offset + count > register_count:
+        if offset < 0 or offset + count > register_count:
             return ExcCodes.ILLEGAL_ADDRESS
         if (result := await self.__check_block(func_code, block_id, address, count, offset, values)):
             return result

--- a/test/simulator/test_simruntime.py
+++ b/test/simulator/test_simruntime.py
@@ -135,6 +135,14 @@ class TestSimRuntime:
         rt = SimRuntime(sd)
         result = await rt.async_getValues(0x03, 10, 1)
         assert result == [15]
+        result = await rt.async_getValues(0x03, 8, 1)
+        assert isinstance(result, ExcCodes)
+        result = await rt.async_getValues(0x03, 9, 1)
+        assert isinstance(result, ExcCodes)
+        result = await rt.async_getValues(0x03, 11, 1)
+        assert isinstance(result, ExcCodes)
+        result = await rt.async_getValues(0x03, 12, 1)
+        assert isinstance(result, ExcCodes)
         result = await rt.async_getValues(0x03, 15, 1)
         assert isinstance(result, ExcCodes)
 


### PR DESCRIPTION
Because offset can be negative, register_count <= offset < 0 doesn't work.

It's specifically `rt.async_getValues(0x03, 8, 1)` that would previously
incorrectly pass the bounds check and return a value (15) due to negative list
indexing. Going even further out of bounds would instead throw an IndexError.

Discovered while SimDevice/SimData for a simple static test server.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
