### PR TITLE
Fix handleFrame dropping the next frame after a skipped one

### DIFF
--- a/pymodbus/framer/base.py
+++ b/pymodbus/framer/base.py
@@ -70,7 +70,7 @@ class FramerBase:
             if used_len >= len(data):
                 return used_len, None
             Log.debug("Processing: {}", data, ":hex")
-            data_len, dev_id, tid, frame_data = self.decode(data)
+            data_len, dev_id, tid, frame_data = self.decode(data[used_len:])
             used_len += data_len
             if not data_len or not frame_data:
                 return used_len, None

--- a/test/framer/test_extras.py
+++ b/test/framer/test_extras.py
@@ -146,3 +146,40 @@ class TestExtras:
         cut, pdu = self._rtu.handleFrame(msg, 0, 0)
         assert cut
         assert not pdu
+
+    def test_tcp_framer_skip_wrong_dev_id_then_decode(self):
+        """A frame for another device followed by a valid one: the valid one must be returned.
+
+        Regression test for handleFrame() not advancing its decode window after
+        skipping a frame addressed to a different device. Without the fix the
+        valid second frame is silently dropped.
+        """
+        wrong = b"\x00\x01\x00\x00\x00\x06\x10\x02\x00\x01\x00\x02"   # dev_id 0x10
+        right = b"\x00\x02\x00\x00\x00\x06\xff\x02\x00\x03\x00\x04"   # dev_id 0xff
+        used_len, pdu = self._tcp.handleFrame(wrong + right, 0xff, 0)
+        assert pdu is not None
+        assert pdu.dev_id == 0xff
+        assert used_len == len(wrong) + len(right)
+
+    def test_tcp_framer_skip_wrong_tid_then_decode(self):
+        """A stale-tid frame followed by a fresh-tid frame: the fresh one must be returned."""
+        stale = b"\x00\x01\x00\x00\x00\x06\xff\x02\x00\x01\x00\x02"   # tid 1
+        fresh = b"\x00\x05\x00\x00\x00\x06\xff\x02\x00\x03\x00\x04"   # tid 5
+        used_len, pdu = self._tcp.handleFrame(stale + fresh, 0, 5)
+        assert pdu is not None
+        assert pdu.transaction_id == 5
+        assert used_len == len(stale) + len(fresh)
+
+    def test_ascii_framer_skip_wrong_dev_id_then_decode(self):
+        """Same regression for the ASCII framer.
+
+        We build the frames via encode() to keep the LRC correct without
+        hard-coding bytes that would silently rot if the LRC algorithm
+        ever changed.
+        """
+        wrong = self._ascii.encode(b"\x02\x00\x01\x00\x02", 0x10, 0)  # dev_id 0x10
+        right = self._ascii.encode(b"\x02\x00\x03\x00\x04", 0xff, 0)  # dev_id 0xff
+        used_len, pdu = self._ascii.handleFrame(wrong + right, 0xff, 0)
+        assert pdu is not None
+        assert pdu.dev_id == 0xff
+        assert used_len == len(wrong) + len(right)


### PR DESCRIPTION
## Summary

Fixes #2933.

`FramerBase.handleFrame()` re-decoded the same prefix of the buffer every
iteration of its skip loop, so when a frame addressed to a different
device or a stale transaction id was followed by a valid frame in the same
buffer, the valid frame was silently consumed but never delivered.

The fix advances the decode window by `used_len` on each iteration:

```diff
-            data_len, dev_id, tid, frame_data = self.decode(data)
+            data_len, dev_id, tid, frame_data = self.decode(data[used_len:])
```

## Affected framers

- `FramerSocket` (Modbus TCP)
- `FramerAscii`
- `FramerTLS` in coalesced-PDU scenarios
- `FramerRTU` is unaffected in practice — its `decode()` returns the full input length on success, so the loop never iterates with leftover bytes.

## Reproduction

```python
from pymodbus.framer import FramerSocket
from pymodbus.pdu import DecodePDU

framer = FramerSocket(DecodePDU(True))
wrong = b"\x00\x01\x00\x00\x00\x06\x10\x02\x00\x01\x00\x02"   # dev_id 0x10
right = b"\x00\x02\x00\x00\x00\x06\xff\x02\x00\x03\x00\x04"   # dev_id 0xff
print(framer.handleFrame(wrong + right, 0xff, 0))
# Before fix: (24, None)  -> valid response silently dropped
# After  fix: (24, ReadDiscreteInputsRequest(dev_id=255, ...))
```

User-visible symptom before the fix: `ModbusIOException("No response received after N retries")` against gateways/bridges that coalesce responses, or whenever a stale response is still in the kernel buffer when the next request is sent.

## Why this is safe

- First iteration has `used_len == 0`, so `data[0:] is data`. Every existing single-frame test path is bit-identical.
- `FramerRTU.decode()` returns `data_len == len(input)` on success, so the loop never advances past the first iteration on good data — behavior unchanged.
- The garbage-skip in `FramerAscii.decode()` happens *inside* one `decode()` call, not via the outer loop, so it still works.
- The wrong-dev_id / wrong-tid `continue` paths now correctly slide past the offending frame and inspect the next one — which is what the `continue` statements were always intended to do.

## Tests

Added three regression tests to `test/framer/test_extras.py`:

- `test_tcp_framer_skip_wrong_dev_id_then_decode`
- `test_tcp_framer_skip_wrong_tid_then_decode`
- `test_ascii_framer_skip_wrong_dev_id_then_decode`

All three fail on `dev` and pass with the fix. The existing 274 framer tests continue to pass.

## Checklist

- [x] `ruff check`
- [x] `pylint --recursive=y examples pymodbus test`
- [x] `zuban check pymodbus examples test`
- [x] `codespell`
- [x] `pytest -x --cov --numprocesses auto`
- [x] No public API change
- [x] No `CHANGELOG.rst` edit (added by maintainers at release time, per recent PR conventions)