### PR TITLE
Fix default no-response behavior for force listen only

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -242,7 +242,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         """
         return self.execute(no_response_expected, pdu_diag.ChangeAsciiInputDelimiterRequest(message=delimiter, dev_id=device_id))
 
-    def diag_force_listen_only(self, *, device_id: int = 1, no_response_expected: bool = False) -> T:
+    def diag_force_listen_only(self, *, device_id: int = 1, no_response_expected: bool = True) -> T:
         """Diagnose force listen only (code 0x08 sub 0x04).
 
         :param device_id: (optional) Modbus device ID


### PR DESCRIPTION
# Summary

This PR fixes the default behavior of `diag_force_listen_only()`.

Previously, the method used `no_response_expected=False` by default, so the client would wait for a reply after sending `Force Listen Only Mode`.

According to the Modbus specification for Diagnostics sub-function `0x08 / 0x0004`, no response is returned for this request.

# Change

- Before: `diag_force_listen_only(..., no_response_expected=False)`
- After: `diag_force_listen_only(..., no_response_expected=True)`

# Rationale

This aligns the client default behavior with the protocol and with the method's own docstring, which already states that no response is returned.

Without this change, a default call to `diag_force_listen_only()` can incorrectly fall into a timeout or retry path even when the request was successfully accepted by the remote device.
