### PR TITLE
Support configured ASCII input delimiter

### DIFF
--- a/pymodbus/framer/ascii.py
+++ b/pymodbus/framer/ascii.py
@@ -12,6 +12,7 @@ from ..logging import Log
 from ..pdu.device import ModbusControlBlock
 from .base import FramerBase
 
+
 _MCB = ModbusControlBlock()
 
 

--- a/pymodbus/framer/ascii.py
+++ b/pymodbus/framer/ascii.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 from binascii import a2b_hex, b2a_hex
 
 from ..logging import Log
+from ..pdu.device import ModbusControlBlock
 from .base import FramerBase
+
+_MCB = ModbusControlBlock()
 
 
 class FramerAscii(FramerBase):
@@ -32,11 +35,17 @@ class FramerAscii(FramerBase):
     END = b'\r\n'
     MIN_SIZE = 8
 
+    @property
+    def end(self) -> bytes:
+        """Return the configured end-of-frame delimiter."""
+        return b"\r" + _MCB.Delimiter
+
 
     def decode(self, data: bytes) -> tuple[int, int, int, bytes]:
         """Decode ADU."""
         used_len = 0
         data_len = len(data)
+        end_marker = self.end
         while True:
             if data_len - used_len < self.MIN_SIZE:
                 Log.debug("Short frame: {} wait for more data", data, ":hex")
@@ -48,11 +57,11 @@ class FramerAscii(FramerBase):
                     return data_len, 0, 0, self.EMPTY
                 used_len += i
                 continue
-            if (end := buffer.find(self.END)) == -1:
+            if (end := buffer.find(end_marker)) == -1:
                 Log.debug("Incomplete frame: {} wait for more data", data, ":hex")
                 return used_len, 0, 0, self.EMPTY
             dev_id = int(buffer[1:3], 16)
-            used_len += end + 2
+            used_len += end + len(end_marker)
             try:
                 lrc = int(buffer[end - 2: end], 16)
                 msg = a2b_hex(buffer[1 : end - 2])
@@ -73,7 +82,7 @@ class FramerAscii(FramerBase):
             f"{device_id:02x}".encode() +
             b2a_hex(payload) +
             f"{checksum:02x}".encode() +
-            self.END
+            self.end
         ).upper()
         return frame
 

--- a/pymodbus/pdu/device.py
+++ b/pymodbus/pdu/device.py
@@ -436,7 +436,7 @@ class ModbusControlBlock:
     _mode = "ASCII"
     _diagnostic = [False] * 16
     _listen_only = False
-    _delimiter = b"\r"
+    _delimiter = b"\n"
     _counters = ModbusCountersHandler()
     _identity = ModbusDeviceIdentification()
     _plus = ModbusPlusStatistics()

--- a/test/framer/test_extras.py
+++ b/test/framer/test_extras.py
@@ -11,6 +11,7 @@ from pymodbus.framer import (
     FramerTLS,
 )
 from pymodbus.pdu import DecodePDU
+from pymodbus.pdu.device import ModbusControlBlock
 
 
 TEST_MESSAGE = b"\x7b\x01\x03\x00\x00\x00\x05\x85\xC9\x7d"
@@ -21,6 +22,7 @@ class TestExtras:
 
     def setup_method(self):
         """Set up the test environment."""
+        ModbusControlBlock().Delimiter = b"\n"
         self.client = None
         self.decoder = DecodePDU(True)
         self._tcp = FramerSocket(self.decoder)

--- a/test/framer/test_framer.py
+++ b/test/framer/test_framer.py
@@ -11,6 +11,7 @@ from pymodbus.framer import (
     FramerTLS,
     FramerType,
 )
+from pymodbus.pdu.device import ModbusControlBlock
 from pymodbus.pdu import DecodePDU, ModbusPDU
 from test.framer.generator import set_calls
 
@@ -76,6 +77,32 @@ class TestFramer:
         used_len, pdu = test_framer.handleFrame(msg, 0, 0)
         assert used_len == len(msg)
         assert pdu
+
+    def test_ascii_framer_uses_configured_delimiter_on_encode(self):
+        """Test ASCII framer encode uses the configured delimiter."""
+        control = ModbusControlBlock()
+        original_delimiter = control.Delimiter
+        control.Delimiter = b"="
+        try:
+            framer = FramerAscii(DecodePDU(False))
+            assert framer.encode(b"\x03\x00\x7c\x00\x02", 0, 0) == b":0003007C00027F\r="
+        finally:
+            control.Delimiter = original_delimiter
+
+    def test_ascii_framer_uses_configured_delimiter_on_decode(self):
+        """Test ASCII framer decode uses the configured delimiter."""
+        control = ModbusControlBlock()
+        original_delimiter = control.Delimiter
+        control.Delimiter = b"="
+        try:
+            framer = FramerAscii(DecodePDU(True))
+            used_len, dev_id, tr_id, payload = framer.decode(b":0003007C00027F\r=")
+            assert used_len == len(b":0003007C00027F\r=")
+            assert dev_id == 0
+            assert tr_id == 0
+            assert payload == b"\x03\x00\x7c\x00\x02"
+        finally:
+            control.Delimiter = original_delimiter
 
 class TestFramerType:
     """Test classes."""

--- a/test/framer/test_framer.py
+++ b/test/framer/test_framer.py
@@ -81,18 +81,16 @@ class TestFramer:
     def test_ascii_framer_uses_configured_delimiter_on_encode(self):
         """Test ASCII framer encode uses the configured delimiter."""
         control = ModbusControlBlock()
-        original_delimiter = control.Delimiter
         control.Delimiter = b"="
         try:
             framer = FramerAscii(DecodePDU(False))
             assert framer.encode(b"\x03\x00\x7c\x00\x02", 0, 0) == b":0003007C00027F\r="
         finally:
-            control.Delimiter = original_delimiter
+            control.Delimiter = b"\n"
 
     def test_ascii_framer_uses_configured_delimiter_on_decode(self):
         """Test ASCII framer decode uses the configured delimiter."""
         control = ModbusControlBlock()
-        original_delimiter = control.Delimiter
         control.Delimiter = b"="
         try:
             framer = FramerAscii(DecodePDU(True))
@@ -102,7 +100,7 @@ class TestFramer:
             assert tr_id == 0
             assert payload == b"\x03\x00\x7c\x00\x02"
         finally:
-            control.Delimiter = original_delimiter
+            control.Delimiter = b"\n"
 
 class TestFramerType:
     """Test classes."""

--- a/test/framer/test_framer.py
+++ b/test/framer/test_framer.py
@@ -11,8 +11,8 @@ from pymodbus.framer import (
     FramerTLS,
     FramerType,
 )
-from pymodbus.pdu.device import ModbusControlBlock
 from pymodbus.pdu import DecodePDU, ModbusPDU
+from pymodbus.pdu.device import ModbusControlBlock
 from test.framer.generator import set_calls
 
 

--- a/test/pdu/test_device.py
+++ b/test/pdu/test_device.py
@@ -252,12 +252,16 @@ class TestDataStore:
 
     def test_modbus_control_block_delimiter(self):
         """Tests the MCB delimiter setting methods."""
-        self.control.Delimiter = b"\r"
-        assert self.control.Delimiter == b"\r"
-        self.control.Delimiter = "="
-        assert self.control.Delimiter == b"="  # type: ignore[comparison-overlap]
-        self.control.Delimiter = 61
-        assert self.control.Delimiter == b"="  # type: ignore[comparison-overlap]
+        original_delimiter = self.control.Delimiter
+        try:
+            self.control.Delimiter = b"\r"
+            assert self.control.Delimiter == b"\r"
+            self.control.Delimiter = "="
+            assert self.control.Delimiter == b"="  # type: ignore[comparison-overlap]
+            self.control.Delimiter = 61
+            assert self.control.Delimiter == b"="  # type: ignore[comparison-overlap]
+        finally:
+            self.control.Delimiter = original_delimiter
 
     def test_modbus_control_block_diagnostic(self):
         """Tests the MCB delimiter setting methods."""

--- a/test/pdu/test_device.py
+++ b/test/pdu/test_device.py
@@ -252,7 +252,6 @@ class TestDataStore:
 
     def test_modbus_control_block_delimiter(self):
         """Tests the MCB delimiter setting methods."""
-        original_delimiter = self.control.Delimiter
         try:
             self.control.Delimiter = b"\r"
             assert self.control.Delimiter == b"\r"
@@ -261,7 +260,7 @@ class TestDataStore:
             self.control.Delimiter = 61
             assert self.control.Delimiter == b"="  # type: ignore[comparison-overlap]
         finally:
-            self.control.Delimiter = original_delimiter
+            self.control.Delimiter = b"\n"
 
     def test_modbus_control_block_diagnostic(self):
         """Tests the MCB delimiter setting methods."""

--- a/test/pdu/test_diag_messages.py
+++ b/test/pdu/test_diag_messages.py
@@ -171,13 +171,12 @@ class TestDataStore:
     async def test_diagnostic_datastore_update(self):
         """Testing diagnostic message execution."""
         control = ModbusControlBlock()
-        original_delimiter = control.Delimiter
         try:
             for message, encoded, datastore_updated in self.requests:
                 encoded = (await message().datastore_update(cast(ModbusServerContext, None), 1)).encode()
                 assert encoded == datastore_updated
         finally:
-            control.Delimiter = original_delimiter
+            control.Delimiter = b"\n"
 
     def test_return_query_data_request(self):
         """Testing diagnostic message execution."""

--- a/test/pdu/test_diag_messages.py
+++ b/test/pdu/test_diag_messages.py
@@ -5,6 +5,7 @@ import pytest
 
 from pymodbus.constants import ModbusPlusOperation, ModbusStatus
 from pymodbus.datastore import ModbusServerContext
+from pymodbus.pdu.device import ModbusControlBlock
 from pymodbus.pdu.diag_message import (
     ChangeAsciiInputDelimiterRequest,
     ChangeAsciiInputDelimiterResponse,
@@ -169,9 +170,14 @@ class TestDataStore:
 
     async def test_diagnostic_datastore_update(self):
         """Testing diagnostic message execution."""
-        for message, encoded, datastore_updated in self.requests:
-            encoded = (await message().datastore_update(cast(ModbusServerContext, None), 1)).encode()
-            assert encoded == datastore_updated
+        control = ModbusControlBlock()
+        original_delimiter = control.Delimiter
+        try:
+            for message, encoded, datastore_updated in self.requests:
+                encoded = (await message().datastore_update(cast(ModbusServerContext, None), 1)).encode()
+                assert encoded == datastore_updated
+        finally:
+            control.Delimiter = original_delimiter
 
     def test_return_query_data_request(self):
         """Testing diagnostic message execution."""


### PR DESCRIPTION
# Summary

This PR fixes `FramerAscii` so that `Change ASCII Input Delimiter` actually affects future ASCII messages.

Previously, the delimiter value was updated in the control block, but the ASCII framer still used a hardcoded `CRLF` terminator for both encoding and decoding.

According to the Modbus ASCII specification, the `Change ASCII Input Delimiter` diagnostic command replaces the default `LF` character used at the end of future messages.

# Change

- `FramerAscii` now builds its end-of-frame marker from the control block delimiter instead of always using a hardcoded `CRLF`
- `decode()` now looks for the configured delimiter
- `encode()` now emits the configured delimiter
- The control block default delimiter is set to `LF`, so the default end-of-frame remains `CRLF`

# Rationale

This aligns the framer behavior with both the protocol and the existing diagnostic command implementation.

Without this change, `Change ASCII Input Delimiter` updates internal state but does not affect actual frame parsing or frame generation, so the command appears to succeed while the wire behavior remains unchanged.
