### PR TITLE
Add ruff format check to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,12 @@ jobs:
         run: |
           uv run zuban check pymodbus examples test
 
-      - name: ruff
+      - name: ruff (format check)
+        if: matrix.run_lint == true
+        run: |
+          uv run ruff format --check .
+
+      - name: ruff (lint check)
         if: matrix.run_lint == true
         run: |
           uv run ruff check .

--- a/check_ci.sh
+++ b/check_ci.sh
@@ -7,6 +7,7 @@ trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 codespell
 ruff check --fix --exit-non-zero-on-fix .
+ruff format .
 pylint --recursive=y examples pymodbus test
 zuban check pymodbus examples test
 if [ $1 ]; then


### PR DESCRIPTION
Added format checking with ruff using `ruff format --check`.
See: https://github.com/pymodbus-dev/pymodbus/pull/2944#issuecomment-4799523799