### PR TITLE
Format test_client.py with ruff

### DIFF
--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -380,8 +380,8 @@ class TestMixin:
 
         with pytest.raises(TypeError):
             ModbusClientMixin.convert_to_registers(
-                bool,
-                ModbusClientMixin.DATATYPE.BITS,  # type: ignore[arg-type]
+                bool,  # type: ignore[arg-type]
+                ModbusClientMixin.DATATYPE.BITS,
             )
 
     def test_client_mixin_convert_datatype_fail(self):

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -380,7 +380,8 @@ class TestMixin:
 
         with pytest.raises(TypeError):
             ModbusClientMixin.convert_to_registers(
-                bool, ModbusClientMixin.DATATYPE.BITS  # type: ignore[arg-type]
+                bool,
+                ModbusClientMixin.DATATYPE.BITS,  # type: ignore[arg-type]
             )
 
     def test_client_mixin_convert_datatype_fail(self):


### PR DESCRIPTION
Fixed problems in test_client.py that cause zuban to report errors after formatting with ruff.

The cause was that ruff moved the ignore comment, so it had to be manually moved so that zuban would ignore the right argument.