### PR TITLE
Remove 'useless-suppression' messages from pylint

### DIFF
--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -22,7 +22,7 @@ class ModbusBaseServer(ModbusProtocol):
 
     active_server: ModbusBaseServer | None = None
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         params: CommParams,
         context: ModbusServerContext | SimDevice | list[SimDevice],

--- a/pymodbus/server/server.py
+++ b/pymodbus/server/server.py
@@ -20,7 +20,7 @@ class ModbusTcpServer(ModbusBaseServer):
         Remember to call serve_forever to start server.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         context: ModbusServerContext | SimDevice | list[SimDevice],
         *,
@@ -155,7 +155,7 @@ class ModbusUdpServer(ModbusBaseServer):
         Remember to call serve_forever to start server.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         context: ModbusServerContext | SimDevice | list[SimDevice],
         *,


### PR DESCRIPTION
Pylint reports warnings about 'useless-suppressions'. They can safely be removed unless there's a specific reason to keep them.

```
$ pylint --recursive=y examples pymodbus test
************* Module pymodbus.server.base
pymodbus/server/base.py:25:0: I0021: Useless suppression of 'too-many-arguments' (useless-suppression)
************* Module pymodbus.server.server
pymodbus/server/server.py:23:0: I0021: Useless suppression of 'too-many-arguments' (useless-suppression)
pymodbus/server/server.py:158:0: I0021: Useless suppression of 'too-many-arguments' (useless-suppression)
```
