### PR TITLE
Drop support for python 3.10, 3.11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.12', '3.13', '3.14']
         include:
-          - python: '3.10'
+          - python: '3.12'
             run_lint: true
           - python: '3.14'
             run_doc: true

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Common features
 * Support all standard frames: socket, rtu, rtu-over-tcp, tcp and ascii
 * Does not have third party dependencies, apart from pyserial (optional)
 * Very lightweight project
-* Requires Python >= 3.10
+* Requires Python >= 3.12
 * Thorough test suite, that test all corners of the library (100% test coverage)
 * Automatically tested on Windows, Linux and MacOS combined with python 3.10 - 3.14
 * Strongly typed API (py.typed present)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,13 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: OS Independent",
     "Operating System :: Microsoft",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: System :: Networking",
     "Topic :: Utilities",
 ]
-requires-python = ">=3.10.0"
+requires-python = ">=3.12.0"
 
 [project.urls]
 Homepage = "https://github.com/pymodbus-dev/pymodbus/"
@@ -46,8 +44,7 @@ serial = [
     "pyserial>=3.5"
 ]
 simulator = [
-    "aiohttp>=3.8.6;python_version<'3.12'",
-    "aiohttp>=3.13.2;python_version>='3.12'"
+    "aiohttp>=3.13.2"
 ]
 documentation = [
     "recommonmark>=0.7.1",


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
pymodbus  is no longer tested on python version 3.10 and version 3.11, that does not mean it will not work !

Currently pymodbus itself is not restricted to python version 3.12 and greater, but some of the tools  used for development are.
