### PR TITLE
Fix non-deterministic convert_from_registers mutating the caller's registers list

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -927,7 +927,9 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         if not (data_len := data_type.value[1]):
             byte_list = bytearray()
             if word_order == "little":
-                registers.reverse()
+                # Reverse a copy; the numeric branch below also works on a
+                # slice copy, so decoding must not mutate the caller's list.
+                registers = list(reversed(registers))
             for x in registers:
                 byte_list.extend(int.to_bytes(x, 2, "big"))
             if data_type == cls.DATATYPE.STRING:

--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -927,8 +927,6 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         if not (data_len := data_type.value[1]):
             byte_list = bytearray()
             if word_order == "little":
-                # Reverse a copy; the numeric branch below also works on a
-                # slice copy, so decoding must not mutate the caller's list.
                 registers = list(reversed(registers))
             for x in registers:
                 byte_list.extend(int.to_bytes(x, 2, "big"))

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -366,6 +366,41 @@ class TestMixin:
         assert result == value
         assert regs == registers
 
+    @pytest.mark.parametrize("word_order", ["big", "little"])
+    @pytest.mark.parametrize(
+        ("datatype", "value"),
+        [
+            (ModbusClientMixin.DATATYPE.STRING, "Hello"),
+            (ModbusClientMixin.DATATYPE.STRING, "abcdefghij"),
+            (ModbusClientMixin.DATATYPE.BITS, [True, False, True] + [False] * 17),
+            (ModbusClientMixin.DATATYPE.INT32, 123456),
+            (ModbusClientMixin.DATATYPE.INT32, [1, 2, 3, 4]),
+        ],
+    )
+    def test_client_mixin_convert_from_registers_no_mutation(
+        self, datatype, value, word_order
+    ):
+        """convert_from_registers must not mutate input and stay deterministic.
+
+        Regression: for STRING/BITS with word_order="little" the registers list
+        was reversed in place, corrupting the caller's data so a second identical
+        call decoded garbage (non-deterministic output).
+        """
+        registers = ModbusClientMixin.convert_to_registers(
+            value, datatype, word_order=word_order
+        )
+        snapshot = list(registers)
+        first = ModbusClientMixin.convert_from_registers(
+            registers, datatype, word_order=word_order
+        )
+        # Decoding must leave the caller's list untouched ...
+        assert registers == snapshot
+        # ... so repeating the identical call yields the identical result.
+        second = ModbusClientMixin.convert_from_registers(
+            registers, datatype, word_order=word_order
+        )
+        assert first == second
+
     def test_client_mixin_convert_fail(self):
         """Test convert fail."""
         with pytest.raises(TypeError):

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -380,12 +380,7 @@ class TestMixin:
     def test_client_mixin_convert_from_registers_no_mutation(
         self, datatype, value, word_order
     ):
-        """convert_from_registers must not mutate input and stay deterministic.
-
-        Regression: for STRING/BITS with word_order="little" the registers list
-        was reversed in place, corrupting the caller's data so a second identical
-        call decoded garbage (non-deterministic output).
-        """
+        """convert_from_registers must not mutate input and stay deterministic."""
         registers = ModbusClientMixin.convert_to_registers(
             value, datatype, word_order=word_order
         )
@@ -393,9 +388,7 @@ class TestMixin:
         first = ModbusClientMixin.convert_from_registers(
             registers, datatype, word_order=word_order
         )
-        # Decoding must leave the caller's list untouched ...
         assert registers == snapshot
-        # ... so repeating the identical call yields the identical result.
         second = ModbusClientMixin.convert_from_registers(
             registers, datatype, word_order=word_order
         )


### PR DESCRIPTION
### The bug

`ModbusClientMixin.convert_from_registers(..., word_order="little")` reverses the caller's `registers` list **in place** for `STRING`/`BITS`, so the input is corrupted and a second identical call returns garbage — the decode is non-deterministic:

```python
from pymodbus.client.mixin import ModbusClientMixin as M
DT = M.DATATYPE

regs = M.convert_to_registers("Hello", DT.STRING, word_order="little")  # [28416, 27756, 18533]
a = M.convert_from_registers(regs, DT.STRING, word_order="little")      # 'Hello'   (regs now reversed!)
b = M.convert_from_registers(regs, DT.STRING, word_order="little")      # 'o\x00llHe'
assert a == b   # AssertionError — same args, different result
```

The same happens for `BITS` once the value spans more than one register. The numeric types (`INT*`/`UINT*`/`FLOAT*`) are **not** affected — they already decode without mutating the input.

### Why this is a bug

- A pure decode helper must be side-effect free and deterministic: calling it twice with the same arguments must give the same result and must not alter the arguments. Here the first call silently rewrites the caller's buffer.
- It's internally inconsistent: the numeric branch slices a copy (`regs = registers[i:i+data_len]`) before reversing, so it never touches the input; only the `data_len == 0` (STRING/BITS) branch reverses the original.
- The docstring documents no mutation of `registers`.

### Root cause

`pymodbus/client/mixin.py`, in the `data_len == 0` branch of `convert_from_registers`:

```python
if word_order == "little":
    registers.reverse()        # in-place reverse of the caller's list
```

`list.reverse()` mutates in place. The fix reverses a copy instead, mirroring what the numeric branch below already does:

```python
if word_order == "little":
    registers = list(reversed(registers))
```

### Tests

Added `test_client_mixin_convert_from_registers_no_mutation` to `test/client/test_client.py`, parametrized over `STRING` / multi-register `BITS` / `INT32` × `big`/`little`. It asserts the input list is unchanged after decoding and that two consecutive identical calls return equal results. The three `little` STRING/BITS cases fail on `dev` and pass with the fix; the rest (and the existing convert tests) stay green.

The existing `test_client_mixin_convert` didn't catch this because it builds a fresh reversed list and calls `convert_from_registers` only once per input.
