### PR TITLE
Fix incorrect order of  `simdata` tuple for `SimDevice` instantiation in `ModbusDeviceContext.__init__`

### DIFF
--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -60,7 +60,7 @@ class ModbusDeviceContext:  # pylint: disable=too-few-public-methods
         self.__build_data(co_simdata)
         self.__build_data(di_simdata)
         self.simdevice = SimDevice(
-            0, simdata=(co_simdata, di_simdata, ir_simdata, hr_simdata)
+            0, simdata=(co_simdata, di_simdata, hr_simdata, ir_simdata)
         )
         Log.warning(
             "ModbusDeviceContext, ModbusSequentialDataBlock, "


### PR DESCRIPTION
The call to the constructor for `SimData` inside `ModbusDeviceContext` introduced in #2897 appears to have an incorrect tuple order for the `simdata` argument. This causes input registers to be swapped with holding registers in versions 3.13.0.
https://github.com/pymodbus-dev/pymodbus/blob/25e72e88eb90e513cab34234e522e4008b42afad/pymodbus/datastore/context.py#L62-L64

Referring to the docs the last two elements should be holding registers followed by input registers.

> The tuple is defined as:
> (\<coils>, \<discrete inputs>, \<holding registers>, \<input registers>)

 -- https://pymodbus.readthedocs.io/en/latest/source/simulator/datamodel.html#pymodbus.simulator.SimDevice.simdata