### PR TITLE
Apply docstring fix in sync serial client from #1850

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -130,7 +130,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
     :param baudrate: Bits per second.
     :param bytesize: Number of bits per byte 7-8.
     :param parity: 'E'ven, 'O'dd or 'N'one
-    :param stopbits: Number of stop bits 0-2.
+    :param stopbits: Number of stop bits 1, 1.5, 2.
     :param handle_local_echo: Discard local echo from dongle.
     :param name: Set communication name, used in logging
     :param reconnect_delay: Not used in the sync client

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -33,7 +33,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
     :param baudrate: Bits per second.
     :param bytesize: Number of bits per byte 7-8.
     :param parity: 'E'ven, 'O'dd or 'N'one
-    :param stopbits: Number of stop bits 1, 1.5, 2.
+    :param stopbits: Number of stop bits 1, 1.5, 2. (Note: 1.5 falls back to 2 on POSIX systems)
     :param handle_local_echo: Discard local echo from dongle.
     :param name: Set communication name, used in logging
     :param reconnect_delay: Minimum delay when reconnecting, in seconds (use decimals for milliseconds).
@@ -130,7 +130,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
     :param baudrate: Bits per second.
     :param bytesize: Number of bits per byte 7-8.
     :param parity: 'E'ven, 'O'dd or 'N'one
-    :param stopbits: Number of stop bits 1, 1.5, 2.
+    :param stopbits: Number of stop bits 1, 1.5, 2. (Note: 1.5 falls back to 2 on POSIX systems)
     :param handle_local_echo: Discard local echo from dongle.
     :param name: Set communication name, used in logging
     :param reconnect_delay: Not used in the sync client

--- a/pymodbus/server/server.py
+++ b/pymodbus/server/server.py
@@ -229,7 +229,7 @@ class ModbusSerialServer(ModbusBaseServer):
         :param framer: The framer strategy to use, default FramerType.RTU
         :param identity: An optional identify structure
         :param port: The serial port to attach to
-        :param stopbits: The number of stop bits to use
+        :param stopbits: The number of stop bits to use 1, 1.5, 2. (Note: 1.5 falls back to 2 on POSIX systems)
         :param bytesize: The bytesize of the serial messages
         :param parity: Which kind of parity to use
         :param baudrate: The baud rate to use for the serial device


### PR DESCRIPTION
The `stopbits` parameter typo introduced in #1820 was fixed in #1850, but only the `AsyncModbusSerialClient` docstring was updated. 
https://github.com/pymodbus-dev/pymodbus/blob/e3bc332b182a8df916477412ba2c8529f0b52a9c/pymodbus/client/serial.py#L37

This PR applies that same typo fix to the (sync) `ModbusSerialClient`.