### PR TITLE
Fix pack_bitstring input mutation

### DIFF
--- a/pymodbus/pdu/utils.py
+++ b/pymodbus/pdu/utils.py
@@ -19,7 +19,7 @@ def pack_bitstring(bits: list[bool], align_byte=True) -> bytes:
     """
     ret = b""
     i = packed = 0
-    t_bits = bits
+    t_bits = bits.copy()
     bits_extra = 8 if align_byte else 16
     if extra := len(bits) % bits_extra:
         t_bits += [False] * (bits_extra - extra)

--- a/test/pdu/test_bit.py
+++ b/test/pdu/test_bit.py
@@ -15,9 +15,10 @@ class TestModbusBitMessage:
         """Test basic bit message encoding/decoding."""
         for i in range(1, 20):
             data = [True] * i
+            expected = data + [False] * (-len(data) % 8)
             pdu = bit_msg.ReadCoilsResponse(bits=data)
             pdu.decode(pdu.encode())
-            assert pdu.bits == data
+            assert pdu.bits == expected
 
     def test_bit_read_base_requests(self):
         """Test bit read request encoding."""

--- a/test/pdu/test_pdu.py
+++ b/test/pdu/test_pdu.py
@@ -633,6 +633,27 @@ class TestPdu:
         assert pack_bitstring(bitlist) == bytestream
 
     @pytest.mark.parametrize(
+        ("align_byte", "expected"),
+        [
+            (True, b"\x05"),
+            (False, b"\x05\x00"),
+        ],
+    )
+    def test_pack_bitstring_does_not_mutate_input(
+        self,
+        align_byte,
+        expected,
+    ):
+        """Test that pack_bitstring leaves the input list unchanged."""
+        bits = [True, False, True]
+        original = bits.copy()
+
+        result = pack_bitstring(bits, align_byte=align_byte)
+
+        assert result == expected
+        assert bits == original
+
+    @pytest.mark.parametrize(
         ("bytestream", "bitlist"),
         [
             (b"\x01", [True] + [False] * 7),


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
## Summary

Prevent `pack_bitstring()` from modifying the list supplied by the caller.

The function previously assigned the input list directly to `t_bits` and
then extended it with padding bits. This caused non-aligned input lists to
be modified during encoding.

## Changes

- Copy the input list before appending padding bits.
- Add regression tests for byte and word alignment.
- Update the bit response encoding test to explicitly account for padding
  instead of relying on mutation of the original input list.

## Testing

- `python -m pytest test/pdu/test_pdu.py -n 0`
- `python -m pytest test/pdu -n 0`
- `./check_ci.sh`

Full test result:

- 1907 passed
- 5 skipped
- 99.97% coverage
