### PR TITLE
Disable pylint too-many-arguments

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -66,7 +66,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         port: str,
         *,
@@ -158,7 +158,7 @@ class ModbusSerialClient(ModbusBaseSyncClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         port: str,
         *,

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -59,7 +59,7 @@ class AsyncModbusTcpClient(ModbusBaseClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         host: str,
         *,
@@ -138,7 +138,7 @@ class ModbusTcpClient(ModbusBaseSyncClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         host: str,
         *,

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -57,7 +57,7 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         host: str,
         *,
@@ -138,7 +138,7 @@ class ModbusTlsClient(ModbusTcpClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         host: str,
         *,

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -59,7 +59,7 @@ class AsyncModbusUdpClient(ModbusBaseClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         host: str,
         *,
@@ -138,7 +138,7 @@ class ModbusUdpClient(ModbusBaseSyncClient):
     Please refer to :ref:`Pymodbus internals` for advanced usage.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         host: str,
         *,

--- a/pymodbus/server/server.py
+++ b/pymodbus/server/server.py
@@ -84,7 +84,7 @@ class ModbusTlsServer(ModbusTcpServer):
         Remember to call serve_forever to start server.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         context: ModbusServerContext | SimDevice | list[SimDevice],
         *,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,8 @@ disable = [
     "file-ignored",       # ONLY to be used with extreme care.
     "format",             # NOT wanted, handled by ruff
     "locally-disabled",   # NOT wanted
-    "suppressed-message"  # NOT wanted"""
+    "suppressed-message", # NOT wanted"""
+    "too-many-arguments",
 ]
 
 [tool.pylint.reports]


### PR DESCRIPTION
Requested pylint configuration from https://github.com/pymodbus-dev/pymodbus/pull/2962#discussion_r3595136700