### PR TITLE
Remove unnecessary casts in `SimDevice`

### DIFF
--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -149,7 +149,7 @@ class SimDevice:
                 "simdata= must be SimData, list of SimData or tuple with 4 list of SimData"
             )
         for i in range(4):
-            sim_list = cast(tuple, self.simdata)[i]
+            sim_list = self.simdata[i]
             if not isinstance(sim_list, list):
                 raise TypeError(f"simdata=tuple[{TUPLE_NAMES[i]}] -> must be a list")
             for inx, entry in enumerate(sim_list):
@@ -186,9 +186,7 @@ class SimDevice:
         self.__check_simple2()
         if isinstance(self.simdata, tuple):
             for i in range(4):
-                self.__check_block(
-                    cast(tuple, self.simdata)[i], (i in {0, 1}), TUPLE_NAMES[i]
-                )
+                self.__check_block(self.simdata[i], (i in {0, 1}), TUPLE_NAMES[i])
         else:
             x_simdata = (
                 self.simdata if isinstance(self.simdata, list) else [self.simdata]
@@ -279,7 +277,7 @@ class SimDevice:
         #  (<coils>, <discrete inputs>, <holding registers>, <input registers>)
         convert = {0: "c", 1: "d", 2: "h", 3: "i"}
         for i in range(4):
-            x_simdata = cast(tuple, self.simdata)[i]
+            x_simdata = self.simdata[i]
             x_simdata.sort(key=lambda x: x.address)
             if i in {0, 1}:
                 b[convert[i]] = self.__create_block_bits(x_simdata)


### PR DESCRIPTION
Type checkers are able to narrow down the type to `tuple` and retain more information such as the element types. This gives the type more information than just casting to a `tuple`.

For example, line `sim_list` will be of type `Any` with the cast, but without it the actual type is inferred by the `zuban`.
https://github.com/pymodbus-dev/pymodbus/blob/3ca82d1ca201e3558f1991c1e17236f72ab70c8e/pymodbus/simulator/simdevice.py#L152

```python
# With tuple cast
sim_list = cast(tuple, self.simdata)[i]
reveal_type(sim_list) # pymodbus/simulator/simdevice.py:153: note: Revealed type is "Any"

# Without tuple cast
sim_list = self.simdata[i]
reveal_type(sim_list) # pymodbus/simulator/simdevice.py:153: note: Revealed type is "builtins.list[pymodbus.simulator.simdata.SimData]"
```

In this case removing the cast provides more information for later usages of `sim_list` such as in `__check_simple_blocks`,
```python
 for inx, entry in enumerate(sim_list):
    reveal_type(entry) # pymodbus/simulator/simdevice.py:156: note: Revealed type is "pymodbus.simulator.simdata.SimData"

    if not isinstance(entry, SimData):
        raise TypeError(
            f"simdata[{inx}]=tuple[{TUPLE_NAMES[i]}] -> list[{inx}] is not a SimData entry"
        )
    if i < 2 and entry.datatype != DataType.BITS:
        raise TypeError(
            f"simdata[{inx}]=tuple[{TUPLE_NAMES[i]}] -> list[{inx}] not DataType.BITS, not allowed"
        )
```
