### PR TITLE
Allow ModbusBaseServer to directly accept a SimCore instance as context

### DIFF
--- a/pymodbus/server/base.py
+++ b/pymodbus/server/base.py
@@ -25,7 +25,7 @@ class ModbusBaseServer(ModbusProtocol):
     def __init__(
         self,
         params: CommParams,
-        context: ModbusServerContext | SimDevice | list[SimDevice],
+        context: ModbusServerContext | SimDevice | list[SimDevice] | SimCore,
         ignore_missing_devices: bool,
         broadcast_enable: bool,
         identity: ModbusDeviceIdentification | None,
@@ -46,7 +46,9 @@ class ModbusBaseServer(ModbusProtocol):
             for func in custom_pdu:
                 self.decoder.register(func)
         self.context: ModbusServerContext | SimCore
-        if not isinstance(context, ModbusServerContext):
+        if isinstance(context, SimCore):
+            self.context = context
+        elif not isinstance(context, ModbusServerContext):
             self.context = SimCore(context)
         elif context.simdevices:
             self.context = SimCore(context.simdevices)

--- a/pymodbus/server/server.py
+++ b/pymodbus/server/server.py
@@ -9,6 +9,7 @@ from ..framer import FramerType
 from ..pdu import ModbusPDU
 from ..pdu.device import ModbusDeviceIdentification
 from ..simulator import SimDevice
+from ..simulator.simcore import SimCore
 from ..transport import CommParams, CommType
 from .base import ModbusBaseServer
 
@@ -22,7 +23,7 @@ class ModbusTcpServer(ModbusBaseServer):
 
     def __init__(
         self,
-        context: ModbusServerContext | SimDevice | list[SimDevice],
+        context: ModbusServerContext | SimDevice | list[SimDevice] | SimCore,
         *,
         framer=FramerType.SOCKET,
         identity: ModbusDeviceIdentification | None = None,
@@ -86,7 +87,7 @@ class ModbusTlsServer(ModbusTcpServer):
 
     def __init__(
         self,
-        context: ModbusServerContext | SimDevice | list[SimDevice],
+        context: ModbusServerContext | SimDevice | list[SimDevice] | SimCore,
         *,
         framer=FramerType.TLS,
         identity: ModbusDeviceIdentification | None = None,
@@ -148,7 +149,7 @@ class ModbusUdpServer(ModbusBaseServer):
 
     def __init__(
         self,
-        context: ModbusServerContext | SimDevice | list[SimDevice],
+        context: ModbusServerContext | SimDevice | list[SimDevice] | SimCore,
         *,
         framer=FramerType.SOCKET,
         identity: ModbusDeviceIdentification | None = None,
@@ -209,7 +210,7 @@ class ModbusSerialServer(ModbusBaseServer):
 
     def __init__(
         self,
-        context: ModbusServerContext | SimDevice | list[SimDevice],
+        context: ModbusServerContext | SimDevice | list[SimDevice] | SimCore,
         *,
         framer: FramerType = FramerType.RTU,
         identity: ModbusDeviceIdentification | None = None,


### PR DESCRIPTION
Related to discussion #2966