### PR TITLE
Fix synchronous response timeout on continuous garbage

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from threading import RLock
+from time import monotonic
 
 from ..exceptions import ConnectionException, ModbusIOException
 from ..framer import FramerAscii, FramerBase, FramerRTU
@@ -83,6 +84,7 @@ class TransactionManager(ModbusProtocol):
     def sync_get_response(self, dev_id, tid) -> ModbusPDU:
         """Receive until PDU is correct or timeout."""
         databuffer = b""
+        deadline = monotonic() + self.comm_params.timeout_connect
         while True:
             if not (data := self.sync_client.recv(None)):
                 raise asyncio.exceptions.TimeoutError()
@@ -115,6 +117,8 @@ class TransactionManager(ModbusProtocol):
             databuffer = databuffer[used_len:]
             if pdu:
                 return self.trace_pdu(False, pdu)
+            if monotonic() >= deadline:
+                raise asyncio.exceptions.TimeoutError()
 
     def sync_execute(self, no_response_expected: bool, request: ModbusPDU) -> ModbusPDU:
         """Execute requests asynchronously.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -119,7 +119,9 @@ def define_commandline_client(
 ):
     """Define commandline."""
     my_port = str(use_port)
-    cmdline = ["--comm", use_comm, "--framer", use_framer, "--timeout", "0.1"]
+    # Socket-backed serial can take seconds to complete long RTU frames under load.
+    timeout = "10" if use_comm == "serial" else "0.1"
+    cmdline = ["--comm", use_comm, "--framer", use_framer, "--timeout", timeout]
     if use_comm == "serial":
         if use_host == NULLMODEM_HOST:
             use_host = f"{use_host}:{my_port}"

--- a/test/transaction/test_transaction.py
+++ b/test/transaction/test_transaction.py
@@ -648,3 +648,30 @@ class TestSyncTransaction:
         client.recv.side_effect = [response]
         pdu = transact.sync_get_response(1, 0)
         assert isinstance(pdu, ReadCoilsResponse)
+
+    def test_transaction_sync_get_response_garbage_timeout(self, use_clc):
+        """Test continuous invalid input cannot bypass the response timeout."""
+        client = self.dummy_client(use_clc)
+        transact = TransactionManager(
+            use_clc,
+            FramerRTU(DecodePDU(False)),
+            5,
+            False,
+            None,
+            None,
+            None,
+            sync_client=client,
+        )
+        transact.comm_params.timeout_connect = 0.01
+        client.recv = mock.Mock(return_value=b" Busy ")  # type: ignore[method-assign]
+
+        with (
+            mock.patch(
+                "pymodbus.transaction.transaction.monotonic",
+                side_effect=[0.0, 0.02],
+            ),
+            pytest.raises(asyncio.exceptions.TimeoutError),
+        ):
+            transact.sync_get_response(1, 0)
+
+        client.recv.assert_called_once_with(None)


### PR DESCRIPTION
## Summary

- bound synchronous response parsing with a monotonic deadline based on the configured timeout
- check the deadline after each unsuccessful parse so a frame already being received can complete
- add a deterministic regression test for continuous invalid input

`sync_get_response()` previously depended on `recv()` returning empty bytes. Continuous non-Modbus input therefore kept the parser loop alive indefinitely and bypassed the retry logic in `sync_execute()`.

The socket-backed serial examples now use a ten-second response timeout. Their previous 100 ms setting was suitable as an inactivity timeout, but too short once the timeout also bounds the complete response parse, especially on loaded macOS CI runners.

## Validation

- `uv run pytest test/transaction/test_transaction.py` — 43 passed
- `uv run pytest` — 1,905 passed, 5 skipped
- `uv run codespell`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pylint --recursive=y examples pymodbus test`
- `uv run zuban check pymodbus examples test`

Fixes #2960
