### PR TITLE
Fix routing of unsupported MEI types

### DIFF
--- a/pymodbus/pdu/mei_message.py
+++ b/pymodbus/pdu/mei_message.py
@@ -211,5 +211,6 @@ class ReadDeviceInformationResponse(ModbusPDU):
                     data[count - object_length : count],
                 ]
 
+
 DecodePDU.add_pdu(_EncapsulatedInterfaceTransport, _EncapsulatedInterfaceTransport)
 DecodePDU.add_sub_pdu(ReadDeviceInformationRequest, ReadDeviceInformationResponse)

--- a/pymodbus/pdu/mei_message.py
+++ b/pymodbus/pdu/mei_message.py
@@ -31,6 +31,28 @@ class _OutOfSpaceException(Exception):
         self.oid = oid
 
 
+class _EncapsulatedInterfaceTransport(ModbusPDU):
+    """Base PDU for dispatching Encapsulated Interface Transport messages."""
+
+    function_code = 0x2B
+
+    @classmethod
+    def decode_sub_function_code(cls, data: bytes) -> int:
+        """Decode the MEI type."""
+        return int(data[2])
+
+    def decode(self, data: bytes) -> None:
+        """Decode the MEI type."""
+        self.sub_function_code = int(data[0])
+
+    async def datastore_update(
+        self, context: ModbusServerContext, device_id: int
+    ) -> ModbusPDU:
+        """Reject unsupported MEI types."""
+        _ = context, device_id
+        return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_FUNCTION)
+
+
 class ReadDeviceInformationRequest(ModbusPDU):
     """ReadDeviceInformationRequest."""
 
@@ -189,6 +211,5 @@ class ReadDeviceInformationResponse(ModbusPDU):
                     data[count - object_length : count],
                 ]
 
-
-DecodePDU.add_pdu(ReadDeviceInformationRequest, ReadDeviceInformationResponse)
+DecodePDU.add_pdu(_EncapsulatedInterfaceTransport, _EncapsulatedInterfaceTransport)
 DecodePDU.add_sub_pdu(ReadDeviceInformationRequest, ReadDeviceInformationResponse)

--- a/test/pdu/test_mei_messages.py
+++ b/test/pdu/test_mei_messages.py
@@ -8,7 +8,8 @@ from typing import cast
 
 import pytest
 
-from pymodbus.constants import DeviceInformation
+from pymodbus.constants import DeviceInformation, ExcCodes
+from pymodbus.pdu.decoders import DecodePDU
 from pymodbus.pdu.device import ModbusControlBlock
 from pymodbus.pdu.mei_message import (
     ReadDeviceInformationRequest,
@@ -41,6 +42,25 @@ class TestMeiMessage:
         handle.decode(b"\x0e\x01\x00")
         assert handle.read_code == DeviceInformation.BASIC
         assert not handle.object_id
+
+    def test_device_information_mei_type_is_routed(self):
+        """Test MEI type 0x0E is routed to device identification."""
+        pdu = DecodePDU(True).decode(b"\x2b\x0e\x01\x00")
+
+        assert isinstance(pdu, ReadDeviceInformationRequest)
+
+    @pytest.mark.parametrize("mei_type", [0x00, 0x0D, 0x0F, 0xFF])
+    async def test_unsupported_mei_type_is_not_device_information(
+        self, mei_type, mock_server_context
+    ):
+        """Test unsupported MEI types are not routed to device identification."""
+        pdu = DecodePDU(True).decode(bytes([0x2B, mei_type, 0x01, 0x00]))
+
+        assert pdu
+        assert not isinstance(pdu, ReadDeviceInformationRequest)
+        assert pdu.sub_function_code == mei_type
+        response = await pdu.datastore_update(mock_server_context(), 0)
+        assert response.exception_code == ExcCodes.ILLEGAL_FUNCTION
 
     async def test_read_device_information_request(self, mock_server_context):
         """Test basic bit message encoding/decoding."""


### PR DESCRIPTION
## Summary

Prevent unsupported Encapsulated Interface Transport (FC 0x2B) MEI types from being routed to the Read Device Identification implementation.

## Problem

Function code `0x2B` uses the `MEI Type` field to dispatch requests to different encapsulated interfaces. Read Device Identification is specifically assigned MEI type `0x0E`, while `0x0D` represents the separately defined CANopen General Reference interface and other ranges are reserved.

Previously, `ReadDeviceInformationRequest` was registered as both the base handler for function `0x2B` and the handler for MEI type `0x0E`. When the decoder received another MEI type and could not find a matching subtype, it retained the base `ReadDeviceInformationRequest` object. The server could consequently process an unsupported or reserved MEI request as Read Device Identification and return a normal `0x0E` response with semantics unrelated to the original request.

## Changes

This change introduces a generic Encapsulated Interface Transport dispatch PDU as the base handler for function `0x2B`. MEI type `0x0E` continues to route to `ReadDeviceInformationRequest`, while unsupported and reserved MEI types remain on the generic handler and return `ILLEGAL_FUNCTION (0x01)` instead of entering the device-identification logic.

Tests verify that `0x0E` still routes correctly and that MEI types `0x00`, `0x0D`, `0x0F`, and `0xFF` are not interpreted as Read Device Identification requests and return the expected exception.