### PR TITLE
Reject unknown specific device identification objects

### DIFF
--- a/pymodbus/pdu/device.py
+++ b/pymodbus/pdu/device.py
@@ -205,7 +205,7 @@ class ModbusDeviceIdentification:
 
         :param key: The register to read
         """
-        return self.stat_data.setdefault(key, "")
+        return self.stat_data.get(key, "")
 
     def __str__(self):
         """Build a representation of the device.

--- a/pymodbus/pdu/mei_message.py
+++ b/pymodbus/pdu/mei_message.py
@@ -79,6 +79,10 @@ class ReadDeviceInformationRequest(ModbusPDU):
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
 
         information = DeviceInformationFactory.get(_MCB, self.read_code, self.object_id)
+        if self.read_code == DeviceInformation.SPECIFIC and (
+            0x07 <= self.object_id < 0x80 or not information.get(self.object_id)
+        ):
+            return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_ADDRESS)
         return ReadDeviceInformationResponse(
             read_code=self.read_code,
             information=information,

--- a/test/pdu/test_device.py
+++ b/test/pdu/test_device.py
@@ -171,6 +171,7 @@ class TestDataStore:
         assert self.ident[0x08] != "x"
         assert self.ident[0x10] != "reserved"
         assert not self.ident[0x54]
+        assert 0x54 not in dict(self.ident)
 
     def test_modbus_device_identification_summary(self):
         """Test device identification summary creation."""

--- a/test/pdu/test_mei_messages.py
+++ b/test/pdu/test_mei_messages.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import pytest
 
-from pymodbus.constants import DeviceInformation
+from pymodbus.constants import DeviceInformation, ExcCodes
 from pymodbus.pdu.device import ModbusControlBlock
 from pymodbus.pdu.mei_message import (
     ReadDeviceInformationRequest,
@@ -61,6 +61,14 @@ class TestMeiMessage:
             _ = result.information[0x81]
 
         handle = ReadDeviceInformationRequest(
+            read_code=DeviceInformation.SPECIFIC, object_id=0x00
+        )
+        result = await handle.datastore_update(context, 0)
+        assert cast(ReadDeviceInformationResponse, result).information == {
+            0x00: "Company"
+        }
+
+        handle = ReadDeviceInformationRequest(
             read_code=DeviceInformation.EXTENDED, object_id=0x80
         )
         result = await handle.datastore_update(context, 0)
@@ -81,6 +89,17 @@ class TestMeiMessage:
         assert (await handle.datastore_update(context, 0)).function_code == 0xAB
         handle.object_id = 0x100
         assert (await handle.datastore_update(context, 0)).function_code == 0xAB
+        handle = ReadDeviceInformationRequest(
+            read_code=DeviceInformation.SPECIFIC, object_id=0x54
+        )
+        result = await handle.datastore_update(context, 0)
+        assert result.exception_code == ExcCodes.ILLEGAL_ADDRESS
+        ModbusControlBlock().Identity[0xFE] = ""
+        handle = ReadDeviceInformationRequest(
+            read_code=DeviceInformation.SPECIFIC, object_id=0xFE
+        )
+        result = await handle.datastore_update(context, 0)
+        assert result.exception_code == ExcCodes.ILLEGAL_ADDRESS
 
     def test_read_device_information_calc1(self):
         """Test calculateRtuFrameSize, short buffer."""


### PR DESCRIPTION
## Summary

Return `ILLEGAL_DATA_ADDRESS (0x02)` when an individual Read Device Identification request references an unknown object.

## Problem

Read Device Identification code `0x04` performs individual access to a single object. The Modbus specification requires the server to return exception code `0x02` when the requested object ID does not match a known object.

Previously, `ModbusDeviceIdentification.__getitem__()` used `setdefault()` when reading an object. Accessing an unknown ID therefore inserted it into the identity data with an empty value. `DeviceInformationFactory` then returned that value as a normal object, and `ReadDeviceInformationRequest.datastore_update()` constructed a successful response containing a zero-length object instead of returning an exception.

This also meant that simply reading an unknown object modified the device identity state.

## Changes

Unknown identity lookups are now non-mutating. For individual access, reserved object IDs and objects that are not configured or have no available value return `ILLEGAL_DATA_ADDRESS (0x02)`. Existing stream-access behavior and valid individual object requests remain unchanged.

Tests verify that a valid specific object is returned normally, unknown object `0x54` and unavailable private object `0xFE` return exception code `0x02`, and reading an unknown object does not insert it into the identity dictionary.