### PR TITLE
Fix: validate register write byte counts

### DIFF
--- a/pymodbus/pdu/register_message.py
+++ b/pymodbus/pdu/register_message.py
@@ -149,10 +149,9 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
             self.write_byte_count,
         ) = struct.unpack(">HHHHB", data[:9])
         self._payload_byte_count = len(data) - 9
-        payload = data[9 : self.write_byte_count + 9]
         self.write_registers = [
-            struct.unpack(">H", payload[i : i + 2])[0]
-            for i in range(0, len(payload) - 1, 2)
+            struct.unpack(">H", data[i : i + 2])[0]
+            for i in range(9, min(len(data), self.write_byte_count + 9) - 1, 2)
         ]
 
     async def datastore_update(
@@ -265,10 +264,9 @@ class WriteMultipleRegistersRequest(ModbusPDU):
         """Decode a write single register packet packet request."""
         self.address, self.count, self.byte_count = struct.unpack(">HHB", data[:5])
         self._payload_byte_count = len(data) - 5
-        payload = data[5 : self.byte_count + 5]
         self.registers = [
-            struct.unpack(">H", payload[idx : idx + 2])[0]
-            for idx in range(0, len(payload) - 1, 2)
+            struct.unpack(">H", data[idx : idx + 2])[0]
+            for idx in range(5, min(len(data), self.byte_count + 5) - 1, 2)
         ]
 
     async def datastore_update(

--- a/pymodbus/pdu/register_message.py
+++ b/pymodbus/pdu/register_message.py
@@ -163,12 +163,9 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
         if not 1 <= self.write_count <= 0x079:
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
-        if (
-            self.write_byte_count != self.write_count * 2
-            or (
-                self._payload_byte_count is not None
-                and self._payload_byte_count != self.write_byte_count
-            )
+        if self.write_byte_count != self.write_count * 2 or (
+            self._payload_byte_count is not None
+            and self._payload_byte_count != self.write_byte_count
         ):
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
         rc = await context.async_setValues(

--- a/pymodbus/pdu/register_message.py
+++ b/pymodbus/pdu/register_message.py
@@ -119,6 +119,7 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
         self.write_registers = write_registers
         self.write_count = len(self.write_registers)
         self.write_byte_count = self.write_count * 2
+        self._payload_byte_count: int | None = None
 
     def encode(self) -> bytes:
         """Encode the request packet."""
@@ -147,10 +148,12 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
             self.write_count,
             self.write_byte_count,
         ) = struct.unpack(">HHHHB", data[:9])
-        self.write_registers = []
-        for i in range(9, self.write_byte_count + 9, 2):
-            register = struct.unpack(">H", data[i : i + 2])[0]
-            self.write_registers.append(register)
+        self._payload_byte_count = len(data) - 9
+        payload = data[9 : self.write_byte_count + 9]
+        self.write_registers = [
+            struct.unpack(">H", payload[i : i + 2])[0]
+            for i in range(0, len(payload) - 1, 2)
+        ]
 
     async def datastore_update(
         self, context: ModbusServerContext, device_id: int
@@ -159,6 +162,14 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
         if not (1 <= self.read_count <= 0x07D):
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
         if not 1 <= self.write_count <= 0x079:
+            return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
+        if (
+            self.write_byte_count != self.write_count * 2
+            or (
+                self._payload_byte_count is not None
+                and self._payload_byte_count != self.write_byte_count
+            )
+        ):
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
         rc = await context.async_setValues(
             device_id, self.function_code, self.write_address, self.write_registers
@@ -243,6 +254,8 @@ class WriteMultipleRegistersRequest(ModbusPDU):
     function_code = 16
     rtu_byte_count_pos = 6
     _pdu_length = 5  # func + adress1 + adress2 + outputQuant1 + outputQuant2
+    byte_count: int | None = None
+    _payload_byte_count: int | None = None
 
     def encode(self) -> bytes:
         """Encode a write single register packet packet request."""
@@ -253,16 +266,24 @@ class WriteMultipleRegistersRequest(ModbusPDU):
 
     def decode(self, data: bytes) -> None:
         """Decode a write single register packet packet request."""
-        self.address, self.count, _byte_count = struct.unpack(">HHB", data[:5])
-        self.registers = []
-        for idx in range(5, (self.count * 2) + 5, 2):
-            self.registers.append(struct.unpack(">H", data[idx : idx + 2])[0])
+        self.address, self.count, self.byte_count = struct.unpack(">HHB", data[:5])
+        self._payload_byte_count = len(data) - 5
+        payload = data[5 : self.byte_count + 5]
+        self.registers = [
+            struct.unpack(">H", payload[idx : idx + 2])[0]
+            for idx in range(0, len(payload) - 1, 2)
+        ]
 
     async def datastore_update(
         self, context: ModbusServerContext, device_id: int
     ) -> ModbusPDU:
         """Update diagnostic request on the given device."""
         if not 1 <= self.count <= 0x07B:
+            return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
+        if self.byte_count is not None and (
+            self.byte_count != self.count * 2
+            or self._payload_byte_count != self.byte_count
+        ):
             return ExceptionResponse(self.function_code, ExcCodes.ILLEGAL_VALUE)
         rc = await context.async_setValues(
             device_id, self.function_code, self.address, self.registers

--- a/test/pdu/test_register_read_messages.py
+++ b/test/pdu/test_register_read_messages.py
@@ -141,6 +141,46 @@ class TestReadRegisterMessages:
         response = await request.datastore_update(context, 0)
         assert request.function_code == response.function_code
 
+    @pytest.mark.parametrize(
+        "frame",
+        [
+            b"\x00\x01\x00\x01\x00\x02\x00\x02\x02\x00\x0a",
+            b"\x00\x01\x00\x01\x00\x02\x00\x01\x04\x00\x0a\x00\x0b",
+            b"\x00\x01\x00\x01\x00\x02\x00\x01\x02\x00",
+            b"\x00\x01\x00\x01\x00\x02\x00\x01\x02\x00\x0a\x00",
+            b"\x00\x01\x00\x01\x00\x02\x00\x01\x01\x00",
+        ],
+    )
+    async def test_read_write_multiple_registers_rejects_invalid_byte_count(
+        self, frame, mock_server_context
+    ):
+        """Test inconsistent write byte counts are rejected before writing."""
+        request = ReadWriteMultipleRegistersRequest()
+        request.decode(frame)
+        context = mock_server_context()
+        context.async_setValues = mock.AsyncMock()
+
+        result = await request.datastore_update(context, 1)
+
+        assert result.exception_code == ExcCodes.ILLEGAL_VALUE
+        context.async_setValues.assert_not_awaited()
+
+    async def test_read_write_multiple_registers_accepts_valid_byte_count(
+        self, mock_server_context
+    ):
+        """Test a consistent write byte count reaches the datastore."""
+        request = ReadWriteMultipleRegistersRequest()
+        request.decode(b"\x00\x01\x00\x01\x00\x02\x00\x02\x04\x00\x0a\x00\x0b")
+        context = mock_server_context()
+        context.async_setValues = mock.AsyncMock(return_value=0)
+
+        result = await request.datastore_update(context, 1)
+
+        assert result.function_code == request.function_code
+        context.async_setValues.assert_awaited_once_with(
+            1, request.function_code, 2, [0x0A, 0x0B]
+        )
+
     async def test_read_write_multiple_registers_verify(self, mock_server_context):
         """Test read/write multiple registers."""
         context = mock_server_context()

--- a/test/pdu/test_register_write_messages.py
+++ b/test/pdu/test_register_write_messages.py
@@ -73,6 +73,46 @@ class TestWriteRegisterMessages:
         request = WriteMultipleRegistersRequest(address=0, registers=None)
         assert not request.registers
 
+    @pytest.mark.parametrize(
+        "frame",
+        [
+            b"\x00\x01\x00\x02\x02\x00\x0a",
+            b"\x00\x01\x00\x01\x04\x00\x0a\x00\x0b",
+            b"\x00\x01\x00\x01\x02\x00",
+            b"\x00\x01\x00\x01\x02\x00\x0a\x00",
+            b"\x00\x01\x00\x01\x01\x00",
+        ],
+    )
+    async def test_write_multiple_registers_rejects_invalid_byte_count(
+        self, frame, mock_server_context
+    ):
+        """Test inconsistent byte counts are rejected before writing."""
+        request = WriteMultipleRegistersRequest()
+        request.decode(frame)
+        context = mock_server_context()
+        context.async_setValues = mock.AsyncMock()
+
+        result = await request.datastore_update(context, 1)
+
+        assert result.exception_code == ExcCodes.ILLEGAL_VALUE
+        context.async_setValues.assert_not_awaited()
+
+    async def test_write_multiple_registers_accepts_valid_byte_count(
+        self, mock_server_context
+    ):
+        """Test a consistent byte count reaches the datastore."""
+        request = WriteMultipleRegistersRequest()
+        request.decode(b"\x00\x01\x00\x02\x04\x00\x0a\x00\x0b")
+        context = mock_server_context()
+        context.async_setValues = mock.AsyncMock(return_value=0)
+
+        result = await request.datastore_update(context, 1)
+
+        assert result.count == 2
+        context.async_setValues.assert_awaited_once_with(
+            1, request.function_code, 1, [0x0A, 0x0B]
+        )
+
     def test_serializing_to_string(self):
         """Test serializing to string."""
         for request in iter(self.write.keys()):


### PR DESCRIPTION
## Problem

Modbus function codes `0x10` (Write Multiple Registers) and `0x17` (Read/Write Multiple Registers) require the write byte count to equal twice the write quantity, because every register occupies two bytes.

The request decoders did not enforce this relationship. For `0x10`, decoding was based on the quantity while the declared byte count was discarded, which could cause extra data to be ignored or truncated data to raise a parsing error. For `0x17`, registers were decoded using the byte count, but a byte count inconsistent with the write quantity could still reach the datastore. As a result, malformed requests could be accepted, incorrectly parsed, or fail without returning the required `Illegal Data Value (03)` response.

## Changes

- Preserve the declared byte count and actual payload length for decoded `0x10` and `0x17` requests, validate both before accessing the datastore, and return `Illegal Data Value (03)` when they are inconsistent. Parsing now consumes only complete register values so malformed payloads can be rejected cleanly instead of raising `struct.error`.
- Add regression tests covering byte counts that are too small, too large, odd, shorter than the actual payload, or followed by extra data. The tests also verify that malformed requests do not write to the datastore and that valid requests continue to succeed.