### PR TITLE
Fix: validate byte count in file_message.py decode handlers

### DIFF
--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -63,8 +63,7 @@ class ReadFileRecordRequest(ModbusPDU):
     def decode(self, data: bytes) -> None:
         """Decode the incoming request."""
         self.records = []
-        byte_count = int(data[0])
-        if byte_count > len(data) - 1:
+        if (byte_count := int(data[0])) > len(data) - 1:
             raise ModbusException(f"Invalid byte count: {byte_count}")
         for count in range(1, byte_count, 7):
             decoded = struct.unpack(">BHHH", data[count : count + 7])
@@ -171,8 +170,7 @@ class WriteFileRecordRequest(ModbusPDU):
 
     def decode(self, data: bytes) -> None:
         """Decode the incoming request."""
-        byte_count = int(data[0])
-        if byte_count > len(data) - 1:
+        if (byte_count := int(data[0])) > len(data) - 1:
             raise ModbusException(f"Invalid byte count: {byte_count}")
         count = 1
         self.records.clear()

--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -64,6 +64,8 @@ class ReadFileRecordRequest(ModbusPDU):
         """Decode the incoming request."""
         self.records = []
         byte_count = int(data[0])
+        if byte_count > len(data) - 1:
+            raise ModbusException(f"Invalid byte count: {byte_count}")
         for count in range(1, byte_count, 7):
             decoded = struct.unpack(">BHHH", data[count : count + 7])
             record = FileRecord(
@@ -170,6 +172,8 @@ class WriteFileRecordRequest(ModbusPDU):
     def decode(self, data: bytes) -> None:
         """Decode the incoming request."""
         byte_count = int(data[0])
+        if byte_count > len(data) - 1:
+            raise ModbusException(f"Invalid byte count: {byte_count}")
         count = 1
         self.records.clear()
         while count < byte_count:
@@ -314,6 +318,8 @@ class ReadFifoQueueResponse(ModbusPDU):
         """Decode a the response."""
         self.values = []
         _, count = struct.unpack(">HH", data[0:4])
+        if 4 + count * 2 > len(data):
+            raise ModbusException(f"Invalid fifo count: {count}")
         for index in range(0, count):
             idx = 4 + index * 2
             self.values.append(struct.unpack(">H", data[idx : idx + 2])[0])

--- a/test/pdu/test_file_message.py
+++ b/test/pdu/test_file_message.py
@@ -216,11 +216,11 @@ class TestBitMessage:
         handle.decode(request)
         # assert handle.records[0] == record
 
-
     def test_read_file_record_request_decode_invalid_byte_count(self):
         """Test ReadFileRecordRequest raises ModbusException on oversized byte_count."""
         import pytest
         from pymodbus.exceptions import ModbusException
+
         handle = ReadFileRecordRequest()
         with pytest.raises(ModbusException):
             handle.decode(bytes([0xFF, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01]))
@@ -229,14 +229,18 @@ class TestBitMessage:
         """Test WriteFileRecordRequest raises ModbusException on oversized byte_count."""
         import pytest
         from pymodbus.exceptions import ModbusException
+
         handle = WriteFileRecordRequest()
         with pytest.raises(ModbusException):
-            handle.decode(bytes([0xFF, 0x06, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00]))
+            handle.decode(
+                bytes([0xFF, 0x06, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00])
+            )
 
     def test_read_fifo_queue_response_decode_invalid_count(self):
         """Test ReadFifoQueueResponse raises ModbusException on oversized count."""
         import pytest
         from pymodbus.exceptions import ModbusException
+
         handle = ReadFifoQueueResponse()
         with pytest.raises(ModbusException):
             handle.decode(bytes([0x00, 0x00, 0xFF, 0xFF]))

--- a/test/pdu/test_file_message.py
+++ b/test/pdu/test_file_message.py
@@ -218,18 +218,12 @@ class TestBitMessage:
 
     def test_read_file_record_request_decode_invalid_byte_count(self):
         """Test ReadFileRecordRequest raises ModbusException on oversized byte_count."""
-        import pytest
-        from pymodbus.exceptions import ModbusException
-
         handle = ReadFileRecordRequest()
         with pytest.raises(ModbusException):
             handle.decode(bytes([0xFF, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01]))
 
     def test_write_file_record_request_decode_invalid_byte_count(self):
         """Test WriteFileRecordRequest raises ModbusException on oversized byte_count."""
-        import pytest
-        from pymodbus.exceptions import ModbusException
-
         handle = WriteFileRecordRequest()
         with pytest.raises(ModbusException):
             handle.decode(
@@ -238,9 +232,6 @@ class TestBitMessage:
 
     def test_read_fifo_queue_response_decode_invalid_count(self):
         """Test ReadFifoQueueResponse raises ModbusException on oversized count."""
-        import pytest
-        from pymodbus.exceptions import ModbusException
-
         handle = ReadFifoQueueResponse()
         with pytest.raises(ModbusException):
             handle.decode(bytes([0x00, 0x00, 0xFF, 0xFF]))

--- a/test/pdu/test_file_message.py
+++ b/test/pdu/test_file_message.py
@@ -216,6 +216,31 @@ class TestBitMessage:
         handle.decode(request)
         # assert handle.records[0] == record
 
+
+    def test_read_file_record_request_decode_invalid_byte_count(self):
+        """Test ReadFileRecordRequest raises ModbusException on oversized byte_count."""
+        import pytest
+        from pymodbus.exceptions import ModbusException
+        handle = ReadFileRecordRequest()
+        with pytest.raises(ModbusException):
+            handle.decode(bytes([0xFF, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01]))
+
+    def test_write_file_record_request_decode_invalid_byte_count(self):
+        """Test WriteFileRecordRequest raises ModbusException on oversized byte_count."""
+        import pytest
+        from pymodbus.exceptions import ModbusException
+        handle = WriteFileRecordRequest()
+        with pytest.raises(ModbusException):
+            handle.decode(bytes([0xFF, 0x06, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00]))
+
+    def test_read_fifo_queue_response_decode_invalid_count(self):
+        """Test ReadFifoQueueResponse raises ModbusException on oversized count."""
+        import pytest
+        from pymodbus.exceptions import ModbusException
+        handle = ReadFifoQueueResponse()
+        with pytest.raises(ModbusException):
+            handle.decode(bytes([0x00, 0x00, 0xFF, 0xFF]))
+
     def test_write_file_record_response_frame_size(self):
         """Test write file record response rtu frame size calculation."""
         request = b"\x00\x00\x0d\x06\x00\x04\x00\x07\x00\x03\x06\xaf\x04\xbe\x10\x0d"


### PR DESCRIPTION
Adds bounds checking to three decode handlers in `pymodbus/pdu/file_message.py`,
consistent with the fixes applied in #2974 and #2977.

**Changes:**
- `ReadFileRecordRequest.decode`: validate `byte_count` against `len(data)` before iterating
- `WriteFileRecordRequest.decode`: validate `byte_count` against `len(data)` before looping
- `ReadFifoQueueResponse.decode`: validate `count` against `len(data)` before iterating

Previously, an oversized `byte_count` field caused `struct.unpack()` to raise
`struct.error`, which escaped the `ModbusException`/`ValueError`/`IndexError`
handler in `DecodePDU.decode()`. The fix raises `ModbusException` instead,
matching the behaviour added in #2974 and #2977.

Related to security advisory GHSA-xxxx (private).