### PR TITLE
Use dependency groups for development and documentation dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create virtualenv and sync dependencies
         run: |
-          uv sync --all-extras
+          uv sync --all-extras --all-groups
 
       - name: codespell
         if: matrix.run_doc == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create virtualenv and sync dependencies
         run: |
-          uv sync --all-extras --all-groups
+          uv sync --all-extras
 
       - name: codespell
         if: matrix.run_doc == true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ all = [
     "pymodbus[serial, simulator, documentation, development]"
 ]
 
+[dependency-groups]
+dev = [
+    "pymodbus[development]",
+]
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,6 @@ simulator = [
     "aiohttp>=3.8.6;python_version<'3.12'",
     "aiohttp>=3.14.1;python_version>='3.12'"
 ]
-all = [
-    "pymodbus[serial, simulator]"
-]
 
 [dependency-groups]
 dev = [
@@ -77,6 +74,10 @@ documentation = [
     "Sphinx>=7.3.7;python_version<'3.12'",
     "Sphinx>=9.1.0;python_version>='3.12'",
     "sphinx-rtd-theme>=3.1.0"
+]
+all = [
+    {include-group = "dev"},
+    {include-group = "documentation"},
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,6 @@ documentation = [
     "Sphinx>=9.1.0;python_version>='3.12'",
     "sphinx-rtd-theme>=3.1.0"
 ]
-all = [
-    {include-group = "dev"},
-    {include-group = "documentation"},
-]
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ documentation = [
     "Sphinx>=9.1.0;python_version>='3.12'",
     "sphinx-rtd-theme>=3.1.0"
 ]
+dev-all = [
+    "pymodbus[all]",
+    {include-group = "dev"},
+    {include-group = "documentation"},
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ simulator = [
     "aiohttp>=3.8.6;python_version<'3.12'",
     "aiohttp>=3.14.1;python_version>='3.12'"
 ]
+all = [
+    "pymodbus[serial,simulator]"
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,13 @@ simulator = [
     "aiohttp>=3.8.6;python_version<'3.12'",
     "aiohttp>=3.14.1;python_version>='3.12'"
 ]
-
-[dependency-groups]
-dev = [
+documentation = [
+    "recommonmark>=0.7.1",
+    "Sphinx>=7.3.7;python_version<'3.12'",
+    "Sphinx>=9.1.0;python_version>='3.12'",
+    "sphinx-rtd-theme>=3.1.0"
+]
+development = [
     "build>=1.5.0",
     "codespell>=2.4.2",
     "coverage>=7.14.3",
@@ -69,16 +73,8 @@ dev = [
     "types-pyserial",
     "zuban>=0.9.0"
 ]
-documentation = [
-    "recommonmark>=0.7.1",
-    "Sphinx>=7.3.7;python_version<'3.12'",
-    "Sphinx>=9.1.0;python_version>='3.12'",
-    "sphinx-rtd-theme>=3.1.0"
-]
 all = [
-    "pymodbus[serial,simulator]",
-    {include-group = "dev"},
-    {include-group = "documentation"},
+    "pymodbus[serial, simulator, documentation, development]"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,6 @@ simulator = [
     "aiohttp>=3.8.6;python_version<'3.12'",
     "aiohttp>=3.14.1;python_version>='3.12'"
 ]
-all = [
-    "pymodbus[serial,simulator]"
-]
 
 [dependency-groups]
 dev = [
@@ -78,8 +75,8 @@ documentation = [
     "Sphinx>=9.1.0;python_version>='3.12'",
     "sphinx-rtd-theme>=3.1.0"
 ]
-dev-all = [
-    "pymodbus[all]",
+all = [
+    "pymodbus[serial,simulator]",
     {include-group = "dev"},
     {include-group = "documentation"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,12 @@ simulator = [
     "aiohttp>=3.8.6;python_version<'3.12'",
     "aiohttp>=3.14.1;python_version>='3.12'"
 ]
-documentation = [
-    "recommonmark>=0.7.1",
-    "Sphinx>=7.3.7;python_version<'3.12'",
-    "Sphinx>=9.1.0;python_version>='3.12'",
-    "sphinx-rtd-theme>=3.1.0"
+all = [
+    "pymodbus[serial, simulator]"
 ]
-development = [
+
+[dependency-groups]
+dev = [
     "build>=1.5.0",
     "codespell>=2.4.2",
     "coverage>=7.14.3",
@@ -73,8 +72,11 @@ development = [
     "types-pyserial",
     "zuban>=0.9.0"
 ]
-all = [
-    "pymodbus[serial, simulator, documentation, development]"
+documentation = [
+    "recommonmark>=0.7.1",
+    "Sphinx>=7.3.7;python_version<'3.12'",
+    "Sphinx>=9.1.0;python_version>='3.12'",
+    "sphinx-rtd-theme>=3.1.0"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
`pyproject.toml` used to list development and documentation dependencies (pytest, zuban, sphinx, etc.) as optional dependencies. This means that it's possible to install development-only extras from PyPI. 

> Provides-Extra: serial, simulator, documentation, development, all
> -- https://pypi.org/project/pymodbus/

It doesn't really make sense to install dev/docs dependencies as an end user. Dependency groups ([PEP 735](https://peps.python.org/pep-0735/)) can be used instead to isolate those dependencies.

> This specification defines dependency groups, a mechanism for storing package requirements in pyproject.toml files **such that they are not included in project metadata when it is built**.
> 
> Dependency groups are **suitable for internal development use-cases like linting and testing**, as well as for projects which are not built for distribution, like collections of related scripts.
 -- https://packaging.python.org/en/latest/specifications/dependency-groups/

`documentation` and `devlopment` have been moved into dependency groups. Additionally `development` can be renamed to `dev` so that UV will automatically install them when working in the project (see: https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies)