### PR TITLE
Add --all-groups flag to uv sync in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create virtualenv and sync dependencies
         run: |
-          uv sync --all-extras
+          uv sync --all-extras --all-groups
 
       - name: codespell
         if: matrix.run_doc == true


### PR DESCRIPTION
Addresses #2982 with CI change. This can be merged before #2982, since it will also sync all groups if there any (currently there aren't any until #2982 is merged).