### PR TITLE
Accept any Sequence[int] in convert_from_registers

### DIFF
--- a/pymodbus/client/mixin.py
+++ b/pymodbus/client/mixin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import enum
 import struct
+from collections.abc import Sequence
 from typing import Generic, Literal, TypeVar, cast
 
 from ..constants import ModbusStatus
@@ -905,7 +906,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
     @classmethod
     def convert_from_registers(  # noqa: C901
         cls,
-        registers: list[int],
+        registers: Sequence[int],
         data_type: DATATYPE,
         word_order: Literal["big", "little"] = "big",
         string_encoding: str = "utf-8",
@@ -948,7 +949,7 @@ class ModbusClientMixin(Generic[T]):  # pylint: disable=too-many-public-methods
         for i in range(0, reg_len, data_len):
             regs = registers[i : i + data_len]
             if word_order == "little":
-                regs.reverse()
+                regs = list(reversed(regs))
             byte_list = bytearray()
             for x in regs:
                 byte_list.extend(int.to_bytes(x, 2, "big"))

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -394,6 +394,32 @@ class TestMixin:
         )
         assert first == second
 
+    @pytest.mark.parametrize("word_order", ["big", "little"])
+    @pytest.mark.parametrize(
+        ("datatype", "value"),
+        [
+            (ModbusClientMixin.DATATYPE.UINT16, 258),
+            (ModbusClientMixin.DATATYPE.INT32, -2130574588),
+            (ModbusClientMixin.DATATYPE.UINT64, 72623859790382856),
+            (ModbusClientMixin.DATATYPE.FLOAT32, 8.125736),
+            (ModbusClientMixin.DATATYPE.STRING, "abcdef"),
+        ],
+    )
+    def test_client_mixin_convert_from_registers_sequence(
+        self, datatype, value, word_order
+    ):
+        """convert_from_registers must accept any Sequence[int], e.g. a tuple (#2957)."""
+        registers = ModbusClientMixin.convert_to_registers(
+            value, datatype, word_order=word_order
+        )
+        from_list = ModbusClientMixin.convert_from_registers(
+            registers, datatype, word_order=word_order
+        )
+        from_tuple = ModbusClientMixin.convert_from_registers(
+            tuple(registers), datatype, word_order=word_order
+        )
+        assert from_tuple == from_list
+
     def test_client_mixin_convert_fail(self):
         """Test convert fail."""
         with pytest.raises(TypeError):


### PR DESCRIPTION
### Summary

First of possibly several small PRs following up on discussion https://github.com/pymodbus-dev/pymodbus/discussions/2957, scoped to the example converter `ModbusClientMixin.convert_from_registers`.

It loosens the `registers` parameter annotation from `list[int]` to `Sequence[int]`, so callers can pass a `tuple` (or any other `Sequence[int]`) without a type error. The only list-specific operation in the function body — the in-place `regs.reverse()` on the little-endian word-order path — is replaced with `regs = list(reversed(regs))`, mirroring the pattern the same function already uses a few lines earlier (`registers = list(reversed(registers))`). Every other use of the parameter (`len()`, iteration, slicing) is already valid on any `Sequence`.

This also fixes a latent runtime bug: before this change, passing a `tuple` with `word_order="little"` and a multi-register data type raised `AttributeError: 'tuple' object has no attribute 'reverse'`.

Targets `dev` (pymodbus's development branch), not `master`.

Note: the `:param registers:` docstring still reads "list of registers"; left as-is to keep the diff minimal — happy to update the wording if preferred.

### Validation
- `pytest -x test/client/test_client.py -k convert` -> 128 passed, 72 deselected
- `pytest test/client/test_client.py` (full file) -> 200 passed
- New regression test `test_client_mixin_convert_from_registers_sequence` fails on the pre-change code (`AttributeError` at the `regs.reverse()` line) and passes after the fix.
- `ruff check` and `ruff format --check` on the touched files -> clean.

Discussion: https://github.com/pymodbus-dev/pymodbus/discussions/2957

### AI/LLM disclosure
- AI coding tools (agent-assisted editing) were used to help draft and modify the code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project's contributor terms; AI output was not pasted unreviewed.
