### PR TITLE
Use `typing.Protocol` for defining SimAction rather than Callable TypeAlias

### DIFF
--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import TypeAlias, cast
 
@@ -15,7 +15,7 @@ from .simutils import DataType, SimUtils
 
 SimAction: TypeAlias = Callable[
     [int, int, int, int, list[int], list[int] | list[bool] | None],
-    Awaitable[ExcCodes | None],
+    Coroutine[None, None, ExcCodes | None],
 ]
 SimRegs: TypeAlias = tuple[int, list[int], list[int]]
 TUPLE_NAMES = ("coils", "discrete inputs", "holding registers", "input registers")

--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Protocol, TypeAlias, cast
+from typing import TypeAlias, cast
 
 from ..constants import ExcCodes
 from ..pdu.device import ModbusDeviceIdentification
@@ -12,31 +13,10 @@ from .simdata import SimData
 from .simutils import DataType, SimUtils
 
 
-class SimAction(Protocol):  # pylint: disable=too-few-public-methods
-    """Callback protocol for functions called when registers are being accessed."""
-
-    async def __call__(
-        self,
-        function_code: int,
-        start_address: int,
-        address: int,
-        count: int,
-        current_registers: list[int],
-        set_values: list[int] | list[bool] | None,
-        /,
-    ) -> ExcCodes | None:
-        """Call when registers are being accessed.
-
-        :param function_code: The function code being executed.
-        :param start_address: The starting address of the register block.
-        :param address: The address of the register being accessed.
-        :param count: The number of registers being accessed.
-        :param current_registers: The current values of the registers.
-        :param set_values: The values to set, if any.
-        :return: An exception code, if any.
-        """
-
-
+SimAction: TypeAlias = Callable[
+    [int, int, int, int, list[int], list[int] | list[bool] | None],
+    Awaitable[ExcCodes | None],
+]
 SimRegs: TypeAlias = tuple[int, list[int], list[int]]
 TUPLE_NAMES = ("coils", "discrete inputs", "holding registers", "input registers")
 

--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TypeAlias, cast
+from typing import Protocol, TypeAlias, cast
 
 from ..constants import ExcCodes
 from ..pdu.device import ModbusDeviceIdentification
@@ -13,10 +12,32 @@ from .simdata import SimData
 from .simutils import DataType, SimUtils
 
 
-SimAction: TypeAlias = Callable[
-    [int, int, int, int, list[int], list[int] | list[bool] | None],
-    Awaitable[ExcCodes | None],
-]
+class SimAction(Protocol):
+    """Callback protocol for functions called when registers are being accessed."""
+
+    async def __call__(
+        self,
+        function_code: int,
+        start_address: int,
+        address: int,
+        count: int,
+        current_registers: list[int],
+        set_values: list[int] | list[bool] | None,
+        /,
+    ) -> ExcCodes | None:
+        """
+        Call when registers are being accessed.
+
+        :param function_code: The function code being executed.
+        :param start_address: The starting address of the register block.
+        :param address: The address of the register being accessed.
+        :param count: The number of registers being accessed.
+        :param current_registers: The current values of the registers.
+        :param set_values: The values to set, if any.
+        :return: An exception code, if any.
+        """
+
+
 SimRegs: TypeAlias = tuple[int, list[int], list[int]]
 TUPLE_NAMES = ("coils", "discrete inputs", "holding registers", "input registers")
 

--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -12,7 +12,7 @@ from .simdata import SimData
 from .simutils import DataType, SimUtils
 
 
-class SimAction(Protocol):
+class SimAction(Protocol):  # pylint: disable=too-few-public-methods
     """Callback protocol for functions called when registers are being accessed."""
 
     async def __call__(
@@ -25,8 +25,7 @@ class SimAction(Protocol):
         set_values: list[int] | list[bool] | None,
         /,
     ) -> ExcCodes | None:
-        """
-        Call when registers are being accessed.
+        """Call when registers are being accessed.
 
         :param function_code: The function code being executed.
         :param start_address: The starting address of the register block.


### PR DESCRIPTION
The protocol has been made to conform better with the requirement that the `SimAction` must be an async function:
https://github.com/pymodbus-dev/pymodbus/blob/24806400867890aa48410ffa6965a2ff959d2e01/pymodbus/simulator/simdevice.py#L123-L126

Using `Callable[..., Awaitable[...]` currently allows something more general to be passed, so using `async __call__` is more inline with the requirement that the action is an async function. Alternatively the `Coroutine` type could have been used in place of `Awaitable`. This is because `Coroutine` is assignable to `Awaitable`, but not the other way around (`Callable` is a subtype of `Awaitable`).

The protocol is also a convenient place to put documentation for each parameter and is easier to understand than the long list of parameters in the `Callable`:
https://github.com/pymodbus-dev/pymodbus/blob/24806400867890aa48410ffa6965a2ff959d2e01/pymodbus/simulator/simdevice.py#L16-L19

Note: `/` was intentionally added to the protocol to make it positional only. This means that it behaves exactly the same as the TypeAlias during type checking. The only exception being that it is more specific to reflect the requirement of an async function, not just a callable that returns an `Awaitable` object.