### PR TITLE
Update contents, and fix rendering of `SimDevice.action` 

### DIFF
--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -101,7 +101,7 @@ class SimDevice:
     #:         count: int,            # request count
     #:         current_registers: list[int],  # current registers (modify inline)
     #:         set_values: list[int] | list[bool] | None  # request values to be written (None for read requests)
-    #:     ) -> None | ExceptionResponse:
+    #:     ) -> ExcCode | None:
     #:
     #: action can:
     #:
@@ -109,7 +109,7 @@ class SimDevice:
     #:
     #: - update set_values (affect the register update)
     #:
-    #: - return an ExceptionResponse.
+    #: - return a member of :class:`pymodbus.constants.ExcCodes`.
     #:
     #: .. tip:: use functools.partial to add extra parameters if needed.
     action: SimAction | None = None

--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -101,7 +101,7 @@ class SimDevice:
     #:         count: int,            # request count
     #:         current_registers: list[int],  # current registers (modify inline)
     #:         set_values: list[int] | list[bool] | None  # request values to be written (None for read requests)
-    #      ) -> None | ExceptionResponse:
+    #:     ) -> None | ExceptionResponse:
     #:
     #: action can:
     #:

--- a/pymodbus/simulator/simdevice.py
+++ b/pymodbus/simulator/simdevice.py
@@ -101,7 +101,7 @@ class SimDevice:
     #:         count: int,            # request count
     #:         current_registers: list[int],  # current registers (modify inline)
     #:         set_values: list[int] | list[bool] | None  # request values to be written (None for read requests)
-    #:     ) -> ExcCode | None:
+    #:     ) -> ExcCodes | None:
     #:
     #: action can:
     #:


### PR DESCRIPTION
- Sphinx wasn't rendering the code block because the comment line was missing `:`. This was easily corrected replacing `#  ` with `#: `.

- Also updated the return type to reflect what the type hints state. It should be a member of the `ExcCodes` enum instead of `ExceptionResponse`.