### PR TITLE
Update NullModem list with supported clients/servers

### DIFF
--- a/doc/source/library/nullmodem.rst
+++ b/doc/source/library/nullmodem.rst
@@ -12,7 +12,6 @@ The NullModem works with the normal transport types, and simply substitutes the 
 - *UDP*
 
 The NullModem is currently integrated in
-- :mod:`Modbus<x>Client`
 - :mod:`AsyncModbus<x>Client`
 - :mod:`Modbus<x>Server`
 - :mod:`AsyncModbus<x>Server`

--- a/doc/source/library/nullmodem.rst
+++ b/doc/source/library/nullmodem.rst
@@ -14,6 +14,5 @@ The NullModem works with the normal transport types, and simply substitutes the 
 The NullModem is currently integrated in
 - :mod:`AsyncModbus<x>Client`
 - :mod:`Modbus<x>Server`
-- :mod:`AsyncModbus<x>Server`
 
 Of course the NullModem requires that server and client(s) run in the same python instance.


### PR DESCRIPTION
Addresses: https://github.com/pymodbus-dev/pymodbus/discussions/2994#discussioncomment-17816099

Also removes `AsyncModbus<x>Servers` from the list as these don't exist. 
