### PR TITLE
Let CancelledError propagate from async execute

### DIFF
--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -224,11 +224,6 @@ class TransactionManager(ModbusProtocol):
                     return response
                 except asyncio.exceptions.TimeoutError:
                     count_retries += 1
-                except asyncio.exceptions.CancelledError as exc:
-                    raise self._io_exception_from_request(
-                        "Request cancelled outside library.",
-                        request,
-                    ) from exc
             if self.count_until_disconnect < 0:
                 self.connection_lost(asyncio.TimeoutError("Server not responding"))
                 raise self._io_exception_from_request(

--- a/test/transaction/test_transaction.py
+++ b/test/transaction/test_transaction.py
@@ -247,10 +247,9 @@ class TestTransaction:
             await asyncio.sleep(0.1)
             resp.cancel()
             await asyncio.sleep(0.1)
-            with pytest.raises(ModbusIOException) as exc_info:
+            with pytest.raises(asyncio.CancelledError):
                 await resp
-            assert exc_info.value.fcode == request.function_code
-            assert exc_info.value.dev_id == request.dev_id
+            assert resp.cancelled()
         elif scenario == 7:  # response
             transact.comm_params.timeout_connect = 0.2
             resp = asyncio.create_task(transact.execute(False, request))


### PR DESCRIPTION
Fixes #3009.

The async execute path caught asyncio.CancelledError and re-raised it as a ModbusIOException. Because that is a plain Exception, callers using a try/except Exception around read/write calls swallow it, so Task.cancel() no longer actually cancels a request that is waiting for a response.

Dropping the handler lets the CancelledError propagate normally, which releases the lock on the way out and cancels the task as expected. Updated the cancel scenario in the transaction test to check the task is cancelled rather than expecting the wrapped exception.