### PR TITLE
Close the udp socket in close(), not just drop the reference

### DIFF
--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -204,6 +204,8 @@ class ModbusUdpClient(ModbusBaseSyncClient):
 
         :meta private:
         """
+        if self.socket:
+            self.socket.close()
         self.socket = None
 
     def send(self, request: bytes, addr: tuple | None = None) -> int:

--- a/test/client/test_client_sync.py
+++ b/test/client/test_client_sync.py
@@ -61,6 +61,15 @@ class TestSyncClientUdp:
         client = ModbusUdpClient("127.0.0.1")
         assert client.is_socket_open()
 
+    def test_udp_client_close_releases_socket(self):
+        """Test the udp client close method releases the socket."""
+        client = ModbusUdpClient("127.0.0.1")
+        assert client.connect()
+        sock = client.socket
+        client.close()
+        assert sock.fileno() == -1
+        assert not client.connected
+
     def test_udp_client_send(self):
         """Test the udp client send method."""
         client = ModbusUdpClient("127.0.0.1")


### PR DESCRIPTION
### `ModbusUdpClient.close()` leaves the socket open

`close()` documents that it closes the underlying socket connection, but it only clears the
attribute:

```python
# pymodbus/client/udp.py:202
def close(self):
    """Close the underlying socket connection.

    :meta private:
    """
    self.socket = None
```

Its two siblings both close the socket first — `ModbusTcpClient.close()` (`client/tcp.py:210`)
and `ModbusSerialClient.close()` (`client/serial.py:248`):

```python
def close(self):
    """Close the underlying socket connection."""
    if self.socket:
        self.socket.close()
    self.socket = None
```

### Reproduction

Two lines of the documented API, on `dev` at b4ce31d:

```python
import warnings
from pymodbus.client import ModbusUdpClient

warnings.simplefilter("always", ResourceWarning)
client = ModbusUdpClient("127.0.0.1")
client.connect()
sock = client.socket
client.close()
print("connected  :", client.connected)
print("fileno()   :", sock.fileno())      # -1 would mean actually closed
```

Before:

```
ResourceWarning: unclosed <socket.socket fd=3, family=2, type=2, proto=0, laddr=('0.0.0.0', 0)>
connected  : False
fileno()   : 3
```

After:

```
connected  : False
fileno()   : -1
```

`close()` reports success and `connected` flips to `False`, so the client looks correctly torn
down while the socket is still open. Under CPython the fd is usually reclaimed by refcounting
once the last reference goes away — which is why this has gone unnoticed — but it is not
reclaimed whenever a reference survives (a retry handler, a traceback frame, a caller holding
`client.socket`), and CPython itself reports the socket as unclosed on the plain path above.

`connect()` already routes its bind failure through this same `close()` at `client/udp.py:196`,
and #3000 / #3008 just made `send()`/`recv()` call `self.close()` on `OSError` for the tcp and
serial clients. If udp gets that same treatment, `close()` needs to actually close.

### Change

Two lines in `close()`, matching tcp and serial. Plus a test in `TestSyncClientUdp` asserting
the socket is released rather than only dereferenced; it needs no network, since the udp
`connect()` only creates the socket.

Verified red/green: with the source reverted the test fails `assert 16 == -1`; with the fix the
file's 35 tests pass. `ruff format --check`, `ruff check` and `codespell` are clean, and pylint
is unchanged at 9.97/10 (the one `C0411` on `test_client_sync.py:23` is present at `dev` too).
In a full `pytest` run the 20 failures are all pre-existing TLS-certificate and live-server
example tests, identical at `dev` and on this branch.

---

Disclosure: this fix was written with AI assistance (Claude). I verified the reproduction, the
red/green runs and the test-suite comparison myself.
