### PR TITLE
docs: add server_datamodel example to examples page

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -126,6 +126,15 @@ Source: :github:`examples/server_updating.py`
     :noindex:
 
 
+Server datamodel
+^^^^^^^^^^^^^^^^
+Source: :github:`examples/server_datamodel.py`
+
+.. automodule:: examples.server_datamodel
+    :undoc-members:
+    :noindex:
+
+
 Simulator example
 ^^^^^^^^^^^^^^^^^
 Source: :github:`examples/simulator.py`


### PR DESCRIPTION
### Description

`examples/server_datamodel.py` is present in the repo and is exercised by CI (`test/examples/test_examples.py::test_server_datamodel`), but it was not referenced in `doc/source/examples.rst`, so it never appeared in the published documentation next to the other `server_*` examples.

This adds it to the **Advanced examples** section, right after *Server updating*, using the same `automodule` format as the neighbouring entries.

### Verification

- `sphinx -b html doc build/html` builds cleanly, no new warnings.
- New "Server datamodel" section renders with the module docstring content.

Discussed first in #3013.