### PR TITLE
Validate FC23 write count against MAX_WRITE_COUNT, not MAX_READ_COUNT

### DIFF
--- a/pymodbus/pdu/register_message.py
+++ b/pymodbus/pdu/register_message.py
@@ -131,7 +131,7 @@ class ReadWriteMultipleRegistersRequest(ModbusPDU):
         self.verifyAddress(address=self.read_address)
         self.verifyAddress(address=self.write_address)
         self.verifyCount(self.MAX_READ_COUNT, count=self.read_count)
-        self.verifyCount(self.MAX_READ_COUNT, count=self.write_count)
+        self.verifyCount(self.MAX_WRITE_COUNT, count=self.write_count)
         result = struct.pack(
             ">HHHHB",
             self.read_address,

--- a/test/pdu/test_register_read_messages.py
+++ b/test/pdu/test_register_read_messages.py
@@ -1,5 +1,6 @@
 """Test register read messages."""
 
+import struct
 from unittest import mock
 
 import pytest
@@ -83,6 +84,34 @@ class TestReadRegisterMessages:
         with pytest.raises(ModbusIOException) as exc_info:
             reg.decode(b"\x14\x00\x03\x00\x11")
         assert exc_info.value.fcode == reg.function_code
+
+    def test_readwrite_encode_write_count_limit(self):
+        """Encoding must reject a write count above the FC23 maximum of 121.
+
+        121 write registers is a 252 byte PDU, 122 is 254 and does not fit in
+        the 253 byte MODBUS PDU.
+        """
+
+        def build(count):
+            return ReadWriteMultipleRegistersRequest(
+                read_address=1,
+                read_count=1,
+                write_address=1,
+                write_registers=[0] * count,
+            )
+
+        assert len(build(121).encode()) + 1 <= 253
+        with pytest.raises(ValueError):  # noqa: PT011
+            build(122).encode()
+
+    def test_readwrite_decode_write_count_above_limit(self):
+        """Decoding must accept 122..125 so the server can answer ILLEGAL_VALUE.
+
+        Raising here would make the server drop the frame without a response.
+        """
+        request = ReadWriteMultipleRegistersRequest()
+        request.decode(struct.pack(">HHHHB", 1, 1, 1, 122, 244) + b"\x00\x00" * 122)
+        assert request.write_count == 122
 
     async def test_register_read_requests_count_errors(self, mock_server_context):
         """This tests that the register request messages.


### PR DESCRIPTION
`ReadWriteMultipleRegistersRequest.encode()` checks the write count against `MAX_READ_COUNT` (125) instead of `MAX_WRITE_COUNT` (121), so the client encodes requests that are over the MODBUS size limit. `MAX_WRITE_COUNT` has no other reference in the repo.

#2997 introduced the constants and rewrote the two literals:

```diff
-        self.verifyCount(125, count=self.read_count)
-        self.verifyCount(121, count=self.write_count)
+        self.verifyCount(self.MAX_READ_COUNT, count=self.read_count)
+        self.verifyCount(self.MAX_READ_COUNT, count=self.write_count)
```

The second line should have been `MAX_WRITE_COUNT`. Measured on released 3.15.0 vs 3.14.0 with `readwrite_registers(..., values=[0]*122)`:

| version | 122 write registers |
|---|---|
| 3.14.0 | `ValueError: 1 <= count 122 <= 121 !` |
| 3.15.0 | encodes; `FramerRTU.buildFrame` puts **257 bytes** on the wire |

The FC23 request PDU is `10 + 2N` bytes, so `N = 121` is 252 and `N = 122` is 254, past the 253 byte PDU maximum (RTU ADU 257 > 256). That derivation lands on the same 121 the spec gives as `0x0079`, and on the same value this PDU's own `datastore_update()` already enforces server-side (`1 <= write_count <= 0x079`) — which is why a pymodbus client can now send a request a pymodbus server answers with ILLEGAL_VALUE.

`decode()` is deliberately left at `MAX_READ_COUNT`. Raising there makes `DecodePDU.decode()` swallow the frame and the server answer nothing, replacing a correct exception response with silence. The second test pins that.

Existing coverage could not catch this: `test_register_read_requests_count_errors` goes through `datastore_update()`, the path that was already right, and its out-of-range cases are 2048 and 0, never 122..125.

Mutants run against the new tests: revert → the encode test fails; tighten `decode()` as well → the decode test fails; `MAX_WRITE_COUNT = 125` → the encode test fails. Full suite 1968 → 1970 passing, `check_ci.sh` steps clean (codespell, ruff check/format, pylint 10.00, zuban).

AI assistance was used in preparing this change.
