### PR TITLE
Fix FC17 response decode: identifier included the run indicator byte

### DIFF
--- a/pymodbus/pdu/other_message.py
+++ b/pymodbus/pdu/other_message.py
@@ -6,6 +6,7 @@ import struct
 
 from ..constants import ModbusStatus
 from ..datastore import ModbusServerContext
+from ..exceptions import ModbusIOException
 from .decoders import DecodePDU
 from .device import DeviceInformationFactory, ModbusControlBlock
 from .pdu import ModbusPDU
@@ -243,8 +244,14 @@ class ReportDeviceIdResponse(ModbusPDU):
         raw value that a user can decode to whatever it should be.
         """
         self.byte_count = int(data[0])
-        self.identifier = data[1 : self.byte_count + 1]
-        status = int(data[-1])
+        if not 1 <= self.byte_count <= len(data) - 1:
+            raise ModbusIOException(
+                f"byte_count {self.byte_count} outside 1..{len(data) - 1} "
+                f"for packet of length {len(data)}",
+                function_code=self.function_code,
+            )
+        self.identifier = data[1 : self.byte_count]
+        status = int(data[self.byte_count])
         self.status = status == ID_ON
 
 

--- a/test/pdu/test_other_messages.py
+++ b/test/pdu/test_other_messages.py
@@ -3,7 +3,10 @@
 from typing import cast
 from unittest import mock
 
+import pytest
+
 import pymodbus.pdu.other_message as pymodbus_message
+from pymodbus.exceptions import ModbusIOException
 
 
 class TestOtherMessage:
@@ -155,9 +158,28 @@ class TestOtherMessage:
             )
 
             assert response.encode() == b"\tPymodbus\xff"
-            response.decode(b"\x03\x12\x00")
+            response.decode(b"\tPymodbus\xff")
+            assert response.status
+            assert response.identifier == b"Pymodbus"
+            response.decode(b"\x03\x12\x00\x00")
             assert not response.status
             assert response.identifier == b"\x12\x00"
 
             response.status = False
             assert response.encode() == b"\x03\x12\x00\x00"
+
+    def test_report_device_id_response_roundtrip(self):
+        """Test decode(encode()) keeps identifier and status unchanged."""
+        for identifier, status in ((b"Pymodbus", True), (b"\x12", False)):
+            sent = pymodbus_message.ReportDeviceIdResponse(identifier, status)
+            received = pymodbus_message.ReportDeviceIdResponse()
+            received.decode(sent.encode())
+            assert received.identifier == identifier
+            assert received.status == status
+
+    def test_report_device_id_response_invalid_byte_count(self):
+        """Test byte count pointing outside the received data raises."""
+        response = pymodbus_message.ReportDeviceIdResponse()
+        for frame in (b"\x00\x12\xff", b"\x04\x12\xff"):
+            with pytest.raises(ModbusIOException):
+                response.decode(frame)


### PR DESCRIPTION
`ReportDeviceIdResponse.encode()` and `.decode()` disagree about what the FC17
byte-count field covers. `encode()` counts identifier + run indicator:

```python
length = len(self.identifier) + 1
```

`decode()` slices byte-count bytes as the identifier alone:

```python
self.identifier = data[1 : self.byte_count + 1]
```

So decoding the frame the library itself encodes for `identifier=b"Pymodbus"`,
status ON (`\x09Pymodbus\xff`) yields `identifier == b"Pymodbus\xff"` — the
run-indicator byte lands in the identifier. Every
`client.report_device_id()` against a pymodbus server returns a polluted
identifier, reproducible on `dev` with a stock `ModbusTcpServer` +
`AsyncModbusTcpClient` on loopback:

| | identifier returned |
|---|---|
| dev | `b'Pymodbus\xff'` |
| this PR | `b'Pymodbus'` |

The encode convention is the one the rest of the library depends on:
`rtu_byte_count_pos = 2` means `calculateRtuFrameSize` computes
`byte_count + 5`, which only frames FC17 RTU responses correctly if the count
covers the run indicator. So the fix is decode-side only:

- `identifier = data[1 : byte_count]` (counted bytes minus the run indicator);
- status is read at `data[byte_count]` — the last counted byte — instead of
  `data[-1]`, so a byte a device appends past the count is no longer taken for
  the run indicator;
- a byte-count guard raising `ModbusIOException`, the same shape as the FC03
  response guard `ReadHoldingRegistersResponse.decode` has carried since #2438
  (with the `function_code=` propagation from #2993), because the new
  `data[byte_count]` access must not turn a lying byte count into a bare
  `IndexError`. This is a response decode (client side; the FC17 request
  carries no data), so the don't-raise-in-server-request-decode concern from
  #3016 does not apply.

Provenance: `4de9e3c7` (2011-01-31) shipped a *self-consistent* pair —
`encode()` counted `len(identifier) + 2`, `decode()` sliced
`data[1:length - 1]`. `b442af51` (2011-09-06, "Finishing the remaining modbus
protocol") changed the slice to `data[1:length + 1]` and left `encode()` alone;
the decoded identifier has been one byte too long ever since — through
`0a77f6c1` (2017), which moved `encode()` to today's `len(identifier) + 1`, and
through the PDU refactor (#2160).

Existing coverage could not catch it: `test_pdu_decode` decodes without
asserting field values, and `test_report_device_id` fed `decode` a malformed
frame (`b"\x03\x12\x00"` — byte count 3, two bytes of payload) and then
asserted that re-encoding produces a different, 4-byte frame — the test was
pinning the asymmetry. That vector is now the well-formed
`b"\x03\x12\x00\x00"` and the re-encode assertion demonstrates a true
round-trip.

Two behavior changes to weigh before merging:

- User code that worked around this with `identifier[:-1]` gets the corrected,
  shorter identifier.
- **A device whose byte count covers the identifier alone loses its last
  counted byte**, which is now read as the run indicator. #1600's capture is
  exactly such a device — payload `07 01 02 42 00 11 01 03 23`, count 7 with
  eight bytes after it. On `dev` it decodes
  `identifier=b'\x01\x02B\x00\x11\x01\x03'`, status from the uncounted trailing
  `0x23`; with this PR it decodes `identifier=b'\x01\x02B\x00\x11\x01'`, status
  from `0x03`. Status is `False` either way, so for that device this change is
  a byte lost from the identifier, not a repair.

Spec §6.17 calls the FC17 payload "device specific" and settles neither
reading, so no decode is right for every vendor. What this PR buys is the one
invariant the library can own: pymodbus decodes its own framing convention —
the same one its RTU size math already assumes. The identifier stays a raw
value for the user to interpret, as the docstring says, and frames with
trailing bytes beyond the count still decode. If you would rather keep exotic
layouts byte-for-byte, keeping the raw payload on the PDU as an escape hatch
is an additive follow-up I am happy to write.

New tests:

- decode assertions on the exact frame the test already encodes
  (`b"\tPymodbus\xff"` → `b"Pymodbus"`, status ON);
- `decode(encode())` round-trip preserves identifier and status for both
  status values (fails on dev: identifier grows a byte per pass);
- byte count 0 and byte count past the end of the frame raise
  `ModbusIOException` (fails on dev: silently decodes garbage).

Validation, macOS / Python 3.13:

```text
pytest test/pdu/test_other_messages.py   # 9 passed (3 failed before the fix)
pytest test                              # 1972 passed, 5 skipped
ruff format --check . / ruff check .     # clean
pylint --recursive=y examples pymodbus test  # 10.00/10
codespell / zuban check                  # clean
```
